### PR TITLE
feat(prototype): add prototype pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 > **Fluent Design Patterns for Modern .NET**  
 > Elegant, declarative, allocation-light implementations of classic patterns—optimized for .NET 9.
 
+
+[![CI](https://github.com/JerrettDavis/PatternKit/actions/workflows/ci.yml/badge.svg)](https://github.com/JerrettDavis/PatternKit/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/JerrettDavis/PatternKit/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/JerrettDavis/PatternKit/security/code-scanning)
+[![codecov](https://codecov.io/gh/JerrettDavis/PatternKit/graph/badge.svg?token=I0LO3HLUTP)](https://codecov.io/gh/JerrettDavis/PatternKit)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 
 ---
@@ -64,11 +68,11 @@ if (parse.Execute("123", out var n))
 
 PatternKit will grow to cover **Creational**, **Structural**, and **Behavioral** patterns with fluent, discoverable APIs:
 
-| Category       | Patterns ✓ = implemented                                                                                                                                                                                                                                   |
-| -------------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Creational** | Factory (planned) • Builder (planned) • Prototype (planned) • Singleton (planned)                                                                                                                                                                          |
-| **Structural** | Adapter (planned) • Bridge (planned) • Composite (planned) • Decorator (planned) • Facade (planned) • Flyweight (planned) • Proxy (planned)                                                                                                                |
-| **Behavioral** | Strategy ✓ • TryStrategy ✓ • ActionStrategy ✓ • Chain of Responsibility (planned) • Command (planned) • Iterator (planned) • Mediator (planned) • Memento (planned) • Observer (planned) • State (planned) • Template Method (planned) • Visitor (planned) |
+| Category       | Patterns ✓ = implemented                                                                                                                                                                                                                              |
+| -------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Creational** | [Factory]( ✓ • Builder ✓ • Prototype ✓ • Singleton (planned)                                                                                                                                                                                          |
+| **Structural** | Adapter (planned) • Bridge (planned) • Composite (planned) • Decorator (planned) • Facade (planned) • Flyweight (planned) • Proxy (planned)                                                                                                           |
+| **Behavioral** | Strategy ✓ • TryStrategy ✓ • ActionStrategy ✓ • ActionChain ✓ • ResultChain ✓• Command (planned) • Iterator (planned) • Mediator (planned) • Memento (planned) • Observer (planned) • State (planned) • Template Method (planned) • Visitor (planned) |
 
 Each pattern will ship with:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ PatternKit will grow to cover **Creational**, **Structural**, and **Behavioral**
 | -------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Creational** | [Factory](docs/patterns/creational/factory/factory.md) ✓ • Builder ✓ • Prototype ✓ • Singleton (planned)                                                                                                                                             |
 | **Structural** | Adapter (planned) • Bridge (planned) • Composite (planned) • Decorator (planned) • Facade (planned) • Flyweight (planned) • Proxy (planned)                                                                                                           |
-| **Behavioral** | Strategy ✓ • TryStrategy ✓ • ActionStrategy ✓ • ActionChain ✓ • ResultChain ✓• Command (planned) • Iterator (planned) • Mediator (planned) • Memento (planned) • Observer (planned) • State (planned) • Template Method (planned) • Visitor (planned) |
+| **Behavioral** | Strategy ✓ • TryStrategy ✓ • ActionStrategy ✓ • ActionChain ✓ • ResultChain ✓ • Command (planned) • Iterator (planned) • Mediator (planned) • Memento (planned) • Observer (planned) • State (planned) • Template Method (planned) • Visitor (planned) |
 
 Each pattern will ship with:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ PatternKit will grow to cover **Creational**, **Structural**, and **Behavioral**
 
 | Category       | Patterns ✓ = implemented                                                                                                                                                                                                                              |
 | -------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Creational** | [Factory]( ✓ • Builder ✓ • Prototype ✓ • Singleton (planned)                                                                                                                                                                                          |
+| **Creational** | [Factory](docs/patterns/creational/factory/factory.md) ✓ • Builder ✓ • Prototype ✓ • Singleton (planned)                                                                                                                                             |
 | **Structural** | Adapter (planned) • Bridge (planned) • Composite (planned) • Decorator (planned) • Facade (planned) • Flyweight (planned) • Proxy (planned)                                                                                                           |
 | **Behavioral** | Strategy ✓ • TryStrategy ✓ • ActionStrategy ✓ • ActionChain ✓ • ResultChain ✓• Command (planned) • Iterator (planned) • Mediator (planned) • Memento (planned) • Observer (planned) • State (planned) • Template Method (planned) • Visitor (planned) |
 

--- a/docs/patterns/creational/factory/factory.md
+++ b/docs/patterns/creational/factory/factory.md
@@ -1,4 +1,4 @@
-# Creational.Factory
+# Factory\<TKey, TOut> and Factory\<TKey, TIn, TOut>
 
 A tiny, immutable, low-overhead factory you configure once, then use everywhere. Map a key to a creator delegate and optionally set a default. Two shapes:
 

--- a/docs/patterns/creational/prototype/prototype.md
+++ b/docs/patterns/creational/prototype/prototype.md
@@ -1,0 +1,115 @@
+# Prototype\<T> and Prototype\<TKey, T>
+
+A fluent, low-overhead Prototype that clones a configured instance and applies optional mutations, plus a keyed registry for multiple prototype families.
+
+- Prototype<T> — single source + cloner + default mutations; Create() and Create(mutate).
+- Prototype<TKey, T> — registry mapping key → (source, cloner, mutations); Create/TryCreate with optional per-call mutate; comparer support for keys.
+
+Use it when you want to “copy and tweak” new instances quickly without large object graphs or reflection.
+
+---
+
+## TL;DR (single)
+
+```csharp
+using PatternKit.Creational.Prototype;
+
+public sealed class Widget { public string Name { get; set; } public int Size { get; set; } }
+static Widget Clone(in Widget w) => new() { Name = w.Name, Size = w.Size };
+
+var proto = Prototype<Widget>
+    .Create(new Widget { Name = "base", Size = 1 }, Clone)
+    .With(w => w.Size++)               // default mutation
+    .Build();
+
+var a = proto.Create();                // Name=base, Size=2
+var b = proto.Create(w => w.Size += 8);// Name=base, Size=10
+```
+
+## TL;DR (registry)
+
+```csharp
+using PatternKit.Creational.Prototype;
+
+enum Kind { Circle, Square }
+
+public sealed class Shape { public string Name { get; set; } public double A { get; set; } }
+static Shape Clone(in Shape s) => new() { Name = s.Name, A = s.A };
+
+var shapes = Prototype<Kind, Shape>
+    .Create()
+    .Map(Kind.Circle, new Shape { Name = "circle", A = 2 }, Clone)
+    .Map(Kind.Square, new Shape { Name = "square", A = 3 }, Clone)
+    .Default(new Shape { Name = "unknown", A = 0 }, Clone)
+    .Build();
+
+var c = shapes.Create(Kind.Circle);                // circle, A=2
+var s = shapes.Create(Kind.Square, sh => sh.A++);  // square, A=4 (mutated)
+```
+
+---
+
+## API at a glance
+
+```csharp
+// Single
+public sealed class Prototype<T>
+{
+    public delegate T Cloner(in T source);
+
+    public static Builder Create(T source, Cloner cloner);
+
+    public sealed class Builder
+    {
+        public Builder With(Action<T> mutate);  // append default mutations (combined)
+        public Prototype<T> Build();
+    }
+
+    public T Create();                // clone + default mutations
+    public T Create(Action<T> mutate);// clone + default + per-call mutation
+}
+
+// Registry
+public sealed class Prototype<TKey, T> where TKey : notnull
+{
+    public delegate T Cloner(in T source);
+
+    public static Builder Create(IEqualityComparer<TKey>? comparer = null);
+
+    public sealed class Builder
+    {
+        public Builder Map(TKey key, T source, Cloner cloner);  // last wins
+        public Builder Mutate(TKey key, Action<T> mutate);       // append family mutations
+        public Builder Default(T source, Cloner cloner);         // optional default
+        public Builder DefaultMutate(Action<T> mutate);          // append default mutations
+        public Prototype<TKey, T> Build();
+    }
+
+    public T Create(TKey key);                    // throws if missing and no default
+    public T Create(TKey key, Action<T> mutate);  // per-call mutate
+    public bool TryCreate(TKey key, out T value); // false only if no mapping and no default
+}
+```
+
+### Semantics
+
+- Cloning uses your Cloner delegate (no reflection); prefer method groups/static lambdas.
+- Default mutations are composed in order; per-call mutate runs after defaults.
+- Registry: last Map wins; Mutate appends; Build snapshots an immutable map; comparer controls key semantics.
+- Create throws when no mapping and no default; TryCreate returns false in that case.
+
+---
+
+## Tips
+
+- Keep Clone simple and pure; avoid sharing mutable state between clones.
+- For structs or hot paths, keep fields small and prefer in parameters to avoid copies.
+- With string keys, pass StringComparer.OrdinalIgnoreCase to Create for case-insensitive lookups.
+
+---
+
+## See also
+
+- [Creational.Factory](../factory/factory.md) — key → creator registry (no source object).
+- [Creational.Builder.Composer](../builder/composer.md) — functional composition when you need transforms + validations.
+

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -3,36 +3,39 @@
   items:
     - name: Behavioral
       items:
-        - name: Chain
+        - name: Chain of Responsibility
           items:
-            - name: Behavioral.Chain.ActionChain
+            - name: ActionChain
               href: behavioral/chain/actionchain.md
-            - name: Behavioral.Chain.ResultChain
+            - name: ResultChain
               href: behavioral/chain/resultchain.md
         - name: Strategy
           items:
-            - name: Behavioral.Strategy.Strategy
+            - name: Strategy
               href: behavioral/strategy/strategy.md
-            - name: Behavioral.Strategy.TryStrategy
+            - name: TryStrategy
               href: behavioral/strategy/trystrategy.md
-            - name: Behavioral.Strategy.ActionStrategy
+            - name: ActionStrategy
               href: behavioral/strategy/actionstrategy.md
-            - name: Behavioral.Strategy.AsyncStrategy
+            - name: AsyncStrategy
               href: behavioral/strategy/asyncstrategy.md
     - name: Creational
       items:
         - name: Builder
           items:
-            - name: Creational.Builder.BranchBuilder
+            - name: BranchBuilder
               href: creational/builder/branchbuilder.md
-            - name: Creational.Builder.ChainBuilder
+            - name: ChainBuilder
               href: creational/builder/chainbuilder.md
-            - name: Creational.Builder.Composer
+            - name: Composer
               href: creational/builder/composer.md
-            - name: Creational.Builder.MutableBuilder
+            - name: MutableBuilder
               href: creational/builder/mutablebuilder.md
         - name: Factory
           items:
-            - name: Creational.Factory
+            - name: Factory
               href: creational/factory/factory.md
-
+        - name: Prototype
+          items:
+            - name: Prototype
+              href: creational/prototype/prototype.md

--- a/src/PatternKit.Core/Creational/Prototype/Prototype.cs
+++ b/src/PatternKit.Core/Creational/Prototype/Prototype.cs
@@ -1,0 +1,209 @@
+using System.Collections.ObjectModel;
+
+namespace PatternKit.Creational.Prototype;
+
+/// <summary>
+/// Fluent, low-overhead prototype that clones a configured <typeparamref name="T"/> using a supplied <see cref="Cloner"/>,
+/// then applies optional default mutations. Immutable after <see cref="Builder.Build"/>.
+/// </summary>
+/// <typeparam name="T">The prototype type to clone.</typeparam>
+public sealed class Prototype<T>
+{
+    /// <summary>Delegate that clones a source instance into a new instance.</summary>
+    public delegate T Cloner(in T source);
+
+    private readonly T _source;
+    private readonly Cloner _cloner;
+    private readonly Action<T>? _mutations;
+
+    private Prototype(T source, Cloner cloner, Action<T>? mutations)
+        => (_source, _cloner, _mutations) = (source, cloner, mutations);
+
+    /// <summary>Create a new builder from a <paramref name="source"/> and <paramref name="cloner"/>.</summary>
+    public static Builder Create(T source, Cloner cloner) => new(source, cloner);
+
+    /// <summary>Clone the configured prototype and apply default mutations (if any).</summary>
+    public T Create()
+    {
+        var clone = _cloner(in _source);
+        _mutations?.Invoke(clone);
+        return clone;
+    }
+
+    /// <summary>Clone and then apply both default mutations and an extra, per-call <paramref name="mutate"/>.</summary>
+    public T Create(Action<T>? mutate)
+    {
+        var clone = _cloner(in _source);
+        _mutations?.Invoke(clone);
+        mutate?.Invoke(clone);
+        return clone;
+    }
+
+    /// <summary>Fluent builder for <see cref="Prototype{T}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly T _source;
+        private readonly Cloner _cloner;
+        private Action<T>? _mutations;
+
+        internal Builder(T source, Cloner cloner) => (_source, _cloner) = (source, cloner);
+
+        /// <summary>Add a default mutation to apply to every clone.</summary>
+        public Builder With(Action<T> mutate)
+        {
+            _mutations = _mutations is null ? mutate : (Action<T>)Delegate.Combine(_mutations, mutate);
+            return this;
+        }
+
+        /// <summary>Build an immutable prototype instance.</summary>
+        public Prototype<T> Build() => new(_source, _cloner, _mutations);
+    }
+}
+
+/// <summary>
+/// Prototype registry that maps a <typeparamref name="TKey"/> to a (prototype, cloner, mutations) family. Immutable after build.
+/// </summary>
+/// <typeparam name="TKey">Key used to select a family (e.g., enum, string).</typeparam>
+/// <typeparam name="T">Prototype type.</typeparam>
+public sealed class Prototype<TKey, T> where TKey : notnull
+{
+    /// <summary>Delegate that clones a source instance into a new instance.</summary>
+    public delegate T Cloner(in T source);
+
+    private readonly IReadOnlyDictionary<TKey, Family> _families;
+    private readonly Family _default;
+    private readonly bool _hasDefault;
+
+    private readonly struct Family(
+        T source,
+        Cloner clone,
+        Action<T>? mutations
+    )
+    {
+        public readonly T Source = source;
+        public readonly Cloner Clone = clone;
+        public readonly Action<T>? Mutations = mutations;
+
+        public T Create()
+        {
+            var obj = Clone(in Source);
+            Mutations?.Invoke(obj);
+            return obj;
+        }
+
+        public T Create(Action<T>? mutate)
+        {
+            var obj = Clone(in Source);
+            Mutations?.Invoke(obj);
+            mutate?.Invoke(obj);
+            return obj;
+        }
+
+        public Family WithMutation(Action<T> m)
+            => new(Source, Clone, Mutations is null ? m : (Action<T>)Delegate.Combine(Mutations, m));
+    }
+
+    private Prototype(IReadOnlyDictionary<TKey, Family> families, bool hasDefault, Family @default)
+        => (_families, _hasDefault, _default) = (families, hasDefault, @default);
+
+    /// <summary>Create a new builder; pass a key comparer for custom key semantics.</summary>
+    public static Builder Create(IEqualityComparer<TKey>? comparer = null) => new(comparer ?? EqualityComparer<TKey>.Default);
+
+    /// <summary>Create a clone for <paramref name="key"/>; throws if missing and no default exists.</summary>
+    public T Create(TKey key)
+    {
+        if (_families.TryGetValue(key, out var fam)) return fam.Create();
+        if (_hasDefault) return _default.Create();
+        ThrowNoFamily(key);
+        return default!;
+    }
+
+    /// <summary>Create a clone and apply a per-call <paramref name="mutate"/>.</summary>
+    public T Create(TKey key, Action<T>? mutate)
+    {
+        if (_families.TryGetValue(key, out var fam)) return fam.Create(mutate);
+        if (_hasDefault) return _default.Create(mutate);
+        ThrowNoFamily(key);
+        return default!;
+    }
+
+    /// <summary>Try to create a clone for <paramref name="key"/>.</summary>
+    public bool TryCreate(TKey key, out T value)
+    {
+        if (_families.TryGetValue(key, out var fam))
+        {
+            value = fam.Create();
+            return true;
+        }
+
+        if (_hasDefault)
+        {
+            value = _default.Create();
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    private static void ThrowNoFamily(TKey key)
+        => throw new InvalidOperationException($"No prototype family for key '{key}'. Configure Map(...) or Default(...).");
+
+    /// <summary>Fluent builder for the registry prototype.</summary>
+    public sealed class Builder
+    {
+        private readonly Dictionary<TKey, Family> _map;
+        private Family? _default;
+
+        internal Builder(IEqualityComparer<TKey> comparer) => _map = new(comparer);
+
+        /// <summary>Register or replace a prototype family for <paramref name="key"/>.</summary>
+        public Builder Map(TKey key, T source, Cloner cloner)
+        {
+            _map[key] = new Family(source, cloner, mutations: null);
+            return this;
+        }
+
+        /// <summary>Add or append a mutation to the family under <paramref name="key"/>.</summary>
+        public Builder Mutate(TKey key, Action<T> mutate)
+        {
+            if (_map.TryGetValue(key, out var fam))
+                _map[key] = fam.WithMutation(mutate);
+            else
+                _map[key] = new Family(source: default(T)!, static (in _) => default(T)!, mutations: mutate);
+            return this;
+        }
+
+        /// <summary>Set or replace the default prototype family.</summary>
+        public Builder Default(T source, Cloner cloner)
+        {
+            _default = new Family(source, cloner, mutations: null);
+            return this;
+        }
+
+        /// <summary>Add or append a default mutation.</summary>
+        public Builder DefaultMutate(Action<T> mutate)
+        {
+            _default = _default is { } fam ? fam.WithMutation(mutate) : new Family(default!, static (in _) => default!, mutate);
+            return this;
+        }
+
+        /// <summary>Build an immutable registry snapshot.</summary>
+        public Prototype<TKey, T> Build()
+        {
+            // Validate: ensure families without source/cloner are not left half-configured
+            foreach (var item in _map.ToArray())
+            {
+                if (Equals(item.Value.Source, default(T)) || item.Value.Clone is null)
+                    throw new InvalidOperationException($"Map(key, source, cloner) must be called before Mutate for key '{item.Key}'.");
+            }
+
+            var ro = new ReadOnlyDictionary<TKey, Family>(new Dictionary<TKey, Family>(_map, _map.Comparer));
+            var hasDefault = _default is { } df && !Equals(df.Source, default(T));
+            var def = hasDefault ? _default : new Family(default!, static (in _) => ThrowBeforeDefault(), null);
+            return new Prototype<TKey, T>(ro, hasDefault, def ?? throw new InvalidOperationException("No Default() configured."));
+
+            static T ThrowBeforeDefault() => throw new InvalidOperationException("No Default() configured.");
+        }
+    }
+}

--- a/src/PatternKit.Core/PatternKit.Core.csproj
+++ b/src/PatternKit.Core/PatternKit.Core.csproj
@@ -4,10 +4,6 @@
         <RootNamespace>PatternKit</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="System.Collections.Immutable" Version="9.0.9"/>
-    </ItemGroup>
-
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
     </ItemGroup>

--- a/src/PatternKit.Core/packages.lock.json
+++ b/src/PatternKit.Core/packages.lock.json
@@ -11,16 +11,6 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Direct",
-        "requested": "[9.0.9, )",
-        "resolved": "9.0.9",
-        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w==",
-        "dependencies": {
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
       "System.Threading.Tasks.Extensions": {
         "type": "Direct",
         "requested": "[4.5.4, )",
@@ -35,84 +25,14 @@
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
       },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
-      },
-      "System.Numerics.Vectors": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
-      },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "4.5.3",
+        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
       }
     },
-    ".NETStandard,Version=v2.1": {
-      "System.Collections.Immutable": {
-        "type": "Direct",
-        "requested": "[9.0.9, )",
-        "resolved": "9.0.9",
-        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w==",
-        "dependencies": {
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
-      },
-      "System.Numerics.Vectors": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
-      }
-    },
-    "net8.0": {
-      "System.Collections.Immutable": {
-        "type": "Direct",
-        "requested": "[9.0.9, )",
-        "resolved": "9.0.9",
-        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w=="
-      }
-    },
-    "net9.0": {
-      "System.Collections.Immutable": {
-        "type": "Direct",
-        "requested": "[9.0.9, )",
-        "resolved": "9.0.9",
-        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w=="
-      }
-    }
+    ".NETStandard,Version=v2.1": {},
+    "net8.0": {},
+    "net9.0": {}
   }
 }

--- a/src/PatternKit.Examples/packages.lock.json
+++ b/src/PatternKit.Examples/packages.lock.json
@@ -69,13 +69,13 @@
         "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w=="
       },
       "patternkit.core": {
+        "type": "Project"
+      },
+      "patternkit.generators": {
         "type": "Project",
         "dependencies": {
           "System.Collections.Immutable": "[9.0.9, )"
         }
-      },
-      "patternkit.generators": {
-        "type": "Project"
       }
     },
     "net9.0": {
@@ -146,13 +146,13 @@
         "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w=="
       },
       "patternkit.core": {
+        "type": "Project"
+      },
+      "patternkit.generators": {
         "type": "Project",
         "dependencies": {
           "System.Collections.Immutable": "[9.0.9, )"
         }
-      },
-      "patternkit.generators": {
-        "type": "Project"
       }
     }
   }

