### PR TITLE
Add Bridge pattern generator

### DIFF
--- a/docs/generators/bridge.md
+++ b/docs/generators/bridge.md
@@ -1,0 +1,37 @@
+# Bridge Generator
+
+The Bridge generator emits the protected forwarding members that connect an abstraction to an implementor contract. Generated code has no runtime dependency on PatternKit.
+
+## Usage
+
+```csharp
+using PatternKit.Generators.Bridge;
+
+[BridgeImplementor]
+public partial interface IRenderer
+{
+    void DrawLine(int x1, int y1, int x2, int y2);
+    ValueTask FlushAsync(CancellationToken ct = default);
+}
+
+[BridgeAbstraction(typeof(IRenderer), GenerateDefault = true)]
+public partial class Shape
+{
+    public void Draw() => DrawLine(0, 0, 10, 10);
+}
+```
+
+The generator adds a protected constructor, an `Implementor` property, and protected forwarding methods that preserve the implementor signatures.
+
+## Attributes
+
+- `[BridgeImplementor]` marks an interface or abstract class implementor contract.
+- `[BridgeAbstraction(typeof(TImplementor))]` marks the partial abstraction class.
+- `[BridgeIgnore]` excludes a method or property from forwarding.
+
+## Diagnostics
+
+- `PKBRG001`: abstraction must be partial.
+- `PKBRG002`: implementor must be an interface or abstract class.
+- `PKBRG003`: unsupported implementor member, such as an event.
+- `PKBRG004`: generated default abstraction type name conflicts with an existing type.

--- a/docs/generators/toc.yml
+++ b/docs/generators/toc.yml
@@ -4,6 +4,9 @@
 - name: Builder
   href: builder.md
 
+- name: Bridge
+  href: bridge.md
+
 - name: Facade
   href: facade.md
 

--- a/src/PatternKit.Generators.Abstractions/Bridge/BridgeAttributes.cs
+++ b/src/PatternKit.Generators.Abstractions/Bridge/BridgeAttributes.cs
@@ -1,0 +1,36 @@
+namespace PatternKit.Generators.Bridge;
+
+/// <summary>
+/// Marks an interface or abstract class as a Bridge implementor contract.
+/// </summary>
+[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class, Inherited = false)]
+public sealed class BridgeImplementorAttribute : Attribute
+{
+    public string? ImplementorTypeName { get; set; }
+}
+
+/// <summary>
+/// Marks a partial class as a Bridge abstraction that forwards protected members to an implementor.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class BridgeAbstractionAttribute : Attribute
+{
+    public BridgeAbstractionAttribute(Type implementorType)
+    {
+        ImplementorType = implementorType;
+    }
+
+    public Type ImplementorType { get; }
+
+    public string ImplementorPropertyName { get; set; } = "Implementor";
+
+    public bool GenerateDefault { get; set; }
+
+    public string? DefaultTypeName { get; set; }
+}
+
+/// <summary>
+/// Excludes an implementor member from generated Bridge forwarding.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+public sealed class BridgeIgnoreAttribute : Attribute;

--- a/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
@@ -116,6 +116,10 @@ PKADP015 | PatternKit.Generators.Adapter | Error | Mapping method must be access
 PKADP016 | PatternKit.Generators.Adapter | Error | Static members are not supported
 PKADP017 | PatternKit.Generators.Adapter | Error | Ref-return members are not supported
 PKADP018 | PatternKit.Generators.Adapter | Error | Indexers are not supported
+PKBRG001 | PatternKit.Generators.Bridge | Error | Bridge abstraction must be partial
+PKBRG002 | PatternKit.Generators.Bridge | Error | Bridge implementor must be an interface or abstract class
+PKBRG003 | PatternKit.Generators.Bridge | Error | Implementor member is unsupported
+PKBRG004 | PatternKit.Generators.Bridge | Error | Generated default abstraction name conflicts
 PKST001 | PatternKit.Generators.State | Error | Type marked with [StateMachine] must be partial
 PKST002 | PatternKit.Generators.State | Error | State type must be an enum
 PKST003 | PatternKit.Generators.State | Error | Trigger type must be an enum

