### PR TITLE
test: raise generator example coverage

### DIFF
--- a/test/PatternKit.Examples.Tests/Decorators/StorageDecoratorExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Decorators/StorageDecoratorExampleTests.cs
@@ -1,0 +1,89 @@
+using PatternKit.Examples.Decorators;
+
+namespace PatternKit.Examples.Tests.Decorators;
+
+public sealed class StorageDecoratorExampleTests
+{
+    [Fact]
+    public void InMemoryStorage_ReadWriteExistsAndDelete_WorkAsExpected()
+    {
+        var storage = new InMemoryFileStorage();
+
+        storage.WriteFile("readme.txt", "hello");
+
+        Assert.True(storage.FileExists("readme.txt"));
+        Assert.Equal("hello", storage.ReadFile("readme.txt"));
+
+        storage.DeleteFile("readme.txt");
+
+        Assert.False(storage.FileExists("readme.txt"));
+        Assert.Throws<FileNotFoundException>(() => storage.ReadFile("readme.txt"));
+    }
+
+    [Fact]
+    public void GeneratedDecoratorChain_ForwardsAndInvalidatesCache()
+    {
+        var inner = new InMemoryFileStorage();
+        var storage = FileStorageDecorators.Compose(
+            inner,
+            next => new CachingFileStorage(next),
+            next => new LoggingFileStorage(next));
+
+        storage.WriteFile("invoice.txt", "v1");
+        Assert.Equal("v1", storage.ReadFile("invoice.txt"));
+        Assert.Equal("v1", storage.ReadFile("invoice.txt"));
+
+        storage.WriteFile("invoice.txt", "v2");
+
+        Assert.Equal("v2", storage.ReadFile("invoice.txt"));
+        Assert.True(storage.FileExists("invoice.txt"));
+
+        storage.DeleteFile("invoice.txt");
+        Assert.False(storage.FileExists("invoice.txt"));
+    }
+
+    [Fact]
+    public void RetryDecorator_RetriesUntilOperationSucceeds()
+    {
+        var storage = new RetryFileStorage(new FlakyStorage(failuresBeforeSuccess: 2), maxRetries: 3, retryDelayMs: 0);
+
+        storage.WriteFile("data.txt", "payload");
+
+        Assert.Equal("payload", storage.ReadFile("data.txt"));
+    }
+
+    [Fact]
+    public void RetryDecorator_RethrowsAfterRetriesAreExhausted()
+    {
+        var storage = new RetryFileStorage(new FlakyStorage(failuresBeforeSuccess: 5), maxRetries: 2, retryDelayMs: 0);
+
+        Assert.Throws<IOException>(() => storage.WriteFile("data.txt", "payload"));
+    }
+
+    private sealed class FlakyStorage : IFileStorage
+    {
+        private readonly InMemoryFileStorage _inner = new();
+        private int _remainingFailures;
+
+        public FlakyStorage(int failuresBeforeSuccess)
+        {
+            _remainingFailures = failuresBeforeSuccess;
+        }
+
+        public string ReadFile(string path) => _inner.ReadFile(path);
+
+        public void WriteFile(string path, string content)
+        {
+            if (_remainingFailures-- > 0)
+            {
+                throw new IOException("Transient write failure.");
+            }
+
+            _inner.WriteFile(path, content);
+        }
+
+        public bool FileExists(string path) => _inner.FileExists(path);
+
+        public void DeleteFile(string path) => _inner.DeleteFile(path);
+    }
+}

--- a/test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs
@@ -1,0 +1,105 @@
+using PatternKit.Examples.Generators.Memento;
+
+namespace PatternKit.Examples.Tests.GeneratorTests;
+
+public sealed class MementoGeneratorExamplesTests
+{
+    [Fact]
+    public void EditorState_EditingOperations_AreImmutableAndClampRanges()
+    {
+        var initial = EditorStateDemo.EditorState.Empty();
+
+        var inserted = initial.Insert("Hello").Insert(" world");
+        var selected = inserted.Select(0, 50);
+        var replaced = selected.Insert("Hi");
+        var backspaced = replaced.Backspace();
+
+        Assert.Equal("", initial.Text);
+        Assert.Equal("Hello world", inserted.Text);
+        Assert.True(selected.HasSelection);
+        Assert.Equal(0, selected.SelectionStart);
+        Assert.Equal(inserted.Text.Length, selected.SelectionEnd);
+        Assert.Equal("Hi", replaced.Text);
+        Assert.Equal("H", backspaced.Text);
+        Assert.Equal("Text='H' Cursor=1", backspaced.ToString());
+    }
+
+    [Fact]
+    public void TextEditor_TracksUndoRedoAndClear()
+    {
+        var editor = new EditorStateDemo.TextEditor();
+
+        editor.Apply(state => state.Insert("Hello"));
+        editor.Apply(state => state.Insert(" world"));
+
+        Assert.Equal("Hello world", editor.Current.Text);
+        Assert.True(editor.CanUndo);
+        Assert.False(editor.CanRedo);
+
+        Assert.True(editor.Undo());
+        Assert.Equal("Hello", editor.Current.Text);
+        Assert.True(editor.Redo());
+        Assert.Equal("Hello world", editor.Current.Text);
+
+        editor.Clear();
+
+        Assert.Equal(EditorStateDemo.EditorState.Empty(), editor.Current);
+        Assert.False(editor.CanUndo);
+        Assert.False(editor.CanRedo);
+    }
+
+    [Fact]
+    public void EditorStateDemo_RunAndManualSnapshot_ReturnExpectedLogEntries()
+    {
+        var runLog = EditorStateDemo.Run();
+        var manualLog = EditorStateDemo.RunManualSnapshot();
+
+        Assert.Contains(runLog, line => line.StartsWith("Final:", StringComparison.Ordinal));
+        Assert.Contains(runLog, line => line.Contains("Redo failed", StringComparison.Ordinal));
+        Assert.Contains(manualLog, line => line == "Restored equals State1: True");
+    }
+
+    [Fact]
+    public void GameState_MutatorsAndSaveLoad_WorkAsExpected()
+    {
+        var state = new GameStateDemo.GameState();
+
+        state.MovePlayer(3, 4);
+        state.TakeDamage(25);
+        state.Heal(10);
+        state.AddScore(250);
+        state.AdvanceLevel();
+
+        Assert.Equal(3, state.PlayerX);
+        Assert.Equal(4, state.PlayerY);
+        Assert.Equal(100, state.Health);
+        Assert.Equal(250, state.Score);
+        Assert.Equal(2, state.Level);
+        Assert.Equal("Level 2: Health=100, Score=250, Pos=(3,4)", state.ToString());
+    }
+
+    [Fact]
+    public void GameSession_PerformActionMutatesStateAndReportsNoRedoWhenNoForwardHistoryExists()
+    {
+        var session = new GameStateDemo.GameSession();
+
+        session.PerformAction(state => state.MovePlayer(5, 3), "move");
+        session.PerformAction(state => state.TakeDamage(10), "damage");
+
+        Assert.Equal(5, session.State.PlayerX);
+        Assert.Equal(3, session.State.PlayerY);
+        Assert.Equal(90, session.State.Health);
+        Assert.False(session.RedoToCheckpoint());
+    }
+
+    [Fact]
+    public void GameStateDemo_RunAndSaveLoad_ReturnExpectedLogEntries()
+    {
+        var runLog = GameStateDemo.Run();
+        var saveLoadLog = GameStateDemo.RunSaveLoad();
+
+        Assert.Contains(runLog, line => line.StartsWith("Final:", StringComparison.Ordinal));
+        Assert.Contains(runLog, line => line.Contains("Redo failed", StringComparison.Ordinal));
+        Assert.Contains(saveLoadLog, line => line.StartsWith("Game loaded:", StringComparison.Ordinal));
+    }
+}