--- a/src/PatternKit.Generators/PatternKit.Generators.csproj
+++ b/src/PatternKit.Generators/PatternKit.Generators.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+        <PackageReference Include="System.Collections.Immutable" Version="9.0.9" />
     </ItemGroup>
 
 </Project>

--- a/src/PatternKit.Generators/packages.lock.json
+++ b/src/PatternKit.Generators/packages.lock.json
@@ -35,6 +35,16 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
+      "System.Collections.Immutable": {
+        "type": "Direct",
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
         "resolved": "4.14.0",
@@ -60,15 +70,6 @@
         "type": "Transitive",
         "resolved": "4.5.1",
         "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w==",
-        "dependencies": {
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
       },
       "System.Memory": {
         "type": "Transitive",
@@ -142,6 +143,16 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
+      "System.Collections.Immutable": {
+        "type": "Direct",
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
         "resolved": "4.14.0",
@@ -162,15 +173,6 @@
         "type": "Transitive",
         "resolved": "4.5.1",
         "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w==",
-        "dependencies": {
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
       },
       "System.Memory": {
         "type": "Transitive",
@@ -238,6 +240,12 @@
           "System.Reflection.Metadata": "9.0.0"
         }
       },
+      "System.Collections.Immutable": {
+        "type": "Direct",
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w=="
+      },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
         "resolved": "4.14.0",
@@ -247,11 +255,6 @@
           "System.Collections.Immutable": "9.0.0",
           "System.Reflection.Metadata": "9.0.0"
         }
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -281,6 +284,12 @@
           "System.Reflection.Metadata": "9.0.0"
         }
       },
