### PR TITLE
Add Chain pattern generator

### DIFF
--- a/docs/generators/chain.md
+++ b/docs/generators/chain.md
@@ -1,0 +1,35 @@
+# Chain Generator
+
+The Chain generator emits deterministic responsibility-chain dispatch for partial chain hosts.
+
+## Usage
+
+```csharp
+using PatternKit.Generators.Chain;
+
+[Chain]
+public partial class Router
+{
+    [ChainHandler(Order = 0)]
+    private bool TryHealth(in Request request, out Response response)
+    {
+        response = new Response(200);
+        return request.Path == "/health";
+    }
+
+    [ChainDefault]
+    private Response NotFound(in Request request) => new(404);
+}
+```
+
+The generated `TryHandle` method invokes handlers by ascending `Order` and stops at the first handler that returns `true`. The generated `Handle` method returns that value or calls the `[ChainDefault]` fallback.
+
+## Diagnostics
+
+- `PKCH001`: chain host must be partial.
+- `PKCH002`: no handlers found.
+- `PKCH003`: duplicate handler order.
+- `PKCH004`: handler signature invalid.
+- `PKCH005`: pipeline terminal missing.
+- `PKCH006`: multiple pipeline terminals.
+- `PKCH007`: default fallback missing.

--- a/docs/generators/toc.yml
+++ b/docs/generators/toc.yml
@@ -7,6 +7,9 @@
 - name: Bridge
   href: bridge.md
 
+- name: Chain
+  href: chain.md
+
 - name: Composite
   href: composite.md
 