--- a/test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs
@@ -1,0 +1,84 @@
+using PatternKit.Examples.Generators.State;
+
+namespace PatternKit.Examples.Tests.GeneratorTests;
+
+public sealed class StateGeneratorExamplesTests
+{
+    [Fact]
+    public void OrderFlow_StartsInDraftAndExposesAvailableTriggers()
+    {
+        var order = new OrderFlow("ORD-TEST", 25m);
+
+        Assert.Equal(OrderState.Draft, order.State);
+        Assert.Equal("Order is being prepared", order.GetStateDescription());
+        Assert.Equal([OrderTrigger.Submit, OrderTrigger.Cancel], order.GetAvailableTriggers().ToArray());
+    }
+
+    [Fact]
+    public async Task OrderFlow_CompletesHappyPath()
+    {
+        var order = new OrderFlow("ORD-TEST", 25m);
+
+        order.Fire(OrderTrigger.Submit);
+        await order.FireAsync(OrderTrigger.Pay, CancellationToken.None);
+        order.Fire(OrderTrigger.Ship);
+
+        Assert.Equal(OrderState.Shipped, order.State);
+        Assert.Equal("Order is on its way to you", order.GetStateDescription());
+    }
+
+    [Fact]
+    public void OrderFlow_GuardBlocksInvalidPayment()
+    {
+        var order = new OrderFlow("ORD-BAD", -1m);
+
+        order.Fire(OrderTrigger.Submit);
+
+        Assert.False(order.CanFire(OrderTrigger.Pay));
+        Assert.Equal(OrderState.Submitted, order.State);
+    }
+
+    [Fact]
+    public void OrderFlow_CanCancelBeforePayment()
+    {
+        var order = new OrderFlow("ORD-CANCEL", 10m);
+
+        order.Fire(OrderTrigger.Submit);
+        order.Fire(OrderTrigger.Cancel);
+
+        Assert.Equal(OrderState.Cancelled, order.State);
+        Assert.Equal("Order has been cancelled", order.GetStateDescription());
+    }
+
+    [Fact]
+    public async Task DocumentWorkflow_RequiresReviewCommentBeforeApproval()
+    {
+        var workflow = new DocumentWorkflow("DOC-1", "Alice");
+
+        workflow.Fire(DocumentAction.SubmitForReview);
+
+        Assert.Equal(DocumentState.PendingReview, workflow.State);
+        Assert.False(workflow.CanFire(DocumentAction.Approve));
+
+        workflow.ReviewComments.Add("Looks good.");
+        workflow.Fire(DocumentAction.Approve);
+        await workflow.FireAsync(DocumentAction.Publish, CancellationToken.None);
+        workflow.Fire(DocumentAction.Archive);
+
+        Assert.Equal(DocumentState.Archived, workflow.State);
+    }
+
+    [Fact]
+    public void DocumentWorkflow_RejectionCanReturnToDraft()
+    {
+        var workflow = new DocumentWorkflow("DOC-2", "Alice");
+        workflow.ReviewComments.Add("Needs changes.");
+
+        workflow.Fire(DocumentAction.SubmitForReview);
+        workflow.Fire(DocumentAction.Reject);
+        workflow.Fire(DocumentAction.Revise);
+
+        Assert.Equal(DocumentState.Draft, workflow.State);
+        Assert.Empty(workflow.ReviewComments);
+    }
+}

--- a/test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs
@@ -1,0 +1,83 @@
+using PatternKit.Examples.Generators.Visitors;
+
+namespace PatternKit.Examples.Tests.GeneratorTests;
+
+public sealed class VisitorGeneratorExamplesTests
+{
+    [Fact]
+    public void ResultVisitor_DispatchesToConcreteDocumentHandlers()
+    {
+        var visitor = new DocumentVisitorBuilder<string>()
+            .When<PdfDocument>(pdf => $"pdf:{pdf.PageCount}")
+            .When<WordDocument>(word => $"word:{word.WordCount}")
+            .When<SpreadsheetDocument>(sheet => $"sheet:{sheet.SheetCount}")
+            .When<MarkdownDocument>(markdown => $"markdown:{markdown.LineCount}")
+            .Default(document => $"default:{document.FileName}")
+            .Build();
+
+        Assert.Equal("pdf:3", new PdfDocument { FileName = "a.pdf", PageCount = 3 }.Accept(visitor));
+        Assert.Equal("word:400", new WordDocument { FileName = "a.docx", WordCount = 400 }.Accept(visitor));
+        Assert.Equal("sheet:2", new SpreadsheetDocument { FileName = "a.xlsx", SheetCount = 2 }.Accept(visitor));
+        Assert.Equal("markdown:9", new MarkdownDocument { FileName = "README.md", LineCount = 9 }.Accept(visitor));
+    }
+
+    [Fact]
+    public void ActionVisitor_CollectsMetadataForEachConcreteDocument()
+    {
+        var log = new List<string>();
+        var visitor = new DocumentActionVisitorBuilder()
+            .When<PdfDocument>(pdf => log.Add($"pdf:{pdf.FileName}:{pdf.IsEncrypted}"))
+            .When<WordDocument>(word => log.Add($"word:{word.FileName}:{word.HasMacros}"))
+            .When<SpreadsheetDocument>(sheet => log.Add($"sheet:{sheet.FileName}:{sheet.HasFormulas}"))
+            .When<MarkdownDocument>(markdown => log.Add($"markdown:{markdown.FileName}:{markdown.HasCodeBlocks}"))
+            .Default(document => log.Add($"default:{document.FileName}"))
+            .Build();
+
+        new PdfDocument { FileName = "contract.pdf", IsEncrypted = true }.Accept(visitor);
+        new WordDocument { FileName = "memo.docx", HasMacros = false }.Accept(visitor);
+        new SpreadsheetDocument { FileName = "budget.xlsx", HasFormulas = true }.Accept(visitor);
+        new MarkdownDocument { FileName = "README.md", HasCodeBlocks = true }.Accept(visitor);
+
+        Assert.Equal(
+            ["pdf:contract.pdf:True", "word:memo.docx:False", "sheet:budget.xlsx:True", "markdown:README.md:True"],
+            log);
+    }
+
+    [Fact]
+    public async Task AsyncVisitors_DispatchToConcreteDocumentHandlers()
+    {
+        var resultVisitor = new DocumentAsyncVisitorBuilder<string>()
+            .WhenAsync<PdfDocument>((pdf, _) => ValueTask.FromResult($"pdf:{pdf.Id}"))
+            .WhenAsync<WordDocument>((word, _) => ValueTask.FromResult($"word:{word.Id}"))
+            .WhenAsync<SpreadsheetDocument>((sheet, _) => ValueTask.FromResult($"sheet:{sheet.Id}"))
+            .WhenAsync<MarkdownDocument>((markdown, _) => ValueTask.FromResult($"markdown:{markdown.Id}"))
+            .DefaultAsync((document, _) => ValueTask.FromResult($"default:{document.Id}"))
+            .Build();
+        var actionLog = new List<string>();
+        var actionVisitor = new DocumentAsyncActionVisitorBuilder()
+            .WhenAsync<PdfDocument>((pdf, _) =>
+            {
+                actionLog.Add($"pdf:{pdf.Id}");
+                return ValueTask.CompletedTask;
+            })
+            .DefaultAsync((document, _) =>
+            {
+                actionLog.Add($"default:{document.Id}");
+                return ValueTask.CompletedTask;
+            })
+            .Build();
+        var document = new PdfDocument { Id = "DOC-1", FileName = "doc.pdf" };
+
+        var result = await document.AcceptAsync(resultVisitor);
+        await document.AcceptAsync(actionVisitor);
+
+        Assert.Equal("pdf:DOC-1", result);
+        Assert.Equal(["pdf:DOC-1"], actionLog);
+    }
+
+    [Fact]
+    public async Task DocumentProcessingDemo_RunAsync_Completes()
+    {
+        await DocumentProcessingDemo.RunAsync();
+    }
+}