+      "System.Collections.Immutable": {
+        "type": "Direct",
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "/kpkgDxH984e3J3z5v/DIFi+0TWbUJXS8HNKUYBy3YnXtK09JVGs3cw5aOV6fDSw5NxbWLWlGrYjRteu6cjX3w=="
+      },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
         "resolved": "4.14.0",
@@ -290,11 +299,6 @@
           "System.Collections.Immutable": "9.0.0",
           "System.Reflection.Metadata": "9.0.0"
         }
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",

--- a/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
+++ b/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <NoWarn>CS1591;CS0649</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/PatternKit.Examples.Tests/packages.lock.json
+++ b/test/PatternKit.Examples.Tests/packages.lock.json
@@ -254,10 +254,7 @@
         }
       },
       "patternkit.core": {
-        "type": "Project",
-        "dependencies": {
-          "System.Collections.Immutable": "[9.0.9, )"
-        }
+        "type": "Project"
       },
       "patternkit.examples": {
         "type": "Project",
@@ -272,7 +269,10 @@
         }
       },
       "patternkit.generators": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "System.Collections.Immutable": "[9.0.9, )"
+        }
       }
     },
     "net9.0": {
@@ -521,10 +521,7 @@
         }
       },
       "patternkit.core": {
-        "type": "Project",
-        "dependencies": {
-          "System.Collections.Immutable": "[9.0.9, )"
-        }
+        "type": "Project"
       },
       "patternkit.examples": {
         "type": "Project",
@@ -539,7 +536,10 @@
         }
       },
       "patternkit.generators": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "System.Collections.Immutable": "[9.0.9, )"
