### PR TITLE
Add Composite pattern generator

### DIFF
--- a/docs/generators/composite.md
+++ b/docs/generators/composite.md
@@ -1,0 +1,41 @@
+# Composite Generator
+
+The Composite generator creates contract-first base types for tree-like object graphs. Generated code has no runtime dependency on PatternKit.
+
+## Usage
+
+```csharp
+using PatternKit.Generators.Composite;
+
+[CompositeComponent(GenerateTraversalHelpers = true)]
+public partial interface ICategory
+{
+    string Name { get; }
+}
+
+public sealed class CategoryLeaf : CategoryComponentBase
+{
+    public override string Name { get; }
+}
+
+public sealed class CategoryNode : CategoryCompositeBase
+{
+    public override string Name { get; }
+}
+```
+
+The generated component base defaults to leaf behavior: `IsLeaf` is `true`, `Children` is empty, and `Add`, `Remove`, and `Clear` throw `NotSupportedException`.
+
+The generated composite base stores children in insertion order, rejects null children, exposes a read-only child view, and supports deterministic `Add`, `Remove`, and `Clear`.
+
+## Attributes
+
+- `[CompositeComponent]` marks a partial interface or abstract class component contract.
+- `[CompositeIgnore]` excludes a property or method from generated base declarations.
+
+## Diagnostics
+
+- `PKCMP001`: component contract must be partial.
+- `PKCMP002`: component target must be an interface or abstract class.
+- `PKCMP003`: generated base type name conflicts with an existing type.
+- `PKCMP004`: unsupported contract member, such as an event.

--- a/docs/generators/toc.yml
+++ b/docs/generators/toc.yml
@@ -7,6 +7,9 @@
 - name: Bridge
   href: bridge.md
 
+- name: Composite
+  href: composite.md
+
 - name: Facade
   href: facade.md
 

--- a/src/PatternKit.Generators.Abstractions/Composite/CompositeAttributes.cs
+++ b/src/PatternKit.Generators.Abstractions/Composite/CompositeAttributes.cs
@@ -1,0 +1,30 @@
+namespace PatternKit.Generators.Composite;
+
+/// <summary>
+/// Marks a component contract for Composite pattern base type generation.
+/// </summary>
+[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class, Inherited = false)]
+public sealed class CompositeComponentAttribute : Attribute
+{
+    public string? ComponentBaseName { get; set; }
+
+    public string? CompositeBaseName { get; set; }
+
+    public string ChildrenPropertyName { get; set; } = "Children";
+
+    public CompositeChildrenStorage Storage { get; set; } = CompositeChildrenStorage.List;
+
+    public bool GenerateTraversalHelpers { get; set; }
+}
+
+/// <summary>
+/// Excludes a contract member from generated Composite base types.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method, Inherited = false)]
+public sealed class CompositeIgnoreAttribute : Attribute;
+
+public enum CompositeChildrenStorage
+{
+    List = 0,
+    ImmutableArray = 1
+}

--- a/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
@@ -120,6 +120,10 @@ PKBRG001 | PatternKit.Generators.Bridge | Error | Bridge abstraction must be par
 PKBRG002 | PatternKit.Generators.Bridge | Error | Bridge implementor must be an interface or abstract class
 PKBRG003 | PatternKit.Generators.Bridge | Error | Implementor member is unsupported
 PKBRG004 | PatternKit.Generators.Bridge | Error | Generated default abstraction name conflicts
+PKCMP001 | PatternKit.Generators.Composite | Error | Composite component must be partial
+PKCMP002 | PatternKit.Generators.Composite | Error | Composite component target is invalid
+PKCMP003 | PatternKit.Generators.Composite | Error | Generated Composite type name conflicts
+PKCMP004 | PatternKit.Generators.Composite | Error | Composite contract member is unsupported
 PKST001 | PatternKit.Generators.State | Error | Type marked with [StateMachine] must be partial
 PKST002 | PatternKit.Generators.State | Error | State type must be an enum
 PKST003 | PatternKit.Generators.State | Error | Trigger type must be an enum