--- a/src/PatternKit.Generators.Abstractions/Chain/ChainAttributes.cs
+++ b/src/PatternKit.Generators.Abstractions/Chain/ChainAttributes.cs
@@ -1,0 +1,28 @@
+namespace PatternKit.Generators.Chain;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class ChainAttribute : Attribute
+{
+    public ChainModel Model { get; set; } = ChainModel.Responsibility;
+    public string HandleMethodName { get; set; } = "Handle";
+    public string TryHandleMethodName { get; set; } = "TryHandle";
+}
+
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public sealed class ChainHandlerAttribute : Attribute
+{
+    public int Order { get; set; }
+    public string? Name { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public sealed class ChainDefaultAttribute : Attribute;
+
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public sealed class ChainTerminalAttribute : Attribute;
+
+public enum ChainModel
+{
+    Responsibility = 0,
+    Pipeline = 1
+}

--- a/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
@@ -120,6 +120,13 @@ PKBRG001 | PatternKit.Generators.Bridge | Error | Bridge abstraction must be par
 PKBRG002 | PatternKit.Generators.Bridge | Error | Bridge implementor must be an interface or abstract class
 PKBRG003 | PatternKit.Generators.Bridge | Error | Implementor member is unsupported
 PKBRG004 | PatternKit.Generators.Bridge | Error | Generated default abstraction name conflicts
+PKCH001 | PatternKit.Generators.Chain | Error | Chain type must be partial
+PKCH002 | PatternKit.Generators.Chain | Error | No chain handlers found
+PKCH003 | PatternKit.Generators.Chain | Error | Duplicate chain handler order
+PKCH004 | PatternKit.Generators.Chain | Error | Chain handler signature invalid
+PKCH005 | PatternKit.Generators.Chain | Error | Pipeline terminal missing
+PKCH006 | PatternKit.Generators.Chain | Error | Multiple pipeline terminals
+PKCH007 | PatternKit.Generators.Chain | Error | Chain default missing
 PKCMP001 | PatternKit.Generators.Composite | Error | Composite component must be partial
 PKCMP002 | PatternKit.Generators.Composite | Error | Composite component target is invalid
 PKCMP003 | PatternKit.Generators.Composite | Error | Generated Composite type name conflicts

--- a/src/PatternKit.Generators/Chain/ChainGenerator.cs
+++ b/src/PatternKit.Generators/Chain/ChainGenerator.cs
@@ -1,0 +1,166 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text;
+
+namespace PatternKit.Generators.Chain;
+
+[Generator]
+public sealed class ChainGenerator : IIncrementalGenerator
+{
+    private static readonly SymbolDisplayFormat TypeFormat = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+                              SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+    private static readonly DiagnosticDescriptor MustBePartial = new("PKCH001", "Chain type must be partial", "Type '{0}' is marked with [Chain] but is not declared as partial", "PatternKit.Generators.Chain", DiagnosticSeverity.Error, true);
+    private static readonly DiagnosticDescriptor MissingHandlers = new("PKCH002", "No chain handlers found", "No [ChainHandler] methods found for chain type '{0}'", "PatternKit.Generators.Chain", DiagnosticSeverity.Error, true);
+    private static readonly DiagnosticDescriptor DuplicateOrder = new("PKCH003", "Duplicate chain handler order", "Multiple chain handlers use Order {0}", "PatternKit.Generators.Chain", DiagnosticSeverity.Error, true);
+    private static readonly DiagnosticDescriptor InvalidHandler = new("PKCH004", "Chain handler signature invalid", "Handler method '{0}' must return bool and accept (in TInput, out TOutput)", "PatternKit.Generators.Chain", DiagnosticSeverity.Error, true);
+    private static readonly DiagnosticDescriptor MissingTerminal = new("PKCH005", "Pipeline terminal missing", "Pipeline chains require a [ChainTerminal] method", "PatternKit.Generators.Chain", DiagnosticSeverity.Error, true);
+    private static readonly DiagnosticDescriptor MultipleTerminals = new("PKCH006", "Multiple pipeline terminals", "Pipeline chains cannot declare multiple [ChainTerminal] methods", "PatternKit.Generators.Chain", DiagnosticSeverity.Error, true);
+    private static readonly DiagnosticDescriptor MissingDefault = new("PKCH007", "Chain default missing", "Responsibility chain '{0}' must declare a [ChainDefault] method for Handle fallback", "PatternKit.Generators.Chain", DiagnosticSeverity.Error, true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var chains = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "PatternKit.Generators.Chain.ChainAttribute",
+            static (node, _) => node is TypeDeclarationSyntax,
+            static (ctx, _) => ctx);
+
+        context.RegisterSourceOutput(chains, static (spc, ctx) =>
+        {
+            if (ctx.TargetSymbol is INamedTypeSymbol type)
+            {
+                var attr = ctx.Attributes.FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Chain.ChainAttribute");
+                if (attr is not null) Generate(spc, type, attr, ctx.TargetNode);
+            }
+        });
+    }
+
+    private static void Generate(SourceProductionContext context, INamedTypeSymbol type, AttributeData attr, SyntaxNode node)
+    {
+        if (!IsPartial(node))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustBePartial, node.GetLocation(), type.Name));
+            return;
+        }
+
+        var model = GetEnum(attr, nameof(ChainAttribute.Model));
+        if (model == 1)
+        {
+            var terminals = GetMethods(type, "PatternKit.Generators.Chain.ChainTerminalAttribute").ToArray();
+            context.ReportDiagnostic(Diagnostic.Create(terminals.Length > 1 ? MultipleTerminals : MissingTerminal, node.GetLocation()));
+            return;
+        }
+
+        var handlers = GetMethods(type, "PatternKit.Generators.Chain.ChainHandlerAttribute")
+            .Select(m => new Handler(m, GetOrder(m)))
+            .OrderBy(h => h.Order)
+            .ThenBy(h => h.Method.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        if (handlers.Length == 0)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MissingHandlers, node.GetLocation(), type.Name));
+            return;
+        }
+        var dup = handlers.GroupBy(h => h.Order).FirstOrDefault(g => g.Count() > 1);
+        if (dup is not null)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(DuplicateOrder, node.GetLocation(), dup.Key));
+            return;
+        }
+
+        if (!TryGetShape(handlers[0].Method, out var input, out var output) || handlers.Any(h => !SameShape(h.Method, input!, output!)))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(InvalidHandler, node.GetLocation(), handlers.First().Method.Name));
+            return;
+        }
+
+        var defaults = GetMethods(type, "PatternKit.Generators.Chain.ChainDefaultAttribute").ToArray();
+        if (defaults.Length == 0)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MissingDefault, node.GetLocation(), type.Name));
+            return;
+        }
+        var fallback = defaults[0];
+        if (!SymbolEqualityComparer.Default.Equals(fallback.ReturnType, output) || fallback.Parameters.Length != 1 ||
+            !SymbolEqualityComparer.Default.Equals(fallback.Parameters[0].Type, input))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(InvalidHandler, node.GetLocation(), fallback.Name));
+            return;
+        }
+
+        var handleName = GetString(attr, nameof(ChainAttribute.HandleMethodName), "Handle");
+        var tryName = GetString(attr, nameof(ChainAttribute.TryHandleMethodName), "TryHandle");
+        context.AddSource($"{type.Name}.Chain.g.cs", Render(type, handlers, fallback, input!, output!, handleName, tryName));
+    }
+
+    private static string Render(INamedTypeSymbol type, Handler[] handlers, IMethodSymbol fallback, ITypeSymbol input, ITypeSymbol output, string handleName, string tryName)
+    {
+        var ns = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString();
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        if (ns is not null)
+        {
+            sb.Append("namespace ").Append(ns).AppendLine(";");
+            sb.AppendLine();
+        }
+        sb.Append("public partial ").Append(GetKind(type)).Append(' ').Append(type.Name).AppendLine();
+        sb.AppendLine("{");
+        sb.Append("    public bool ").Append(tryName).Append("(in ").Append(input.ToDisplayString(TypeFormat)).Append(" input, out ").Append(output.ToDisplayString(TypeFormat)).Append(" output)").AppendLine();
+        sb.AppendLine("    {");
+        foreach (var h in handlers)
+        {
+            sb.Append("        if (").Append(h.Method.Name).Append("(in input, out output)) return true;").AppendLine();
+        }
+        sb.AppendLine("        output = default!;");
+        sb.AppendLine("        return false;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.Append("    public ").Append(output.ToDisplayString(TypeFormat)).Append(' ').Append(handleName).Append("(in ").Append(input.ToDisplayString(TypeFormat)).Append(" input)").AppendLine();
+        sb.AppendLine("    {");
+        sb.Append("        return ").Append(tryName).Append("(in input, out var output) ? output : ").Append(fallback.Name).Append("(in input);").AppendLine();
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static bool TryGetShape(IMethodSymbol method, out ITypeSymbol? input, out ITypeSymbol? output)
+    {
+        input = null;
+        output = null;
+        if (method.ReturnType.SpecialType != SpecialType.System_Boolean || method.Parameters.Length != 2 ||
+            method.Parameters[0].RefKind != RefKind.In || method.Parameters[1].RefKind != RefKind.Out)
+        {
+            return false;
+        }
+        input = method.Parameters[0].Type;
+        output = method.Parameters[1].Type;
+        return true;
+    }
+
+    private static bool SameShape(IMethodSymbol method, ITypeSymbol input, ITypeSymbol output) =>
+        TryGetShape(method, out var i, out var o) &&
+        SymbolEqualityComparer.Default.Equals(i, input) &&
+        SymbolEqualityComparer.Default.Equals(o, output);
+
+    private static IEnumerable<IMethodSymbol> GetMethods(INamedTypeSymbol type, string attr) =>
+        type.GetMembers().OfType<IMethodSymbol>().Where(m => m.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == attr));
+
+    private static int GetOrder(IMethodSymbol method)
+    {
+        var attr = method.GetAttributes().First(a => a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Chain.ChainHandlerAttribute");
+        return attr.NamedArguments.FirstOrDefault(a => a.Key == nameof(ChainHandlerAttribute.Order)).Value.Value is int value ? value : 0;
+    }
+
+    private static bool IsPartial(SyntaxNode node) => node is TypeDeclarationSyntax type && type.Modifiers.Any(SyntaxKind.PartialKeyword);
+    private static int GetEnum(AttributeData attr, string name) => attr.NamedArguments.FirstOrDefault(a => a.Key == name).Value.Value is int value ? value : 0;
+    private static string GetString(AttributeData attr, string name, string fallback) => attr.NamedArguments.FirstOrDefault(a => a.Key == name).Value.Value as string ?? fallback;
+    private static string GetKind(INamedTypeSymbol type) => type.TypeKind == TypeKind.Struct ? (type.IsRecord ? "record struct" : "struct") : (type.IsRecord ? "record class" : "class");
+
+    private readonly record struct Handler(IMethodSymbol Method, int Order);
+}

--- a/test/PatternKit.Generators.Tests/ChainGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ChainGeneratorTests.cs
@@ -1,0 +1,71 @@
+using PatternKit.Generators.Chain;
+
+namespace PatternKit.Generators.Tests;
+
+public class ChainGeneratorTests
+{
+    [Fact]
+    public void GeneratesResponsibilityChain()
+    {
+        const string source = """
+            using PatternKit.Generators.Chain;
+
+            namespace TestNamespace;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Chain]
+            public partial class Router
+            {
+                [ChainHandler(Order = 0)]
+                private bool TryHealth(in Request request, out Response response)
+                {
+                    response = new Response(200);
+                    return request.Path == "/health";
+                }
+
+                [ChainDefault]
+                private Response NotFound(in Request request) => new(404);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GeneratesResponsibilityChain));
+        var gen = new ChainGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Router.Chain.g.cs").SourceText.ToString();
+        Assert.Contains("public bool TryHandle(in global::TestNamespace.Request input, out global::TestNamespace.Response output)", generated);
+        Assert.Contains("public global::TestNamespace.Response Handle", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void ReportsDuplicateOrder()
+    {
+        const string source = """
+            using PatternKit.Generators.Chain;
+
+            namespace TestNamespace;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Chain]
+            public partial class Router
+            {
+                [ChainHandler(Order = 0)] private bool A(in Request request, out Response response) { response = default; return false; }
+                [ChainHandler(Order = 0)] private bool B(in Request request, out Response response) { response = default; return false; }
+                [ChainDefault] private Response NotFound(in Request request) => new(404);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsDuplicateOrder));
+        var gen = new ChainGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKCH003");
+    }
+}


### PR DESCRIPTION
Closes #40.\n\nAdds responsibility-chain generator attributes, deterministic handler ordering, diagnostics, focused Roslyn tests, docs, TOC entry, and analyzer release metadata.\n\nLocal validation:\n- dotnet build src/PatternKit.Generators/PatternKit.Generators.csproj --no-restore