+        }
       }
     }
   }

--- a/test/PatternKit.Generators.Tests/packages.lock.json
+++ b/test/PatternKit.Generators.Tests/packages.lock.json
@@ -206,10 +206,7 @@
         }
       },
       "patternkit.core": {
-        "type": "Project",
-        "dependencies": {
-          "System.Collections.Immutable": "[9.0.9, )"
-        }
+        "type": "Project"
       },
       "patternkit.examples": {
         "type": "Project",
@@ -224,7 +221,10 @@
         }
       },
       "patternkit.generators": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "System.Collections.Immutable": "[9.0.9, )"
+        }
       }
     },
     "net9.0": {
@@ -429,10 +429,7 @@
         }
       },
       "patternkit.core": {
-        "type": "Project",
-        "dependencies": {
-          "System.Collections.Immutable": "[9.0.9, )"
-        }
+        "type": "Project"
       },
       "patternkit.examples": {
         "type": "Project",
@@ -447,7 +444,10 @@
         }
       },
       "patternkit.generators": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "System.Collections.Immutable": "[9.0.9, )"
+        }
       }
     }
   }

--- a/test/PatternKit.Tests/Creational/Prototype/PrototypeTests.cs
+++ b/test/PatternKit.Tests/Creational/Prototype/PrototypeTests.cs
@@ -1,0 +1,215 @@
+using PatternKit.Creational.Prototype;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
+
+namespace PatternKit.Tests.Creational.Prototype;
+
+[Feature("Creational - Prototype<T> & Prototype<TKey,T>")]
+public sealed class PrototypeTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    private enum Kind { A, B }
+    private sealed class Thing
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+        public Thing(string name, int value) { Name = name; Value = value; }
+    }
+
+    private static Thing Clone(in Thing s) => new(s.Name, s.Value); // deep-enough for test
+
+    // ---------------- Single prototype ----------------
+
+    [Scenario("Single prototype: default and per-call mutations are applied")]
+    [Fact]
+    public Task Single_Default_And_PerCall_Mutations()
+        => Given("a prototype with Value++ default mutation", () =>
+                Prototype<Thing>.Create(new Thing("x", 1), Clone)
+                    .With(t => t.Value++)
+                    .Build())
+            .When("Create()", p => p.Create())
+            .Then("Value is 2", t => t is { Name: "x", Value: 2 })
+            .When("Create with per-call +10", _ =>
+            {
+                var p = Prototype<Thing>.Create(new Thing("y", 5), Clone)
+                    .With(t => t.Value++)
+                    .Build();
+                return p.Create(t => t.Value += 10);
+            })
+            .Then("Value is 16 (1 + 10)", t => t is { Name: "y", Value: 16 })
+            .AssertPassed();
+
+    [Scenario("Single prototype: null per-call mutation is ignored")]
+    [Fact]
+    public Task Single_Null_PerCall_Mutation()
+        => Given("a prototype with default mutation Value++", () =>
+                Prototype<Thing>.Create(new Thing("n", 3), Clone).With(t => t.Value++).Build())
+            .When("Create(null mutate)", p => p.Create(null!))
+            .Then("Value is 4", t => t.Value == 4)
+            .AssertPassed();
+
+    [Scenario("Single prototype: multiple default mutations preserve order")]
+    [Fact]
+    public Task Single_Default_Mutations_Order()
+        => Given("a prototype with two default mutations (+1, *2)", () =>
+                Prototype<Thing>.Create(new Thing("o", 2), Clone)
+                    .With(t => t.Value += 1)
+                    .With(t => t.Value *= 2)
+                    .Build())
+            .When("Create()", p => p.Create())
+            .Then("(2+1)*2 = 6", t => t.Value == 6)
+            .AssertPassed();
+
+    // ---------------- Registry prototype ----------------
+
+    [Scenario("Registry: Map + Default + TryCreate semantics")]
+    [Fact]
+    public Task Registry_Map_Default_TryCreate()
+        => Given("a registry with A mapped and a default", () =>
+                Prototype<Kind, Thing>.Create()
+                    .Map(Kind.A, new Thing("A", 1), Clone)
+                    .Default(new Thing("D", 0), Clone)
+                    .Build())
+            .When("Create(A) and Create(B)", r => (Reg: r, A: r.Create(Kind.A), B: r.Create(Kind.B)))
+            .Then("A uses A source", t => t.A is { Name: "A", Value: 1 })
+            .And("B uses default", t => t.B is { Name: "D", Value: 0 })
+            .When("TryCreate unknown", t => t.Reg.TryCreate((Kind)999, out var v) ? v : null!)
+            .Then("falls back to default (non-null)", v => v is not null)
+            .AssertPassed();
+
+    [Scenario("Registry: TryCreate false when missing and no default")]
+    [Fact]
+    public Task Registry_TryCreate_NoDefault_ReturnsFalse()
+        => Given("a registry with only A mapped", () =>
+                Prototype<Kind, Thing>.Create().Map(Kind.A, new Thing("A", 1), Clone).Build())
+            .When("TryCreate B", r => r.TryCreate(Kind.B, out var _))
+            .Then("false", ok => ok == false)
+            .AssertPassed();
+
+    [Scenario("Registry: Create throws when missing and no default (no mutate)")]
+    [Fact]
+    public Task Registry_Create_NoDefault_Throws()
+        => Given("a registry with only A mapped", () =>
+                Prototype<Kind, Thing>.Create().Map(Kind.A, new Thing("A", 1), Clone).Build())
+            .When("Create B", r => Record.Exception(() => r.Create(Kind.B)))
+            .Then("InvalidOperationException", ex => ex is InvalidOperationException)
+            .AssertPassed();
+
+    [Scenario("Registry: Create with per-call mutate throws when missing and no default")]
+    [Fact]
+    public Task Registry_Create_WithMutate_NoDefault_Throws()
+        => Given("a registry with only A mapped", () =>
+                Prototype<Kind, Thing>.Create().Map(Kind.A, new Thing("A", 1), Clone).Build())
+            .When("Create B with per-call", r => Record.Exception(() => r.Create(Kind.B, t => t.Value++)))
+            .Then("InvalidOperationException", ex => ex is InvalidOperationException)
+            .AssertPassed();
+
+    [Scenario("Registry: per-call mutate applies on default path and after default mutations")]
+    [Fact]
+    public Task Registry_PerCall_On_Default_Path_After_DefaultMutations()
+        => Given("default has Value+=2; no mapping for B", () =>
+                Prototype<Kind, Thing>.Create()
+                    .Default(new Thing("D", 1), Clone)
+                    .DefaultMutate(t => t.Value += 2)
+                    .Build())
+            .When("Create B with per-call +5", r => r.Create(Kind.B, t => t.Value += 5))
+            .Then("1+2 then +5 = 8", t => t.Value == 8)
+            .AssertPassed();
+
+    [Scenario("Registry: per-call mutate null is ignored on mapped and default paths")]
+    [Fact]
+    public Task Registry_Null_PerCall_Ignored()
+        => Given("mapped A and a default", () =>
+                Prototype<Kind, Thing>.Create()
+                    .Map(Kind.A, new Thing("A", 1), Clone)
+                    .Default(new Thing("D", 2), Clone)
+                    .Build())
+            .When("Create A(null) and B(null)", r => (A: r.Create(Kind.A, null!), B: r.Create(Kind.B, null!)))
+            .Then("A remains 1", t => t.A.Value == 1)
+            .And("default remains 2", t => t.B.Value == 2)
+            .AssertPassed();
+
+    [Scenario("Registry: DefaultMutate before Default -> Create missing throws (no default)")]
+    [Fact]
+    public Task Registry_DefaultMutate_Without_Default_Builds_NoDefault()
+        => Given("builder with only DefaultMutate", () =>
+                Prototype<Kind, Thing>.Create().DefaultMutate(t => t.Value++).Build())
+            .When("Create B", r => Record.Exception(() => r.Create(Kind.B)))
+            .Then("InvalidOperationException", ex => ex is InvalidOperationException)
+            .AssertPassed();
+
+    [Scenario("Registry: Mutate before Map then Map clears half-configured family (no throw, no mutation)")]
+    [Fact]
+    public Task Registry_Mutate_Before_Map_Then_Map_Clears()
+        => Given("builder Mutate(A) then Map(A)", () =>
+            {
+                var b = Prototype<Kind, Thing>.Create()
+                    .Mutate(Kind.A, t => t.Value += 100) // creates half-configured fam
+                    .Map(Kind.A, new Thing("A", 1), Clone); // replaces with proper fam (no mutations)
+                return b.Build();
+            })
+            .When("Create A (should not have +100)", r => r.Create(Kind.A))
+            .Then("Value == 1", t => t.Value == 1)
+            .AssertPassed();
+
+    [Scenario("Registry: Map then Mutate then Map resets mutations (last Map wins)")]
+    [Fact]
+    public Task Registry_Map_Then_Mutate_Then_Map_Resets()
+        => Given("Map(A) with mutations added then replaced by Map(A)", () =>
+            {
+                var b = Prototype<Kind, Thing>.Create()
+                    .Map(Kind.A, new Thing("A", 1), Clone)
+                    .Mutate(Kind.A, t => t.Value += 10)
+                    .Map(Kind.A, new Thing("A2", 2), Clone); // resets mutations
+                return b.Default(new Thing("D", 0), Clone).Build();
+            })
+            .When("Create A", r => r.Create(Kind.A))
+            .Then("uses last Map with no mutation", t => t is { Name: "A2", Value: 2 })
+            .AssertPassed();
+
+    [Scenario("Registry: multiple Mutate for same key preserve order")] 
+    [Fact]
+    public Task Registry_Multiple_Mutate_Order()
+        => Given("Map(A) then Mutate twice (+1 then *3)", () =>
+                Prototype<Kind, Thing>.Create()
+                    .Map(Kind.A, new Thing("A", 2), Clone)
+                    .Mutate(Kind.A, t => t.Value += 1)
+                    .Mutate(Kind.A, t => t.Value *= 3)
+                    .Build())
+            .When("Create A", r => r.Create(Kind.A))
+            .Then("(2+1)*3 = 9", t => t.Value == 9)
+            .AssertPassed();
+
+    [Scenario("String keys comparer: case-insensitive mapping still works for Prototype registry")]
+    [Fact]
+    public Task Registry_Comparer_StringIgnoreCase()
+        => Given("string-key registry with OrdinalIgnoreCase", () =>
+                Prototype<string, Thing>.Create(StringComparer.OrdinalIgnoreCase)
+                    .Map("json", new Thing("js", 1), Clone)
+                    .Default(new Thing("def", 0), Clone)
+                    .Build())
+            .When("Create('JSON')", r => r.Create("JSON"))
+            .Then("matches 'json' mapping", t => t is { Name: "js", Value: 1 })
+            .AssertPassed();
+
+    [Scenario("Mutate before Map for a key throws on Build")]
+    [Fact]
+    public Task Registry_Mutate_Before_Map_Throws()
+        => Given("a builder where Mutate is called before Map", () =>
+                Prototype<string, Thing>.Create()
+                    .Mutate("x", t => t.Value++) )
+            .When("building (should throw)", b => Record.Exception(() => b.Build()))
+            .Then("InvalidOperationException", ex => ex is InvalidOperationException)
+            .AssertPassed();
+
+    [Scenario("Null key throws ArgumentNullException (string keys)")]
+    [Fact]
+    public Task Registry_Null_Key_Throws()
+        => Given("a registry with default", () =>
+                Prototype<string, Thing>.Create()
+                    .Default(new Thing("def", 0), Clone)
+                    .Build())
+            .When("Create(null)", r => Record.Exception(() => r.Create(null!)))
+            .Then("ArgumentNullException", ex => ex is ArgumentNullException)
+            .AssertPassed();
+}

--- a/test/PatternKit.Tests/packages.lock.json
+++ b/test/PatternKit.Tests/packages.lock.json
@@ -190,10 +190,7 @@
         }
       },
       "patternkit.core": {
-        "type": "Project",
-        "dependencies": {
-          "System.Collections.Immutable": "[9.0.9, )"
-        }
+        "type": "Project"
       },
       "patternkit.examples": {
         "type": "Project",
@@ -208,7 +205,10 @@
         }
       },
       "patternkit.generators": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "System.Collections.Immutable": "[9.0.9, )"
+        }
       }
     },
     "net9.0": {
@@ -400,10 +400,7 @@
         }
       },
       "patternkit.core": {
-        "type": "Project",
-        "dependencies": {
-          "System.Collections.Immutable": "[9.0.9, )"
-        }
+        "type": "Project"
       },
       "patternkit.examples": {
         "type": "Project",
@@ -418,7 +415,10 @@
         }
       },
       "patternkit.generators": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "System.Collections.Immutable": "[9.0.9, )"
+        }
       }
     }
   }


### PR DESCRIPTION
Add a Prototype implementation to support object cloning (shallow and deep). Includes core interfaces/implementations, unit tests, example usages, and documentation/API reference updates. Non-breaking change.