--- a/src/PatternKit.Generators/Bridge/BridgeGenerator.cs
+++ b/src/PatternKit.Generators/Bridge/BridgeGenerator.cs
@@ -1,0 +1,317 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text;
+
+namespace PatternKit.Generators.Bridge;
+
+[Generator]
+public sealed class BridgeGenerator : IIncrementalGenerator
+{
+    private static readonly SymbolDisplayFormat TypeFormat = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+                              SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+    private static readonly DiagnosticDescriptor MustBePartial = new(
+        "PKBRG001",
+        "Bridge abstraction must be partial",
+        "Type '{0}' is marked with [BridgeAbstraction] but is not declared as partial",
+        "PatternKit.Generators.Bridge",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor InvalidImplementor = new(
+        "PKBRG002",
+        "Bridge implementor must be an interface or abstract class",
+        "Implementor type '{0}' must be an interface or abstract class",
+        "PatternKit.Generators.Bridge",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor UnsupportedMember = new(
+        "PKBRG003",
+        "Implementor member is unsupported",
+        "Implementor member '{0}' is not supported by the Bridge generator",
+        "PatternKit.Generators.Bridge",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor DefaultNameConflict = new(
+        "PKBRG004",
+        "Generated default abstraction name conflicts",
+        "Generated default abstraction type name '{0}' conflicts with an existing type in namespace '{1}'",
+        "PatternKit.Generators.Bridge",
+        DiagnosticSeverity.Error,
+        true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var abstractions = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "PatternKit.Generators.Bridge.BridgeAbstractionAttribute",
+            static (node, _) => node is ClassDeclarationSyntax or RecordDeclarationSyntax,
+            static (ctx, _) => ctx);
+
+        context.RegisterSourceOutput(abstractions, static (spc, ctx) =>
+        {
+            if (ctx.TargetSymbol is INamedTypeSymbol type)
+            {
+                var attr = ctx.Attributes.FirstOrDefault(a =>
+                    a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Bridge.BridgeAbstractionAttribute");
+                if (attr is not null)
+                {
+                    Generate(spc, type, attr, ctx.TargetNode);
+                }
+            }
+        });
+    }
+
+    private static void Generate(SourceProductionContext context, INamedTypeSymbol abstraction, AttributeData attribute, SyntaxNode node)
+    {
+        if (!IsPartial(node))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustBePartial, node.GetLocation(), abstraction.Name));
+            return;
+        }
+
+        var implementor = attribute.ConstructorArguments.Length == 1
+            ? attribute.ConstructorArguments[0].Value as INamedTypeSymbol
+            : null;
+
+        if (implementor is null ||
+            (implementor.TypeKind != TypeKind.Interface && !(implementor.TypeKind == TypeKind.Class && implementor.IsAbstract)))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                InvalidImplementor,
+                node.GetLocation(),
+                implementor?.ToDisplayString() ?? "<unknown>"));
+            return;
+        }
+
+        var propertyName = GetString(attribute, nameof(BridgeAbstractionAttribute.ImplementorPropertyName), "Implementor");
+        var generateDefault = GetBool(attribute, nameof(BridgeAbstractionAttribute.GenerateDefault));
+        var defaultTypeName = GetString(attribute, nameof(BridgeAbstractionAttribute.DefaultTypeName), abstraction.Name + "Default");
+
+        if (generateDefault && HasTypeInNamespace(abstraction.ContainingNamespace, defaultTypeName))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DefaultNameConflict,
+                node.GetLocation(),
+                defaultTypeName,
+                abstraction.ContainingNamespace.IsGlobalNamespace ? "" : abstraction.ContainingNamespace.ToDisplayString()));
+            return;
+        }
+
+        var members = GetForwardableMembers(implementor, propertyName).ToArray();
+        foreach (var member in members.Where(m => m.UnsupportedReason is not null))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(UnsupportedMember, node.GetLocation(), member.Name));
+            return;
+        }
+
+        var source = RenderAbstraction(abstraction, implementor, propertyName, members);
+        context.AddSource($"{abstraction.Name}.Bridge.g.cs", source);
+
+        if (generateDefault)
+        {
+            context.AddSource($"{defaultTypeName}.Bridge.Default.g.cs", RenderDefault(abstraction, implementor, defaultTypeName));
+        }
+    }
+
+    private static string RenderAbstraction(INamedTypeSymbol abstraction, INamedTypeSymbol implementor, string propertyName, ForwardMember[] members)
+    {
+        var ns = abstraction.ContainingNamespace.IsGlobalNamespace ? null : abstraction.ContainingNamespace.ToDisplayString();
+        var typeKind = abstraction.IsRecord ? "record class" : "class";
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        if (ns is not null)
+        {
+            sb.Append("namespace ").Append(ns).AppendLine(";");
+            sb.AppendLine();
+        }
+
+        sb.Append("public abstract partial ").Append(typeKind).Append(' ').Append(abstraction.Name);
+        if (abstraction.TypeParameters.Length > 0)
+        {
+            sb.Append('<').Append(string.Join(", ", abstraction.TypeParameters.Select(p => p.Name))).Append('>');
+        }
+        sb.AppendLine();
+        sb.AppendLine("{");
+        var implType = implementor.ToDisplayString(TypeFormat);
+        sb.Append("    protected ").Append(abstraction.Name).Append('(').Append(implType).Append(" implementor)");
+        sb.AppendLine();
+        sb.AppendLine("    {");
+        sb.Append("        ").Append(propertyName).Append(" = implementor ?? throw new global::System.ArgumentNullException(nameof(implementor));").AppendLine();
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.Append("    protected ").Append(implType).Append(' ').Append(propertyName).Append(" { get; }").AppendLine();
+
+        foreach (var member in members)
+        {
+            sb.AppendLine();
+            sb.Append(member.Source);
+        }
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string RenderDefault(INamedTypeSymbol abstraction, INamedTypeSymbol implementor, string defaultTypeName)
+    {
+        var ns = abstraction.ContainingNamespace.IsGlobalNamespace ? null : abstraction.ContainingNamespace.ToDisplayString();
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        if (ns is not null)
+        {
+            sb.Append("namespace ").Append(ns).AppendLine(";");
+            sb.AppendLine();
+        }
+
+        sb.Append("public sealed partial class ").Append(defaultTypeName).Append(" : ").Append(abstraction.ToDisplayString(TypeFormat)).AppendLine();
+        sb.AppendLine("{");
+        sb.Append("    public ").Append(defaultTypeName).Append('(').Append(implementor.ToDisplayString(TypeFormat)).Append(" implementor) : base(implementor)");
+        sb.AppendLine();
+        sb.AppendLine("    {");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static IEnumerable<ForwardMember> GetForwardableMembers(INamedTypeSymbol implementor, string propertyName)
+    {
+        foreach (var member in implementor.GetMembers().OrderBy(m => m.Name, StringComparer.Ordinal))
+        {
+            if (HasIgnore(member) || member.IsStatic)
+            {
+                continue;
+            }
+
+            if (member is IEventSymbol)
+            {
+                yield return new ForwardMember(member.Name, "", "events");
+                continue;
+            }
+
+            if (member is IMethodSymbol method &&
+                method.MethodKind == MethodKind.Ordinary &&
+                (implementor.TypeKind == TypeKind.Interface || method.IsAbstract || method.IsVirtual))
+            {
+                yield return new ForwardMember(member.Name, RenderMethod(method, propertyName), null);
+            }
+
+            if (member is IPropertySymbol property &&
+                !property.IsIndexer &&
+                (implementor.TypeKind == TypeKind.Interface || property.IsAbstract || property.IsVirtual))
+            {
+                yield return new ForwardMember(member.Name, RenderProperty(property, propertyName), null);
+            }
+        }
+    }
+
+    private static string RenderMethod(IMethodSymbol method, string propertyName)
+    {
+        var sb = new StringBuilder();
+        sb.Append("    protected ").Append(method.ReturnType.ToDisplayString(TypeFormat)).Append(' ').Append(method.Name);
+        if (method.TypeParameters.Length > 0)
+        {
+            sb.Append('<').Append(string.Join(", ", method.TypeParameters.Select(p => p.Name))).Append('>');
+        }
+
+        sb.Append('(').Append(string.Join(", ", method.Parameters.Select(RenderParameter))).Append(')').AppendLine();
+        sb.Append("        => ").Append(propertyName).Append('.').Append(method.Name);
+        if (method.TypeParameters.Length > 0)
+        {
+            sb.Append('<').Append(string.Join(", ", method.TypeParameters.Select(p => p.Name))).Append('>');
+        }
+        sb.Append('(').Append(string.Join(", ", method.Parameters.Select(RenderArgument))).AppendLine(");");
+        return sb.ToString();
+    }
+
+    private static string RenderProperty(IPropertySymbol property, string propertyName)
+    {
+        return $"    protected {property.Type.ToDisplayString(TypeFormat)} {property.Name} => {propertyName}.{property.Name};";
+    }
+
+    private static string RenderParameter(IParameterSymbol parameter)
+    {
+        var prefix = parameter.RefKind switch
+        {
+            RefKind.Ref => "ref ",
+            RefKind.Out => "out ",
+            RefKind.In => "in ",
+            _ => ""
+        };
+        var defaultValue = parameter.HasExplicitDefaultValue
+            ? " = " + RenderDefaultValue(parameter)
+            : "";
+        return $"{prefix}{parameter.Type.ToDisplayString(TypeFormat)} {parameter.Name}{defaultValue}";
+    }
+
+    private static string RenderArgument(IParameterSymbol parameter)
+    {
+        var prefix = parameter.RefKind switch
+        {
+            RefKind.Ref => "ref ",
+            RefKind.Out => "out ",
+            RefKind.In => "in ",
+            _ => ""
+        };
+        return prefix + parameter.Name;
+    }
+
+    private static string RenderDefaultValue(IParameterSymbol parameter)
+    {
+        if (parameter.ExplicitDefaultValue is null)
+        {
+            return "default";
+        }
+        if (parameter.Type.SpecialType == SpecialType.System_String)
+        {
+            return "@\"" + parameter.ExplicitDefaultValue.ToString()!.Replace("\"", "\"\"") + "\"";
+        }
+        if (parameter.Type.SpecialType == SpecialType.System_Boolean)
+        {
+            return (bool)parameter.ExplicitDefaultValue ? "true" : "false";
+        }
+        return parameter.ExplicitDefaultValue.ToString() ?? "default";
+    }
+
+    private static bool IsPartial(SyntaxNode node) =>
+        node is TypeDeclarationSyntax type && type.Modifiers.Any(SyntaxKind.PartialKeyword);
+
+    private static bool HasIgnore(ISymbol symbol) =>
+        symbol.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Bridge.BridgeIgnoreAttribute");
+
+    private static string GetString(AttributeData attribute, string name, string fallback)
+    {
+        foreach (var item in attribute.NamedArguments)
+        {
+            if (item.Key == name && item.Value.Value is string value && !string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+        return fallback;
+    }
+
+    private static bool GetBool(AttributeData attribute, string name)
+    {
+        foreach (var item in attribute.NamedArguments)
+        {
+            if (item.Key == name && item.Value.Value is bool value)
+            {
+                return value;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasTypeInNamespace(INamespaceSymbol ns, string name) =>
+        ns.GetTypeMembers(name).Any();
+
+    private readonly record struct ForwardMember(string Name, string Source, string? UnsupportedReason);
+}

--- a/test/PatternKit.Generators.Tests/BridgeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/BridgeGeneratorTests.cs
@@ -1,0 +1,102 @@
+using PatternKit.Generators.Bridge;
+
+namespace PatternKit.Generators.Tests;
+
+public class BridgeGeneratorTests
+{
+    [Fact]
+    public void GeneratesBridgeForwardingAndDefaultType()
+    {
+        const string source = """
+            using PatternKit.Generators.Bridge;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestNamespace;
+
+            [BridgeImplementor]
+            public partial interface IRenderer
+            {
+                void DrawLine(int x1, int y1, int x2, int y2);
+                ValueTask FlushAsync(CancellationToken ct = default);
+            }
+
+            [BridgeAbstraction(typeof(IRenderer), GenerateDefault = true, DefaultTypeName = "DefaultShape")]
+            public partial class Shape
+            {
+                public void Draw() => DrawLine(0, 0, 1, 1);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GeneratesBridgeForwardingAndDefaultType));
+        var gen = new BridgeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
+        Assert.Contains(generated, s => s.HintName == "Shape.Bridge.g.cs");
+        Assert.Contains(generated, s => s.HintName == "DefaultShape.Bridge.Default.g.cs");
+
+        var bridgeSource = generated.First(s => s.HintName == "Shape.Bridge.g.cs").SourceText.ToString();
+        Assert.Contains("protected global::TestNamespace.IRenderer Implementor { get; }", bridgeSource);
+        Assert.Contains("protected void DrawLine(int x1, int y1, int x2, int y2)", bridgeSource);
+        Assert.Contains("protected global::System.Threading.Tasks.ValueTask FlushAsync", bridgeSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void ReportsDiagnosticWhenAbstractionIsNotPartial()
+    {
+        const string source = """
+            using PatternKit.Generators.Bridge;
+
+            namespace TestNamespace;
+
+            public interface IRenderer
+            {
+                void Draw();
+            }
+
+            [BridgeAbstraction(typeof(IRenderer))]
+            public class Shape
+            {
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsDiagnosticWhenAbstractionIsNotPartial));
+        var gen = new BridgeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diags = result.Results.SelectMany(r => r.Diagnostics);
+        Assert.Contains(diags, d => d.Id == "PKBRG001");
+    }
+
+    [Fact]
+    public void ReportsDiagnosticWhenImplementorIsConcrete()
+    {
+        const string source = """
+            using PatternKit.Generators.Bridge;
+
+            namespace TestNamespace;
+
+            public sealed class Renderer
+            {
+                public void Draw() { }
+            }
+
+            [BridgeAbstraction(typeof(Renderer))]
+            public partial class Shape
+            {
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsDiagnosticWhenImplementorIsConcrete));
+        var gen = new BridgeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diags = result.Results.SelectMany(r => r.Diagnostics);
+        Assert.Contains(diags, d => d.Id == "PKBRG002");
+    }
+}


### PR DESCRIPTION
Closes #34.\n\nAdds the Bridge generator attributes, source generator, focused Roslyn tests, docs, TOC entry, and analyzer release metadata.\n\nLocal validation:\n- dotnet build src/PatternKit.Generators/PatternKit.Generators.csproj --no-restore\n\nNote: full generator test project build is currently blocked locally by pre-existing PatternKit.Examples generated-code failures under the installed SDK/compiler mix.