--- a/test/PatternKit.Examples.Tests/Messaging/DispatcherExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/DispatcherExampleTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Examples.Messaging;
+using PatternKit.Examples.Messaging.SourceGenerated;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class DispatcherExampleTests
+{
+    [Fact]
+    public async Task DispatcherUsageExamples_RunWithoutThrowing()
+    {
+        await DispatcherUsageExamples.BasicCommandExample();
+        await DispatcherUsageExamples.NotificationExample();
+        await DispatcherUsageExamples.StreamExample();
+        await DispatcherUsageExamples.PipelineExample();
+    }
+
+    [Fact]
+    public async Task CommandHandlers_ReturnExpectedResponsesAndLogOperations()
+    {
+        var logger = new InMemoryLogger();
+        var customerHandler = new CreateCustomerHandler(logger);
+        var orderHandler = new PlaceOrderHandler(logger);
+        var paymentHandler = new ProcessPaymentHandler(logger);
+
+        var customer = await customerHandler.Handle(new CreateCustomerCommand("Ada", "ada@example.com", 1000m), default);
+        var order = await orderHandler.Handle(
+            new PlaceOrderCommand(customer.Id, [new OrderItem(1, "Keyboard", 2, 50m)]),
+            default);
+        var paymentSuccess = await paymentHandler.Handle(new ProcessPaymentCommand(order.Id, order.Total), default);
+
+        Assert.Equal("Ada", customer.Name);
+        Assert.Equal(100m, order.Total);
+        Assert.True(paymentSuccess);
+        Assert.Contains(logger.GetLogs(), log => log.Contains("Creating customer", StringComparison.Ordinal));
+        Assert.Contains(logger.GetLogs(), log => log.Contains("Placing order", StringComparison.Ordinal));
+        Assert.Contains(logger.GetLogs(), log => log.Contains("Processing payment", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task QueryAndStreamHandlers_ReadFromRepositories()
+    {
+        var customers = new InMemoryCustomerRepository();
+        var orders = new InMemoryOrderRepository();
+        var products = new InMemoryProductRepository();
+        customers.Add(new Customer(1, "Ada", "ada@example.com", 1000m));
+        orders.Add(new Order(10, 1, [new OrderItem(1, "Mouse", 1, 25m)], 25m, OrderStatus.Pending));
+
+        var customer = await new GetCustomerHandler(customers).Handle(new GetCustomerQuery(1), default);
+        var customerOrders = await new GetOrdersByCustomerHandler(orders).Handle(new GetOrdersByCustomerQuery(1), default);
+        var productResults = new List<ProductSearchResult>();
+        await foreach (var product in new SearchProductsHandler(products).Handle(new SearchProductsQuery("o", 2), default))
+        {
+            productResults.Add(product);
+        }
+
+        Assert.NotNull(customer);
+        Assert.Equal("Ada", customer.Name);
+        Assert.Single(customerOrders);
+        Assert.Equal(2, productResults.Count);
+        Assert.All(productResults, product => Assert.Contains("o", product.Name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task NotificationHandlers_LogMessages()
+    {
+        var logger = new InMemoryLogger();
+
+        await new SendWelcomeEmailHandler(logger).Handle(new CustomerCreatedEvent(1, "Ada", "ada@example.com"), default);
+        await new UpdateCustomerStatsHandler(logger).Handle(new CustomerCreatedEvent(1, "Ada", "ada@example.com"), default);
+        await new NotifyInventoryHandler(logger).Handle(new OrderPlacedEvent(5, 1, 125m), default);
+        await new SendOrderConfirmationHandler(logger).Handle(new OrderPlacedEvent(5, 1, 125m), default);
+        await new RecordPaymentAuditHandler(logger).Handle(new PaymentProcessedEvent(5, 125m, true), default);
+
+        Assert.Equal(5, logger.GetLogs().Count);
+    }
+
+    [Fact]
+    public async Task PipelineBehaviors_InvokeNextAndLogCrossCuttingSteps()
+    {
+        var logger = new InMemoryLogger();
+        var request = new CreateCustomerCommand("Ada", "ada@example.com", 1000m);
+        var expected = new Customer(7, "Ada", "ada@example.com", 1000m);
+
+        var logged = await new LoggingBehavior<CreateCustomerCommand, Customer>(logger)
+            .Handle(request, default, () => ValueTask.FromResult(expected));
+        var validated = await new ValidationBehavior<CreateCustomerCommand, Customer>(logger)
+            .Handle(request, default, () => ValueTask.FromResult(expected));
+        var measured = await new PerformanceBehavior<CreateCustomerCommand, Customer>(logger)
+            .Handle(request, default, () => ValueTask.FromResult(expected));
+        var transacted = await new TransactionBehavior<CreateCustomerCommand, Customer>(logger)
+            .Handle(request, default, () => ValueTask.FromResult(expected));
+
+        Assert.Same(expected, logged);
+        Assert.Same(expected, validated);
+        Assert.Same(expected, measured);
+        Assert.Same(expected, transacted);
+        Assert.Contains(logger.GetLogs(), log => log.Contains("[Logging]", StringComparison.Ordinal));
+        Assert.Contains(logger.GetLogs(), log => log.Contains("[Validation]", StringComparison.Ordinal));
+        Assert.Contains(logger.GetLogs(), log => log.Contains("[Performance]", StringComparison.Ordinal));
+        Assert.Contains(logger.GetLogs(), log => log.Contains("[Transaction] Committing", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ServiceCollectionExtensions_RegisterGeneratedDispatcherAndHandlers()
+    {
+        var services = new ServiceCollection()
+            .AddSingleton<ILogger, InMemoryLogger>()
+            .AddSingleton<ICustomerRepository, InMemoryCustomerRepository>()
+            .AddSingleton<IOrderRepository, InMemoryOrderRepository>()
+            .AddSingleton<IProductRepository, InMemoryProductRepository>()
+            .AddSourceGeneratedMediator()
+            .AddHandlersFromAssembly(typeof(CreateCustomerHandler).Assembly)
+            .AddBehavior(typeof(LoggingBehavior<,>))
+            .AddBehavior<CreateCustomerCommand, Customer, LoggingBehavior<CreateCustomerCommand, Customer>>();
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<ProductionDispatcher>());
+        Assert.NotNull(provider.GetRequiredService<ICommandHandler<CreateCustomerCommand, Customer>>());
+        Assert.NotEmpty(provider.GetServices<INotificationHandler<CustomerCreatedEvent>>());
+        Assert.NotNull(provider.GetRequiredService<IStreamHandler<SearchProductsQuery, ProductSearchResult>>());
+        Assert.NotNull(provider.GetRequiredService<IPipelineBehavior<CreateCustomerCommand, Customer>>());
+    }
+}

--- a/test/PatternKit.Examples.Tests/ObserverGeneratorDemo/ObserverGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/ObserverGeneratorDemo/ObserverGeneratorDemoTests.cs
@@ -1,0 +1,98 @@
+using PatternKit.Examples.ObserverGeneratorDemo;
+
+namespace PatternKit.Examples.Tests.ObserverGeneratorDemo;
+
+public sealed class ObserverGeneratorDemoTests
+{
+    [Fact]
+    public void TemperatureChanged_PublishesToSubscribersInOrder()
+    {
+        var changed = new TemperatureChanged();
+        var received = new List<string>();
+
+        using var first = changed.Subscribe(reading => received.Add($"first:{reading.SensorId}:{reading.Celsius:F1}"));
+        using var second = changed.Subscribe(reading => received.Add($"second:{reading.SensorId}:{reading.Celsius:F1}"));
+
+        changed.Publish(new TemperatureReading("sensor-a", 21.5, DateTime.UtcNow));
+
+        Assert.Equal(["first:sensor-a:21.5", "second:sensor-a:21.5"], received);
+    }
+
+    [Fact]
+    public void TemperatureChanged_DisposedSubscription_IsNotInvoked()
+    {
+        var changed = new TemperatureChanged();
+        var count = 0;
+        var subscription = changed.Subscribe(_ => count++);
+
+        changed.Publish(new TemperatureReading("sensor-a", 20, DateTime.UtcNow));
+        subscription.Dispose();
+        changed.Publish(new TemperatureReading("sensor-a", 21, DateTime.UtcNow));
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void TemperatureAlertRaised_StopPolicy_DoesNotStopSubsequentGeneratedSubscribers()
+    {
+        var alertRaised = new TemperatureAlertRaised();
+        var handled = false;
+        using var failing = alertRaised.Subscribe(_ => throw new InvalidOperationException("halt"));
+        using var succeeding = alertRaised.Subscribe(_ => handled = true);
+
+        alertRaised.Publish(new TemperatureAlert("sensor-a", 30, 25));
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public async Task NotificationPublished_AwaitsAsyncSubscribers()
+    {
+        var published = new NotificationPublished();
+        var received = new List<string>();
+
+        using var _ = published.Subscribe(async notification =>
+        {
+            await Task.Yield();
+            received.Add(notification.RecipientId);
+        });
+
+        await published.PublishAsync(new Notification("user-1", "hello", 1));
+
+        Assert.Equal(["user-1"], received);
+    }
+
+    [Fact]
+    public void NotificationSent_ContinuesAfterSubscriberExceptions()
+    {
+        var sent = new NotificationSent();
+        var handled = false;
+        using var first = sent.Subscribe(_ => throw new InvalidOperationException("first"));
+        using var second = sent.Subscribe(_ => throw new ArgumentException("second"));
+        using var third = sent.Subscribe(_ => handled = true);
+
+        sent.Publish(new NotificationResult(true, "Email"));
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public async Task NotificationSystem_SendsThroughRegisteredAsyncHandlers()
+    {
+        var system = new NotificationSystem();
+        var results = new List<NotificationResult>();
+
+        using var resultSubscription = system.OnNotificationSent(results.Add);
+        using var pushSubscription = system.SubscribeAsync(async notification =>
+        {
+            var result = await system.SendPushAsync(notification);
+            system.ReportSent(result);
+        });
+
+        await system.SendAsync(new Notification("user-1", "hello", 1));
+
+        var result = Assert.Single(results);
+        Assert.True(result.Success);
+        Assert.Equal("Push", result.Channel);
+    }
+}

--- a/test/PatternKit.Examples.Tests/ProxyGeneratorDemo/ProxyGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/ProxyGeneratorDemo/ProxyGeneratorDemoTests.cs
@@ -1,0 +1,112 @@
+using PatternKit.Examples.ProxyGeneratorDemo;
+using PatternKit.Examples.ProxyGeneratorDemo.Interceptors;
+
+namespace PatternKit.Examples.Tests.ProxyGeneratorDemo;
+
+public sealed class ProxyGeneratorDemoTests
+{
+    [Fact]
+    public void RealPaymentService_StoresSuccessfulTransactions()
+    {
+        var service = new RealPaymentService();
+
+        var result = service.ProcessPayment(CreateRequest("cust-1", 42m));
+        var history = service.GetTransactionHistory("cust-1");
+
+        Assert.True(result.Success);
+        Assert.StartsWith("TXN-", result.TransactionId);
+        var transaction = Assert.Single(history);
+        Assert.Equal("cust-1", transaction.CustomerId);
+        Assert.Equal(42m, transaction.Amount);
+        Assert.Equal("USD", transaction.Currency);
+    }
+
+    [Fact]
+    public async Task RealPaymentService_AsyncPayment_StoresTransaction()
+    {
+        var service = new RealPaymentService();
+
+        var result = await service.ProcessPaymentAsync(CreateRequest("cust-async", 75m));
+
+        Assert.True(result.Success);
+        Assert.Contains("async", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(service.GetTransactionHistory("cust-async"));
+    }
+
+    [Fact]
+    public void GeneratedProxy_WithInterceptors_InvokesInnerService()
+    {
+        var timing = new TimingInterceptor();
+        var proxy = new PaymentServiceProxy(
+            new RealPaymentService(),
+            [timing, new LoggingInterceptor("Test")]);
+
+        var result = proxy.ProcessPayment(CreateRequest("cust-proxy", 100m));
+        var history = proxy.GetTransactionHistory("cust-proxy");
+
+        Assert.True(result.Success);
+        Assert.Single(history);
+        Assert.Contains(nameof(IPaymentService.ProcessPayment), timing.GetTimings().Keys);
+        Assert.Contains(nameof(IPaymentService.GetTransactionHistory), timing.GetTimings().Keys);
+    }
+
+    [Fact]
+    public void GeneratedProxy_WithAuthenticationInterceptor_RejectsInvalidToken()
+    {
+        var proxy = new PaymentServiceProxy(
+            new RealPaymentService(),
+            [new AuthenticationInterceptor(), new RetryInterceptor()]);
+
+        var request = new PaymentRequest
+        {
+            CustomerId = "cust-invalid",
+            Amount = 100m,
+            Currency = "USD",
+            Description = "invalid token",
+            AuthToken = "bad-token"
+        };
+
+        Assert.Throws<UnauthorizedAccessException>(() => proxy.ProcessPayment(request));
+    }
+
+    [Fact]
+    public async Task GeneratedProxy_AsyncInterceptors_InvokeInnerService()
+    {
+        var timing = new TimingInterceptor();
+        var proxy = new PaymentServiceProxy(
+            new RealPaymentService(),
+            [new AuthenticationInterceptor(), timing]);
+
+        var result = await proxy.ProcessPaymentAsync(CreateRequest("cust-proxy-async", 55m));
+
+        Assert.True(result.Success);
+        Assert.Contains(nameof(IPaymentService.ProcessPaymentAsync), timing.GetTimings().Keys);
+    }
+
+    [Fact]
+    public void CachingInterceptor_RecordsTransactionHistoryResults()
+    {
+        var cache = new CachingInterceptor();
+        var proxy = new PaymentServiceProxy(new RealPaymentService(), [cache]);
+
+        proxy.ProcessPayment(CreateRequest("cust-cache", 10m));
+        _ = proxy.GetTransactionHistory("cust-cache");
+
+        var stats = cache.GetStats();
+        Assert.Equal(1, stats.Count);
+        Assert.Equal(0, stats.Expired);
+
+        cache.ClearCache();
+        Assert.Equal(0, cache.GetStats().Count);
+    }
+
+    private static PaymentRequest CreateRequest(string customerId, decimal amount) =>
+        new()
+        {
+            CustomerId = customerId,
+            Amount = amount,
+            Currency = "USD",
+            Description = "test payment",
+            AuthToken = "valid-token-123"
+        };
+}

--- a/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
@@ -1,0 +1,495 @@
+using PatternKit.Generators.Adapter;
+using PatternKit.Generators.Bridge;
+using PatternKit.Generators.Chain;
+using PatternKit.Generators.Command;
+using PatternKit.Generators.Composite;
+using PatternKit.Generators.Composer;
+using PatternKit.Generators.Decorator;
+using PatternKit.Generators.Facade;
+using PatternKit.Generators.Flyweight;
+using PatternKit.Generators.Iterator;
+using PatternKit.Generators.Messaging;
+using PatternKit.Generators.Observer;
+using PatternKit.Generators.Prototype;
+using PatternKit.Generators.Proxy;
+using PatternKit.Generators.Singleton;
+using PatternKit.Generators.State;
+using PatternKit.Generators.Template;
+using PatternKit.Generators;
+
+namespace PatternKit.Generators.Tests;
+
+public sealed class AbstractionsAttributeCoverageTests
+{
+    private enum TestState
+    {
+        Draft,
+        Published
+    }
+
+    private enum TestTrigger
+    {
+        Publish
+    }
+
+    public static TheoryData<Type, AttributeTargets, bool, bool> AttributeUsageCases => new()
+    {
+        { typeof(GenerateAdapterAttribute), AttributeTargets.Class, true, false },
+        { typeof(AdapterMapAttribute), AttributeTargets.Method, false, false },
+        { typeof(BridgeImplementorAttribute), AttributeTargets.Interface | AttributeTargets.Class, false, false },
+        { typeof(BridgeAbstractionAttribute), AttributeTargets.Class, false, false },
+        { typeof(BridgeIgnoreAttribute), AttributeTargets.Method | AttributeTargets.Property, false, false },
+        { typeof(ChainAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(ChainHandlerAttribute), AttributeTargets.Method, false, false },
+        { typeof(ChainDefaultAttribute), AttributeTargets.Method, false, false },
+        { typeof(ChainTerminalAttribute), AttributeTargets.Method, false, false },
+        { typeof(CommandAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(CommandHandlerAttribute), AttributeTargets.Method, false, false },
+        { typeof(CommandHostAttribute), AttributeTargets.Class, false, false },
+        { typeof(CommandCaseAttribute), AttributeTargets.Method, false, false },
+        { typeof(CommandUndoAttribute), AttributeTargets.Method, false, false },
+        { typeof(CompositeComponentAttribute), AttributeTargets.Interface | AttributeTargets.Class, false, false },
+        { typeof(CompositeIgnoreAttribute), AttributeTargets.Property | AttributeTargets.Method, false, false },
+        { typeof(ComposerAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(ComposeStepAttribute), AttributeTargets.Method, false, false },
+        { typeof(ComposeTerminalAttribute), AttributeTargets.Method, false, false },
+        { typeof(ComposeIgnoreAttribute), AttributeTargets.Method, false, false },
+        { typeof(GenerateDecoratorAttribute), AttributeTargets.Interface | AttributeTargets.Class, false, false },
+        { typeof(DecoratorIgnoreAttribute), AttributeTargets.Method | AttributeTargets.Property, false, false },
+        { typeof(GenerateFacadeAttribute), AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, true, false },
+        { typeof(FacadeExposeAttribute), AttributeTargets.Method, false, false },
+        { typeof(FacadeMapAttribute), AttributeTargets.Method, false, false },
+        { typeof(FacadeIgnoreAttribute), AttributeTargets.Method | AttributeTargets.Property, false, false },
+        { typeof(FlyweightAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(FlyweightFactoryAttribute), AttributeTargets.Method, false, false },
+        { typeof(IteratorAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(IteratorStepAttribute), AttributeTargets.Method, false, false },
+        { typeof(TraversalIteratorAttribute), AttributeTargets.Class, false, false },
+        { typeof(DepthFirstAttribute), AttributeTargets.Method, false, false },
+        { typeof(BreadthFirstAttribute), AttributeTargets.Method, false, false },
+        { typeof(TraversalChildrenAttribute), AttributeTargets.Method, false, false },
+        { typeof(GenerateDispatcherAttribute), AttributeTargets.Assembly, false, true },
+        { typeof(ObserverAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(ObserverHubAttribute), AttributeTargets.Class, false, false },
+        { typeof(ObservedEventAttribute), AttributeTargets.Property, false, false },
+        { typeof(PrototypeAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(PrototypeIgnoreAttribute), AttributeTargets.Property | AttributeTargets.Field, false, false },
+        { typeof(PrototypeIncludeAttribute), AttributeTargets.Property | AttributeTargets.Field, false, false },
+        { typeof(PrototypeStrategyAttribute), AttributeTargets.Property | AttributeTargets.Field, false, false },
+        { typeof(GenerateProxyAttribute), AttributeTargets.Interface | AttributeTargets.Class, false, false },
+        { typeof(ProxyIgnoreAttribute), AttributeTargets.Method | AttributeTargets.Property, false, false },
+        { typeof(SingletonAttribute), AttributeTargets.Class, false, false },
+        { typeof(SingletonFactoryAttribute), AttributeTargets.Method, false, false },
+        { typeof(StateMachineAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(StateTransitionAttribute), AttributeTargets.Method, true, false },
+        { typeof(StateGuardAttribute), AttributeTargets.Method, true, false },
+        { typeof(StateEntryAttribute), AttributeTargets.Method, true, false },
+        { typeof(StateExitAttribute), AttributeTargets.Method, true, false },
+        { typeof(TemplateAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(TemplateStepAttribute), AttributeTargets.Method, false, false },
+        { typeof(TemplateHookAttribute), AttributeTargets.Method, false, false }
+    };
+
+    [Theory]
+    [MemberData(nameof(AttributeUsageCases))]
+    public void AttributeUsage_Is_Declared_As_Expected(
+        Type attributeType,
+        AttributeTargets validOn,
+        bool allowMultiple,
+        bool inherited)
+    {
+        var usage = Assert.Single(attributeType.GetCustomAttributes(typeof(AttributeUsageAttribute), false)
+            .Cast<AttributeUsageAttribute>());
+
+        Assert.Equal(validOn, usage.ValidOn);
+        Assert.Equal(allowMultiple, usage.AllowMultiple);
+        Assert.Equal(inherited, usage.Inherited);
+    }
+
+    [Fact]
+    public void Adapter_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var generator = new GenerateAdapterAttribute
+        {
+            Target = typeof(IDisposable),
+            Adaptee = typeof(string),
+            AdapterTypeName = "StringDisposableAdapter",
+            MissingMap = AdapterMissingMapPolicy.ThrowingStub,
+            Sealed = false,
+            Namespace = "Demo.Adapters"
+        };
+        var map = new AdapterMapAttribute { TargetMember = nameof(IDisposable.Dispose) };
+
+        Assert.Equal(typeof(IDisposable), generator.Target);
+        Assert.Equal(typeof(string), generator.Adaptee);
+        Assert.Equal("StringDisposableAdapter", generator.AdapterTypeName);
+        Assert.Equal(AdapterMissingMapPolicy.ThrowingStub, generator.MissingMap);
+        Assert.False(generator.Sealed);
+        Assert.Equal("Demo.Adapters", generator.Namespace);
+        Assert.Equal(nameof(IDisposable.Dispose), map.TargetMember);
+        AssertEnumValues(AdapterMissingMapPolicy.Error, AdapterMissingMapPolicy.ThrowingStub, AdapterMissingMapPolicy.Ignore);
+    }
+
+    [Fact]
+    public void Bridge_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var implementor = new BridgeImplementorAttribute { ImplementorTypeName = "StorageBackend" };
+        var abstraction = new BridgeAbstractionAttribute(typeof(IDisposable))
+        {
+            ImplementorPropertyName = "Backend",
+            GenerateDefault = true,
+            DefaultTypeName = "FileBackend"
+        };
+
+        Assert.Equal("StorageBackend", implementor.ImplementorTypeName);
+        Assert.Equal(typeof(IDisposable), abstraction.ImplementorType);
+        Assert.Equal("Backend", abstraction.ImplementorPropertyName);
+        Assert.True(abstraction.GenerateDefault);
+        Assert.Equal("FileBackend", abstraction.DefaultTypeName);
+        Assert.IsType<BridgeIgnoreAttribute>(new BridgeIgnoreAttribute());
+    }
+
+    [Fact]
+    public void Chain_And_Command_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var chain = new ChainAttribute
+        {
+            Model = ChainModel.Pipeline,
+            HandleMethodName = "Run",
+            TryHandleMethodName = "TryRun"
+        };
+        var handler = new ChainHandlerAttribute { Order = 7, Name = "Audit" };
+        var command = new CommandAttribute
+        {
+            CommandTypeName = "SubmitOrder",
+            GenerateAsync = false,
+            ForceAsync = true,
+            GenerateUndo = true
+        };
+        var commandHandler = new CommandHandlerAttribute { CommandType = typeof(string) };
+
+        Assert.Equal(ChainModel.Pipeline, chain.Model);
+        Assert.Equal("Run", chain.HandleMethodName);
+        Assert.Equal("TryRun", chain.TryHandleMethodName);
+        Assert.Equal(7, handler.Order);
+        Assert.Equal("Audit", handler.Name);
+        Assert.Equal("SubmitOrder", command.CommandTypeName);
+        Assert.False(command.GenerateAsync);
+        Assert.True(command.ForceAsync);
+        Assert.True(command.GenerateUndo);
+        Assert.Equal(typeof(string), commandHandler.CommandType);
+        Assert.IsType<ChainDefaultAttribute>(new ChainDefaultAttribute());
+        Assert.IsType<ChainTerminalAttribute>(new ChainTerminalAttribute());
+        Assert.IsType<CommandHostAttribute>(new CommandHostAttribute());
+        Assert.IsType<CommandCaseAttribute>(new CommandCaseAttribute());
+        Assert.IsType<CommandUndoAttribute>(new CommandUndoAttribute());
+        AssertEnumValues(ChainModel.Responsibility, ChainModel.Pipeline);
+    }
+
+    [Fact]
+    public void Composite_Composer_And_Decorator_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var composite = new CompositeComponentAttribute
+        {
+            ComponentBaseName = "NodeBase",
+            CompositeBaseName = "BranchBase",
+            ChildrenPropertyName = "Items",
+            Storage = CompositeChildrenStorage.ImmutableArray,
+            GenerateTraversalHelpers = true
+        };
+        var composer = new ComposerAttribute
+        {
+            InvokeMethodName = "Run",
+            InvokeAsyncMethodName = "RunAsync",
+            GenerateAsync = true,
+            ForceAsync = true,
+            WrapOrder = ComposerWrapOrder.InnerFirst
+        };
+        var step = new ComposeStepAttribute(12) { Name = "Validate" };
+        var decorator = new GenerateDecoratorAttribute
+        {
+            BaseTypeName = "StorageDecorator",
+            HelpersTypeName = "StorageDecorators",
+            Composition = DecoratorCompositionMode.PipelineNextStyle,
+            GenerateAsync = true,
+            ForceAsync = true
+        };
+
+        Assert.Equal("NodeBase", composite.ComponentBaseName);
+        Assert.Equal("BranchBase", composite.CompositeBaseName);
+        Assert.Equal("Items", composite.ChildrenPropertyName);
+        Assert.Equal(CompositeChildrenStorage.ImmutableArray, composite.Storage);
+        Assert.True(composite.GenerateTraversalHelpers);
+        Assert.Equal("Run", composer.InvokeMethodName);
+        Assert.Equal("RunAsync", composer.InvokeAsyncMethodName);
+        Assert.True(composer.GenerateAsync);
+        Assert.True(composer.ForceAsync);
+        Assert.Equal(ComposerWrapOrder.InnerFirst, composer.WrapOrder);
+        Assert.Equal(12, step.Order);
+        Assert.Equal("Validate", step.Name);
+        Assert.Equal("StorageDecorator", decorator.BaseTypeName);
+        Assert.Equal("StorageDecorators", decorator.HelpersTypeName);
+        Assert.Equal(DecoratorCompositionMode.PipelineNextStyle, decorator.Composition);
+        Assert.True(decorator.GenerateAsync);
+        Assert.True(decorator.ForceAsync);
+        Assert.IsType<CompositeIgnoreAttribute>(new CompositeIgnoreAttribute());
+        Assert.IsType<ComposeTerminalAttribute>(new ComposeTerminalAttribute());
+        Assert.IsType<ComposeIgnoreAttribute>(new ComposeIgnoreAttribute());
+        Assert.IsType<DecoratorIgnoreAttribute>(new DecoratorIgnoreAttribute());
+        AssertEnumValues(CompositeChildrenStorage.List, CompositeChildrenStorage.ImmutableArray);
+        AssertEnumValues(ComposerWrapOrder.OuterFirst, ComposerWrapOrder.InnerFirst);
+        AssertEnumValues(DecoratorCompositionMode.None, DecoratorCompositionMode.HelpersOnly, DecoratorCompositionMode.PipelineNextStyle);
+    }
+
+    [Fact]
+    public void Facade_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var facade = new GenerateFacadeAttribute
+        {
+            FacadeTypeName = "BillingFacade",
+            GenerateAsync = false,
+            ForceAsync = true,
+            MissingMap = FacadeMissingMapPolicy.Stub,
+            TargetTypeName = "Billing.Client",
+            Include = ["CreateInvoice"],
+            Exclude = ["DeleteInvoice"],
+            MemberPrefix = "Billing",
+            FieldName = "_billing"
+        };
+        var expose = new FacadeExposeAttribute { MethodName = "Checkout" };
+        var map = new FacadeMapAttribute { MemberName = "GetInvoice" };
+
+        Assert.Equal("BillingFacade", facade.FacadeTypeName);
+        Assert.False(facade.GenerateAsync);
+        Assert.True(facade.ForceAsync);
+        Assert.Equal(FacadeMissingMapPolicy.Stub, facade.MissingMap);
+        Assert.Equal("Billing.Client", facade.TargetTypeName);
+        Assert.Equal(["CreateInvoice"], facade.Include);
+        Assert.Equal(["DeleteInvoice"], facade.Exclude);
+        Assert.Equal("Billing", facade.MemberPrefix);
+        Assert.Equal("_billing", facade.FieldName);
+        Assert.Equal("Checkout", expose.MethodName);
+        Assert.Equal("GetInvoice", map.MemberName);
+        Assert.IsType<FacadeIgnoreAttribute>(new FacadeIgnoreAttribute());
+        AssertEnumValues(FacadeMissingMapPolicy.Error, FacadeMissingMapPolicy.Stub, FacadeMissingMapPolicy.Ignore);
+    }
+
+    [Fact]
+    public void Flyweight_Iterator_And_Messaging_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var flyweight = new FlyweightAttribute(typeof(string))
+        {
+            CacheTypeName = "SymbolCache",
+            Capacity = 128,
+            Eviction = FlyweightEviction.Lru,
+            Threading = FlyweightThreadingPolicy.Concurrent,
+            GenerateTryGet = false
+        };
+        var iterator = new IteratorAttribute
+        {
+            GenerateEnumerator = false,
+            GenerateTryMoveNext = false
+        };
+        var dispatcher = new GenerateDispatcherAttribute
+        {
+            Namespace = "Demo.Dispatching",
+            Name = "DemoDispatcher",
+            IncludeObjectOverloads = true,
+            IncludeStreaming = false,
+            Visibility = GeneratedVisibility.Internal
+        };
+
+        Assert.Equal(typeof(string), flyweight.KeyType);
+        Assert.Equal("SymbolCache", flyweight.CacheTypeName);
+        Assert.Equal(128, flyweight.Capacity);
+        Assert.Equal(FlyweightEviction.Lru, flyweight.Eviction);
+        Assert.Equal(FlyweightThreadingPolicy.Concurrent, flyweight.Threading);
+        Assert.False(flyweight.GenerateTryGet);
+        Assert.False(iterator.GenerateEnumerator);
+        Assert.False(iterator.GenerateTryMoveNext);
+        Assert.Equal("Demo.Dispatching", dispatcher.Namespace);
+        Assert.Equal("DemoDispatcher", dispatcher.Name);
+        Assert.True(dispatcher.IncludeObjectOverloads);
+        Assert.False(dispatcher.IncludeStreaming);
+        Assert.Equal(GeneratedVisibility.Internal, dispatcher.Visibility);
+        Assert.IsType<FlyweightFactoryAttribute>(new FlyweightFactoryAttribute());
+        Assert.IsType<IteratorStepAttribute>(new IteratorStepAttribute());
+        Assert.IsType<TraversalIteratorAttribute>(new TraversalIteratorAttribute());
+        Assert.IsType<DepthFirstAttribute>(new DepthFirstAttribute());
+        Assert.IsType<BreadthFirstAttribute>(new BreadthFirstAttribute());
+        Assert.IsType<TraversalChildrenAttribute>(new TraversalChildrenAttribute());
+        AssertEnumValues(FlyweightEviction.None, FlyweightEviction.Lru);
+        AssertEnumValues(FlyweightThreadingPolicy.SingleThreadedFast, FlyweightThreadingPolicy.Locking, FlyweightThreadingPolicy.Concurrent);
+        AssertEnumValues(GeneratedVisibility.Public, GeneratedVisibility.Internal);
+    }
+
+    [Fact]
+    public void Memento_Prototype_Observer_Proxy_And_Singleton_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var memento = new MementoAttribute
+        {
+            GenerateCaretaker = true,
+            Capacity = 10,
+            InclusionMode = MementoInclusionMode.ExplicitOnly,
+            SkipDuplicates = false
+        };
+        var mementoStrategy = new MementoStrategyAttribute(MementoCaptureStrategy.DeepCopy);
+        var prototype = new PrototypeAttribute
+        {
+            Mode = PrototypeMode.DeepWhenPossible,
+            CloneMethodName = "Copy",
+            IncludeExplicit = true
+        };
+        var prototypeStrategy = new PrototypeStrategyAttribute(PrototypeCloneStrategy.Clone);
+        var observer = new ObserverAttribute(typeof(string))
+        {
+            Threading = ObserverThreadingPolicy.Concurrent,
+            Exceptions = ObserverExceptionPolicy.Aggregate,
+            Order = ObserverOrderPolicy.Undefined,
+            GenerateAsync = false,
+            ForceAsync = true
+        };
+        var proxy = new GenerateProxyAttribute
+        {
+            ProxyTypeName = "BillingProxy",
+            InterceptorMode = ProxyInterceptorMode.Pipeline,
+            GenerateAsync = true,
+            ForceAsync = true,
+            Exceptions = ProxyExceptionPolicy.Swallow
+        };
+        var singleton = new SingletonAttribute
+        {
+            Mode = SingletonMode.Lazy,
+            Threading = SingletonThreading.SingleThreadedFast,
+            InstancePropertyName = "Current"
+        };
+
+        Assert.True(memento.GenerateCaretaker);
+        Assert.Equal(10, memento.Capacity);
+        Assert.Equal(MementoInclusionMode.ExplicitOnly, memento.InclusionMode);
+        Assert.False(memento.SkipDuplicates);
+        Assert.Equal(MementoCaptureStrategy.DeepCopy, mementoStrategy.Strategy);
+        Assert.Equal(PrototypeMode.DeepWhenPossible, prototype.Mode);
+        Assert.Equal("Copy", prototype.CloneMethodName);
+        Assert.True(prototype.IncludeExplicit);
+        Assert.Equal(PrototypeCloneStrategy.Clone, prototypeStrategy.Strategy);
+        Assert.Equal(typeof(string), observer.PayloadType);
+        Assert.Equal(ObserverThreadingPolicy.Concurrent, observer.Threading);
+        Assert.Equal(ObserverExceptionPolicy.Aggregate, observer.Exceptions);
+        Assert.Equal(ObserverOrderPolicy.Undefined, observer.Order);
+        Assert.False(observer.GenerateAsync);
+        Assert.True(observer.ForceAsync);
+        Assert.Equal("BillingProxy", proxy.ProxyTypeName);
+        Assert.Equal(ProxyInterceptorMode.Pipeline, proxy.InterceptorMode);
+        Assert.True(proxy.GenerateAsync);
+        Assert.True(proxy.ForceAsync);
+        Assert.Equal(ProxyExceptionPolicy.Swallow, proxy.Exceptions);
+        Assert.Equal(SingletonMode.Lazy, singleton.Mode);
+        Assert.Equal(SingletonThreading.SingleThreadedFast, singleton.Threading);
+        Assert.Equal("Current", singleton.InstancePropertyName);
+        Assert.IsType<MementoIgnoreAttribute>(new MementoIgnoreAttribute());
+        Assert.IsType<MementoIncludeAttribute>(new MementoIncludeAttribute());
+        Assert.IsType<ObserverHubAttribute>(new ObserverHubAttribute());
+        Assert.IsType<ObservedEventAttribute>(new ObservedEventAttribute());
+        Assert.IsType<PrototypeIgnoreAttribute>(new PrototypeIgnoreAttribute());
+        Assert.IsType<PrototypeIncludeAttribute>(new PrototypeIncludeAttribute());
+        Assert.IsType<ProxyIgnoreAttribute>(new ProxyIgnoreAttribute());
+        Assert.IsType<SingletonFactoryAttribute>(new SingletonFactoryAttribute());
+        AssertEnumValues(MementoInclusionMode.IncludeAll, MementoInclusionMode.ExplicitOnly);
+        AssertEnumValues(MementoCaptureStrategy.ByReference, MementoCaptureStrategy.Clone, MementoCaptureStrategy.DeepCopy, MementoCaptureStrategy.Custom);
+        AssertEnumValues(PrototypeMode.ShallowWithWarnings, PrototypeMode.Shallow, PrototypeMode.DeepWhenPossible);
+        AssertEnumValues(PrototypeCloneStrategy.ByReference, PrototypeCloneStrategy.ShallowCopy, PrototypeCloneStrategy.Clone, PrototypeCloneStrategy.DeepCopy, PrototypeCloneStrategy.Custom);
+        AssertEnumValues(ObserverThreadingPolicy.SingleThreadedFast, ObserverThreadingPolicy.Locking, ObserverThreadingPolicy.Concurrent);
+        AssertEnumValues(ObserverExceptionPolicy.Continue, ObserverExceptionPolicy.Stop, ObserverExceptionPolicy.Aggregate);
+        AssertEnumValues(ObserverOrderPolicy.RegistrationOrder, ObserverOrderPolicy.Undefined);
+        AssertEnumValues(ProxyInterceptorMode.None, ProxyInterceptorMode.Single, ProxyInterceptorMode.Pipeline);
+        AssertEnumValues(ProxyExceptionPolicy.Rethrow, ProxyExceptionPolicy.Swallow);
+        AssertEnumValues(SingletonMode.Eager, SingletonMode.Lazy);
+        AssertEnumValues(SingletonThreading.ThreadSafe, SingletonThreading.SingleThreadedFast);
+    }
+
+    [Fact]
+    public void State_And_Template_Attributes_Expose_Defaults_And_Configuration()
+    {
+        var stateMachine = new StateMachineAttribute(typeof(TestState), typeof(TestTrigger))
+        {
+            FireMethodName = "Apply",
+            FireAsyncMethodName = "ApplyAsync",
+            CanFireMethodName = "CanApply",
+            GenerateAsync = true,
+            ForceAsync = true,
+            InvalidTrigger = StateMachineInvalidTriggerPolicy.ReturnFalse,
+            GuardFailure = StateMachineGuardFailurePolicy.Ignore
+        };
+        var transition = new StateTransitionAttribute
+        {
+            From = TestState.Draft,
+            Trigger = TestTrigger.Publish,
+            To = TestState.Published
+        };
+        var guard = new StateGuardAttribute
+        {
+            From = TestState.Draft,
+            Trigger = TestTrigger.Publish
+        };
+        var entry = new StateEntryAttribute(TestState.Published);
+        var exit = new StateExitAttribute(TestState.Draft);
+        var template = new TemplateAttribute
+        {
+            ExecuteMethodName = "Run",
+            ExecuteAsyncMethodName = "RunAsync",
+            GenerateAsync = true,
+            ForceAsync = true,
+            ErrorPolicy = TemplateErrorPolicy.HandleAndContinue
+        };
+        var step = new TemplateStepAttribute(3)
+        {
+            Name = "Persist",
+            Optional = true
+        };
+        var hook = new TemplateHookAttribute(HookPoint.OnError)
+        {
+            StepOrder = 3
+        };
+
+        Assert.Equal(typeof(TestState), stateMachine.StateType);
+        Assert.Equal(typeof(TestTrigger), stateMachine.TriggerType);
+        Assert.Equal("Apply", stateMachine.FireMethodName);
+        Assert.Equal("ApplyAsync", stateMachine.FireAsyncMethodName);
+        Assert.Equal("CanApply", stateMachine.CanFireMethodName);
+        Assert.True(stateMachine.GenerateAsync);
+        Assert.True(stateMachine.ForceAsync);
+        Assert.Equal(StateMachineInvalidTriggerPolicy.ReturnFalse, stateMachine.InvalidTrigger);
+        Assert.Equal(StateMachineGuardFailurePolicy.Ignore, stateMachine.GuardFailure);
+        Assert.Equal(TestState.Draft, transition.From);
+        Assert.Equal(TestTrigger.Publish, transition.Trigger);
+        Assert.Equal(TestState.Published, transition.To);
+        Assert.Equal(TestState.Draft, guard.From);
+        Assert.Equal(TestTrigger.Publish, guard.Trigger);
+        Assert.Equal(TestState.Published, entry.State);
+        Assert.Equal(TestState.Draft, exit.State);
+        Assert.Equal("Run", template.ExecuteMethodName);
+        Assert.Equal("RunAsync", template.ExecuteAsyncMethodName);
+        Assert.True(template.GenerateAsync);
+        Assert.True(template.ForceAsync);
+        Assert.Equal(TemplateErrorPolicy.HandleAndContinue, template.ErrorPolicy);
+        Assert.Equal(3, step.Order);
+        Assert.Equal("Persist", step.Name);
+        Assert.True(step.Optional);
+        Assert.Equal(HookPoint.OnError, hook.HookPoint);
+        Assert.Equal(3, hook.StepOrder);
+        AssertEnumValues(StateMachineInvalidTriggerPolicy.Throw, StateMachineInvalidTriggerPolicy.Ignore, StateMachineInvalidTriggerPolicy.ReturnFalse);
+        AssertEnumValues(StateMachineGuardFailurePolicy.Throw, StateMachineGuardFailurePolicy.Ignore, StateMachineGuardFailurePolicy.ReturnFalse);
+        AssertEnumValues(HookPoint.BeforeAll, HookPoint.AfterAll, HookPoint.OnError);
+        AssertEnumValues(TemplateErrorPolicy.Rethrow, TemplateErrorPolicy.HandleAndContinue);
+    }
+
+    private static void AssertEnumValues<TEnum>(params TEnum[] values)
+        where TEnum : struct, Enum
+    {
+        foreach (var value in values)
+        {
+            Assert.True(Enum.IsDefined(value), $"{typeof(TEnum).Name}.{value} should be defined.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add broad coverage for PatternKit.Generators.Abstractions attributes and enum defaults
- add focused example tests for decorator, proxy, observer, messaging, visitor, state, and memento generated demos
- exercise generated example APIs directly so Codecov can cover currently low or uncovered folders

## Validation
- dotnet build src/PatternKit.Generators.Abstractions/PatternKit.Generators.Abstractions.csproj --no-restore
- git diff --check

Local examples tests are blocked by the existing SDK/analyzer mismatch: the local compiler is Microsoft.CodeAnalysis 5.0 while the generator assembly references 5.3, so generated example types are unavailable locally. CI is the authoritative validation for the examples project.