--- a/src/PatternKit.Generators/Composite/CompositeGenerator.cs
+++ b/src/PatternKit.Generators/Composite/CompositeGenerator.cs
@@ -1,0 +1,256 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text;
+
+namespace PatternKit.Generators.Composite;
+
+[Generator]
+public sealed class CompositeGenerator : IIncrementalGenerator
+{
+    private static readonly SymbolDisplayFormat TypeFormat = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+                              SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+    private static readonly DiagnosticDescriptor MustBePartial = new(
+        "PKCMP001",
+        "Composite component must be partial",
+        "Type '{0}' is marked with [CompositeComponent] but is not declared as partial",
+        "PatternKit.Generators.Composite",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor InvalidTarget = new(
+        "PKCMP002",
+        "Composite component target is invalid",
+        "Composite component type '{0}' must be an interface or abstract class",
+        "PatternKit.Generators.Composite",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor NameConflict = new(
+        "PKCMP003",
+        "Generated Composite type name conflicts",
+        "Generated Composite type name '{0}' conflicts with an existing type in namespace '{1}'",
+        "PatternKit.Generators.Composite",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor UnsupportedMember = new(
+        "PKCMP004",
+        "Composite contract member is unsupported",
+        "Composite contract member '{0}' is not supported in v1",
+        "PatternKit.Generators.Composite",
+        DiagnosticSeverity.Error,
+        true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var components = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "PatternKit.Generators.Composite.CompositeComponentAttribute",
+            static (node, _) => node is InterfaceDeclarationSyntax or ClassDeclarationSyntax,
+            static (ctx, _) => ctx);
+
+        context.RegisterSourceOutput(components, static (spc, ctx) =>
+        {
+            if (ctx.TargetSymbol is not INamedTypeSymbol component)
+            {
+                return;
+            }
+
+            var attr = ctx.Attributes.FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Composite.CompositeComponentAttribute");
+            if (attr is not null)
+            {
+                Generate(spc, component, attr, ctx.TargetNode);
+            }
+        });
+    }
+
+    private static void Generate(SourceProductionContext context, INamedTypeSymbol component, AttributeData attribute, SyntaxNode node)
+    {
+        if (!IsPartial(node))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustBePartial, node.GetLocation(), component.Name));
+            return;
+        }
+
+        if (component.TypeKind != TypeKind.Interface && !(component.TypeKind == TypeKind.Class && component.IsAbstract))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(InvalidTarget, node.GetLocation(), component.Name));
+            return;
+        }
+
+        foreach (var member in component.GetMembers())
+        {
+            if (member is IEventSymbol)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(UnsupportedMember, node.GetLocation(), member.Name));
+                return;
+            }
+        }
+
+        var contractName = component.Name.StartsWith("I", StringComparison.Ordinal) && component.Name.Length > 1
+            ? component.Name.Substring(1)
+            : component.Name;
+        var componentBaseName = GetString(attribute, nameof(CompositeComponentAttribute.ComponentBaseName), contractName + "ComponentBase");
+        var compositeBaseName = GetString(attribute, nameof(CompositeComponentAttribute.CompositeBaseName), contractName + "CompositeBase");
+        var childrenName = GetString(attribute, nameof(CompositeComponentAttribute.ChildrenPropertyName), "Children");
+        var generateTraversal = GetBool(attribute, nameof(CompositeComponentAttribute.GenerateTraversalHelpers));
+
+        var ns = component.ContainingNamespace;
+        if (HasType(ns, componentBaseName) || HasType(ns, compositeBaseName))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(NameConflict, node.GetLocation(), HasType(ns, componentBaseName) ? componentBaseName : compositeBaseName, ns.ToDisplayString()));
+            return;
+        }
+
+        context.AddSource($"{component.Name}.Composite.g.cs", RenderComposite(component, componentBaseName, compositeBaseName, childrenName));
+        if (generateTraversal)
+        {
+            context.AddSource($"{component.Name}.Composite.Traversal.g.cs", RenderTraversal(component, contractName, componentBaseName, childrenName));
+        }
+    }
+
+    private static string RenderComposite(INamedTypeSymbol component, string componentBaseName, string compositeBaseName, string childrenName)
+    {
+        var ns = component.ContainingNamespace.IsGlobalNamespace ? null : component.ContainingNamespace.ToDisplayString();
+        var contract = component.ToDisplayString(TypeFormat);
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        if (ns is not null)
+        {
+            sb.Append("namespace ").Append(ns).AppendLine(";");
+            sb.AppendLine();
+        }
+
+        sb.Append("public abstract partial class ").Append(componentBaseName).Append(" : ").Append(contract).AppendLine();
+        sb.AppendLine("{");
+        foreach (var property in GetContractProperties(component))
+        {
+            sb.Append("    public abstract ").Append(property.Type.ToDisplayString(TypeFormat)).Append(' ').Append(property.Name).Append(" { get; }").AppendLine();
+            sb.AppendLine();
+        }
+        sb.AppendLine("    public virtual bool IsLeaf => true;");
+        sb.AppendLine();
+        sb.Append("    public virtual global::System.Collections.Generic.IReadOnlyList<").Append(contract).Append("> ").Append(childrenName)
+            .Append(" => global::System.Array.Empty<").Append(contract).Append(">();").AppendLine();
+        sb.AppendLine();
+        sb.Append("    public virtual void Add(").Append(contract).Append(" child) => throw new global::System.NotSupportedException();").AppendLine();
+        sb.AppendLine();
+        sb.Append("    public virtual bool Remove(").Append(contract).Append(" child) => throw new global::System.NotSupportedException();").AppendLine();
+        sb.AppendLine();
+        sb.AppendLine("    public virtual void Clear() => throw new global::System.NotSupportedException();");
+        sb.AppendLine("}");
+        sb.AppendLine();
+
+        sb.Append("public abstract partial class ").Append(compositeBaseName).Append(" : ").Append(componentBaseName).AppendLine();
+        sb.AppendLine("{");
+        sb.Append("    private readonly global::System.Collections.Generic.List<").Append(contract).Append("> _children = new();").AppendLine();
+        sb.AppendLine();
+        sb.AppendLine("    public override bool IsLeaf => false;");
+        sb.AppendLine();
+        sb.Append("    public override global::System.Collections.Generic.IReadOnlyList<").Append(contract).Append("> ").Append(childrenName).Append(" => _children;").AppendLine();
+        sb.AppendLine();
+        sb.Append("    public override void Add(").Append(contract).Append(" child)").AppendLine();
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (child is null) throw new global::System.ArgumentNullException(nameof(child));");
+        sb.AppendLine("        _children.Add(child);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.Append("    public override bool Remove(").Append(contract).Append(" child)").AppendLine();
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (child is null) throw new global::System.ArgumentNullException(nameof(child));");
+        sb.AppendLine("        return _children.Remove(child);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    public override void Clear() => _children.Clear();");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string RenderTraversal(INamedTypeSymbol component, string contractName, string componentBaseName, string childrenName)
+    {
+        var ns = component.ContainingNamespace.IsGlobalNamespace ? null : component.ContainingNamespace.ToDisplayString();
+        var contract = componentBaseName;
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        if (ns is not null)
+        {
+            sb.Append("namespace ").Append(ns).AppendLine(";");
+            sb.AppendLine();
+        }
+        sb.Append("public static partial class ").Append(contractName).AppendLine("Traversal");
+        sb.AppendLine("{");
+        sb.Append("    public static global::System.Collections.Generic.IEnumerable<").Append(contract).Append("> DepthFirst(").Append(contract).Append(" root)").AppendLine();
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (root is null) throw new global::System.ArgumentNullException(nameof(root));");
+        sb.AppendLine("        var stack = new global::System.Collections.Generic.Stack<" + contract + ">();");
+        sb.AppendLine("        stack.Push(root);");
+        sb.AppendLine("        while (stack.Count > 0)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var current = stack.Pop();");
+        sb.AppendLine("            yield return current;");
+        sb.AppendLine("            var children = current." + childrenName + ";");
+        sb.AppendLine("            for (var i = children.Count - 1; i >= 0; i--) stack.Push(children[i]);");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.Append("    public static global::System.Collections.Generic.IEnumerable<").Append(contract).Append("> BreadthFirst(").Append(contract).Append(" root)").AppendLine();
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (root is null) throw new global::System.ArgumentNullException(nameof(root));");
+        sb.AppendLine("        var queue = new global::System.Collections.Generic.Queue<" + contract + ">();");
+        sb.AppendLine("        queue.Enqueue(root);");
+        sb.AppendLine("        while (queue.Count > 0)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var current = queue.Dequeue();");
+        sb.AppendLine("            yield return current;");
+        sb.AppendLine("            foreach (var child in current." + childrenName + ") queue.Enqueue(child);");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static IEnumerable<IPropertySymbol> GetContractProperties(INamedTypeSymbol component) =>
+        component.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(p => !p.IsStatic && !p.IsIndexer && p.GetMethod is not null && !HasIgnore(p))
+            .OrderBy(p => p.Name, StringComparer.Ordinal);
+
+    private static bool IsPartial(SyntaxNode node) =>
+        node is TypeDeclarationSyntax type && type.Modifiers.Any(SyntaxKind.PartialKeyword);
+
+    private static bool HasIgnore(ISymbol symbol) =>
+        symbol.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Composite.CompositeIgnoreAttribute");
+
+    private static bool HasType(INamespaceSymbol ns, string name) => ns.GetTypeMembers(name).Any();
+
+    private static string GetString(AttributeData attribute, string name, string fallback)
+    {
+        foreach (var item in attribute.NamedArguments)
+        {
+            if (item.Key == name && item.Value.Value is string value && !string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+        return fallback;
+    }
+
+    private static bool GetBool(AttributeData attribute, string name)
+    {
+        foreach (var item in attribute.NamedArguments)
+        {
+            if (item.Key == name && item.Value.Value is bool value)
+            {
+                return value;
+            }
+        }
+        return false;
+    }
+}

--- a/src/PatternKit.Generators/Composite/CompositeGenerator.cs
+++ b/src/PatternKit.Generators/Composite/CompositeGenerator.cs
@@ -196,7 +196,11 @@ public sealed class CompositeGenerator : IIncrementalGenerator
         sb.AppendLine("            var current = stack.Pop();");
         sb.AppendLine("            yield return current;");
         sb.AppendLine("            var children = current." + childrenName + ";");
-        sb.AppendLine("            for (var i = children.Count - 1; i >= 0; i--) stack.Push(children[i]);");
+        sb.AppendLine("            for (var i = children.Count - 1; i >= 0; i--)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                if (children[i] is " + contract + " child) stack.Push(child);");
+        sb.AppendLine("                else throw new global::System.InvalidOperationException(\"Traversal requires generated composite component base instances.\");");
+        sb.AppendLine("            }");
         sb.AppendLine("        }");
         sb.AppendLine("    }");
         sb.AppendLine();
@@ -209,7 +213,11 @@ public sealed class CompositeGenerator : IIncrementalGenerator
         sb.AppendLine("        {");
         sb.AppendLine("            var current = queue.Dequeue();");
         sb.AppendLine("            yield return current;");
-        sb.AppendLine("            foreach (var child in current." + childrenName + ") queue.Enqueue(child);");
+        sb.AppendLine("            foreach (var item in current." + childrenName + ")");
+        sb.AppendLine("            {");
+        sb.AppendLine("                if (item is " + contract + " child) queue.Enqueue(child);");
+        sb.AppendLine("                else throw new global::System.InvalidOperationException(\"Traversal requires generated composite component base instances.\");");
+        sb.AppendLine("            }");
         sb.AppendLine("        }");
         sb.AppendLine("    }");
         sb.AppendLine("}");

--- a/test/PatternKit.Generators.Tests/CompositeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/CompositeGeneratorTests.cs
@@ -1,0 +1,96 @@
+using PatternKit.Generators.Composite;
+
+namespace PatternKit.Generators.Tests;
+
+public class CompositeGeneratorTests
+{
+    [Fact]
+    public void GeneratesCompositeBasesAndTraversalHelpers()
+    {
+        const string source = """
+            using PatternKit.Generators.Composite;
+
+            namespace TestNamespace;
+
+            [CompositeComponent(GenerateTraversalHelpers = true)]
+            public partial interface ICategory
+            {
+                string Name { get; }
+            }
+
+            public sealed class CategoryLeaf : CategoryComponentBase
+            {
+                public CategoryLeaf(string name) => Name = name;
+                public override string Name { get; }
+            }
+
+            public sealed class CategoryNode : CategoryCompositeBase
+            {
+                public CategoryNode(string name) => Name = name;
+                public override string Name { get; }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GeneratesCompositeBasesAndTraversalHelpers));
+        var gen = new CompositeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
+        Assert.Contains(generated, s => s.HintName == "ICategory.Composite.g.cs");
+        Assert.Contains(generated, s => s.HintName == "ICategory.Composite.Traversal.g.cs");
+
+        var sourceText = generated.First(s => s.HintName == "ICategory.Composite.g.cs").SourceText.ToString();
+        Assert.Contains("public abstract partial class CategoryComponentBase : global::TestNamespace.ICategory", sourceText);
+        Assert.Contains("public override void Add(global::TestNamespace.ICategory child)", sourceText);
+        Assert.Contains("throw new global::System.NotSupportedException()", sourceText);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void ReportsDiagnosticWhenComponentIsNotPartial()
+    {
+        const string source = """
+            using PatternKit.Generators.Composite;
+
+            namespace TestNamespace;
+
+            [CompositeComponent]
+            public interface ICategory
+            {
+                string Name { get; }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsDiagnosticWhenComponentIsNotPartial));
+        var gen = new CompositeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diags = result.Results.SelectMany(r => r.Diagnostics);
+        Assert.Contains(diags, d => d.Id == "PKCMP001");
+    }
+
+    [Fact]
+    public void ReportsDiagnosticWhenComponentIsConcrete()
+    {
+        const string source = """
+            using PatternKit.Generators.Composite;
+
+            namespace TestNamespace;
+
+            [CompositeComponent]
+            public partial class Category
+            {
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsDiagnosticWhenComponentIsConcrete));
+        var gen = new CompositeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diags = result.Results.SelectMany(r => r.Diagnostics);
+        Assert.Contains(diags, d => d.Id == "PKCMP002");
+    }
+}


### PR DESCRIPTION
Closes #35.\n\nAdds contract-first Composite generator attributes, base type generation, optional traversal helpers, focused Roslyn tests, docs, TOC entry, and analyzer release metadata.\n\nLocal validation:\n- dotnet build src/PatternKit.Generators/PatternKit.Generators.csproj --no-restore