### PR TITLE
feat: add message envelope primitives

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -139,6 +139,12 @@ If you’re looking for end-to-end, production-shaped demos, check the **Example
 
 ## Additional Patterns
 
+- **[Messaging](messaging/README.md)**
+  In-process messaging primitives and source-generated dispatchers for application flows that are not durable broker responsibilities.
+
+- **[Message Envelope and Context](messaging/message-envelope.md)**
+  Immutable payload envelopes, headers, and execution context for enterprise integration patterns.
+
 - **[TypeDispatcher](behavioral/type-dispatcher/index.md)**
   Type-safe runtime dispatch that routes objects to handlers based on their concrete type.
 

--- a/docs/patterns/messaging/README.md
+++ b/docs/patterns/messaging/README.md
@@ -1,6 +1,12 @@
 # Messaging Patterns
 
-This section covers messaging and event-driven patterns in PatternKit, with a focus on the **Mediator pattern**.
+This section covers messaging and event-driven patterns in PatternKit.
+
+## Message Envelope and Context
+
+`Message<TPayload>`, `MessageHeaders`, and `MessageContext` provide shared in-process metadata for enterprise integration patterns. They carry correlation IDs, causation IDs, idempotency keys, content types, reply addresses, timestamps, cancellation, and execution-scoped items without pretending to be a broker or durable queue.
+
+[Learn More](message-envelope.md)
 
 ## Mediator (Source Generated)
 
@@ -57,6 +63,7 @@ var result = await dispatcher.Send<CreateUser, UserCreated>(
 
 The Source-Generated Mediator complements other PatternKit patterns:
 
+- **[Message Envelope and Context](message-envelope.md)** - Shared metadata for routers, routing slips, sagas, mailboxes, and idempotent receivers
 - **[Runtime Mediator](../behavioral/mediator/index.md)** - Pre-built mediator with PatternKit runtime (use for application code)
 - **Observer** - For reactive event handling and pub/sub
 - **Command** - For encapsulating requests as objects

--- a/docs/patterns/messaging/message-envelope.md
+++ b/docs/patterns/messaging/message-envelope.md
@@ -1,0 +1,117 @@
+# Message Envelope and Context
+
+`Message<TPayload>` is a small immutable envelope for in-process messaging patterns. It carries a payload plus `MessageHeaders`, so routing, sagas, mailboxes, and idempotent receivers can share correlation and delivery metadata without taking a dependency on a broker.
+
+Use it when you need consistent metadata across composed PatternKit patterns:
+
+- correlation and causation IDs
+- message IDs and idempotency keys
+- content type and reply address
+- execution-scoped context items for diagnostics or routing decisions
+
+Use a durable queue, broker, or database when you need cross-process delivery, persistence, retries after process restart, or transactional outbox guarantees.
+
+## Basic Usage
+
+```csharp
+using PatternKit.Messaging;
+
+var message = Message<string>
+    .Create("order-created")
+    .WithMessageId("msg-100")
+    .WithCorrelationId("order-42")
+    .WithCausationId("checkout-7")
+    .WithIdempotencyKey("order-42:created")
+    .WithContentType("text/plain");
+
+Console.WriteLine(message.Headers.CorrelationId); // order-42
+```
+
+Every enrichment call returns a new message or header collection. The original remains unchanged.
+
+```csharp
+var original = Message<string>.Create("payload");
+var enriched = original.WithCorrelationId("corr-1");
+
+Console.WriteLine(original.Headers.CorrelationId is null); // True
+Console.WriteLine(enriched.Headers.CorrelationId);         // corr-1
+```
+
+## Headers
+
+`MessageHeaders` is an immutable, case-insensitive header collection. Well-known names live in `MessageHeaderNames`.
+
+```csharp
+var headers = MessageHeaders.Empty
+    .With(MessageHeaderNames.CorrelationId, "corr-1")
+    .With("tenant", "north");
+
+if (headers.TryGet<string>("tenant", out var tenant))
+{
+    Console.WriteLine(tenant);
+}
+```
+
+Well-known helpers validate required string values:
+
+```csharp
+var headers = MessageHeaders.Empty
+    .WithMessageId("msg-1")
+    .WithCorrelationId("corr-1")
+    .WithIdempotencyKey("idem-1")
+    .WithReplyTo("queue:reply");
+```
+
+Typed readers cover common integration metadata:
+
+```csharp
+var id = Guid.NewGuid();
+var timestamp = DateTimeOffset.UtcNow;
+
+var headers = MessageHeaders.Empty
+    .With("operation-id", id.ToString("D"))
+    .WithTimestamp(timestamp);
+
+headers.TryGetGuid("operation-id", out var operationId);
+var acceptedAt = headers.Timestamp;
+```
+
+## Context
+
+`MessageContext` carries headers, cancellation, and execution-scoped items through a routing operation. Items are intentionally separate from headers: headers describe the message, while items describe the current in-process execution.
+
+```csharp
+using var cts = new CancellationTokenSource();
+
+var context = MessageContext
+    .From(message, cts.Token)
+    .WithItem("attempt", 1)
+    .WithHeader("route", "billing");
+
+if (context.TryGetItem<int>("attempt", out var attempt))
+{
+    Console.WriteLine(attempt);
+}
+```
+
+## Relationship To Other Patterns
+
+`Message<TPayload>` and `MessageContext` are not a replacement for a mediator, observer, or broker. They are shared metadata primitives for higher-level patterns:
+
+- content-based routers can inspect headers and payloads
+- routing slips can update itinerary headers
+- sagas can correlate events by `CorrelationId`
+- mailboxes can process envelopes sequentially
+- idempotent receivers can use `IdempotencyKey`
+
+## API
+
+- <xref:PatternKit.Messaging.Message`1>
+- <xref:PatternKit.Messaging.MessageHeaders>
+- <xref:PatternKit.Messaging.MessageContext>
+- <xref:PatternKit.Messaging.MessageHeaderNames>
+
+## Example Source
+
+- `src/PatternKit.Examples/Messaging/MessageEnvelopeExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/MessageEnvelopeExampleTests.cs`

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -292,6 +292,13 @@
 
 - name: Additional Patterns
   items:
+    - name: Messaging
+      href: messaging/README.md
+      items:
+        - name: Message Envelope and Context
+          href: messaging/message-envelope.md
+        - name: Source-Generated Dispatcher
+          href: messaging/dispatcher.md
     - name: Type-Dispatcher
       href: behavioral/type-dispatcher/index.md
       items:

--- a/src/PatternKit.Core/Messaging/Message.cs
+++ b/src/PatternKit.Core/Messaging/Message.cs
@@ -1,0 +1,80 @@
+namespace PatternKit.Messaging;
+
+/// <summary>
+/// Immutable message envelope that pairs a payload with metadata headers.
+/// </summary>
+/// <typeparam name="TPayload">The payload type carried by the message.</typeparam>
+public sealed class Message<TPayload>
+{
+    /// <summary>
+    /// Creates a message envelope.
+    /// </summary>
+    /// <param name="payload">The payload carried by the message.</param>
+    /// <param name="headers">The message metadata. When omitted, <see cref="MessageHeaders.Empty"/> is used.</param>
+    public Message(TPayload payload, MessageHeaders? headers = null)
+    {
+        Payload = payload;
+        Headers = headers ?? MessageHeaders.Empty;
+    }
+
+    /// <summary>The payload carried by the message.</summary>
+    public TPayload Payload { get; }
+
+    /// <summary>The immutable metadata associated with the message.</summary>
+    public MessageHeaders Headers { get; }
+
+    /// <summary>
+    /// Creates a message envelope with no custom headers.
+    /// </summary>
+    public static Message<TPayload> Create(TPayload payload) => new(payload);
+
+    /// <summary>
+    /// Returns a new message with a different payload and the same headers.
+    /// </summary>
+    public Message<TNewPayload> WithPayload<TNewPayload>(TNewPayload payload) => new(payload, Headers);
+
+    /// <summary>
+    /// Returns a new message with the supplied headers.
+    /// </summary>
+    public Message<TPayload> WithHeaders(MessageHeaders headers)
+    {
+        if (headers is null)
+            throw new ArgumentNullException(nameof(headers));
+
+        return new Message<TPayload>(Payload, headers);
+    }
+
+    /// <summary>
+    /// Returns a new message after applying <paramref name="configure"/> to the existing headers.
+    /// </summary>
+    public Message<TPayload> Enrich(Func<MessageHeaders, MessageHeaders> configure)
+    {
+        if (configure is null)
+            throw new ArgumentNullException(nameof(configure));
+
+        return WithHeaders(configure(Headers) ?? throw new InvalidOperationException("Header enrichment returned null."));
+    }
+
+    /// <summary>
+    /// Returns a new message with a header value set.
+    /// </summary>
+    public Message<TPayload> WithHeader(string name, object? value) => WithHeaders(Headers.With(name, value));
+
+    /// <summary>Returns a new message with the message identifier header set.</summary>
+    public Message<TPayload> WithMessageId(string messageId) => WithHeaders(Headers.WithMessageId(messageId));
+
+    /// <summary>Returns a new message with the correlation identifier header set.</summary>
+    public Message<TPayload> WithCorrelationId(string correlationId) => WithHeaders(Headers.WithCorrelationId(correlationId));
+
+    /// <summary>Returns a new message with the causation identifier header set.</summary>
+    public Message<TPayload> WithCausationId(string causationId) => WithHeaders(Headers.WithCausationId(causationId));
+
+    /// <summary>Returns a new message with the idempotency key header set.</summary>
+    public Message<TPayload> WithIdempotencyKey(string idempotencyKey) => WithHeaders(Headers.WithIdempotencyKey(idempotencyKey));
+
+    /// <summary>Returns a new message with the content type header set.</summary>
+    public Message<TPayload> WithContentType(string contentType) => WithHeaders(Headers.WithContentType(contentType));
+
+    /// <summary>Returns a new message with the reply address header set.</summary>
+    public Message<TPayload> WithReplyTo(string replyTo) => WithHeaders(Headers.WithReplyTo(replyTo));
+}

--- a/src/PatternKit.Core/Messaging/MessageContext.cs
+++ b/src/PatternKit.Core/Messaging/MessageContext.cs
@@ -1,0 +1,126 @@
+using System.Collections.ObjectModel;
+
+namespace PatternKit.Messaging;
+
+/// <summary>
+/// Immutable per-execution context for message routing, diagnostics, and pattern composition.
+/// </summary>
+public sealed class MessageContext
+{
+    private static readonly StringComparer ItemComparer = StringComparer.Ordinal;
+    private readonly Dictionary<string, object?> _items;
+
+    /// <summary>An empty message context.</summary>
+    public static MessageContext Empty { get; } = new(MessageHeaders.Empty, new Dictionary<string, object?>(ItemComparer), cloneItems: false);
+
+    /// <summary>
+    /// Creates a new message context.
+    /// </summary>
+    /// <param name="headers">Headers available to the current execution.</param>
+    /// <param name="cancellationToken">Cancellation token for async message processing.</param>
+    public MessageContext(MessageHeaders? headers = null, CancellationToken cancellationToken = default)
+        : this(headers ?? MessageHeaders.Empty, new Dictionary<string, object?>(ItemComparer), cancellationToken, cloneItems: false)
+    {
+    }
+
+    private MessageContext(
+        MessageHeaders headers,
+        Dictionary<string, object?> items,
+        CancellationToken cancellationToken = default,
+        bool cloneItems = true)
+    {
+        Headers = headers ?? throw new ArgumentNullException(nameof(headers));
+        _items = cloneItems ? new Dictionary<string, object?>(items, ItemComparer) : items;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>Headers available to the current execution.</summary>
+    public MessageHeaders Headers { get; }
+
+    /// <summary>Cancellation token for async message processing.</summary>
+    public CancellationToken CancellationToken { get; }
+
+    /// <summary>Scoped execution items for diagnostics and pattern composition.</summary>
+    public IReadOnlyDictionary<string, object?> Items => new ReadOnlyDictionary<string, object?>(_items);
+
+    /// <summary>
+    /// Creates a context from a message, copying the message headers.
+    /// </summary>
+    public static MessageContext From<TPayload>(Message<TPayload> message, CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        return new MessageContext(message.Headers, cancellationToken);
+    }
+
+    /// <summary>
+    /// Returns a new context with the supplied headers.
+    /// </summary>
+    public MessageContext WithHeaders(MessageHeaders headers)
+    {
+        if (headers is null)
+            throw new ArgumentNullException(nameof(headers));
+
+        return new MessageContext(headers, _items, CancellationToken);
+    }
+
+    /// <summary>
+    /// Returns a new context with a header value set.
+    /// </summary>
+    public MessageContext WithHeader(string name, object? value) => WithHeaders(Headers.With(name, value));
+
+    /// <summary>
+    /// Returns a new context with the supplied cancellation token.
+    /// </summary>
+    public MessageContext WithCancellation(CancellationToken cancellationToken) => new(Headers, _items, cancellationToken);
+
+    /// <summary>
+    /// Returns a new context with an execution item set.
+    /// </summary>
+    public MessageContext WithItem(string key, object? value)
+    {
+        ValidateItemKey(key);
+        var copy = new Dictionary<string, object?>(_items, ItemComparer)
+        {
+            [key] = value
+        };
+
+        return new MessageContext(Headers, copy, CancellationToken, cloneItems: false);
+    }
+
+    /// <summary>
+    /// Returns a new context without an execution item.
+    /// </summary>
+    public MessageContext WithoutItem(string key)
+    {
+        ValidateItemKey(key);
+        if (!_items.ContainsKey(key))
+            return this;
+
+        var copy = new Dictionary<string, object?>(_items, ItemComparer);
+        copy.Remove(key);
+        return new MessageContext(Headers, copy, CancellationToken, cloneItems: false);
+    }
+
+    /// <summary>
+    /// Attempts to read an execution item as <typeparamref name="T"/>.
+    /// </summary>
+    public bool TryGetItem<T>(string key, out T? value)
+    {
+        if (_items.TryGetValue(key, out var raw) && raw is T typed)
+        {
+            value = typed;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static void ValidateItemKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Item key cannot be null, empty, or whitespace.", nameof(key));
+    }
+}

--- a/src/PatternKit.Core/Messaging/MessageHeaderNames.cs
+++ b/src/PatternKit.Core/Messaging/MessageHeaderNames.cs
@@ -1,0 +1,28 @@
+namespace PatternKit.Messaging;
+
+/// <summary>
+/// Well-known header names used by PatternKit messaging and enterprise integration patterns.
+/// </summary>
+public static class MessageHeaderNames
+{
+    /// <summary>Unique identifier for the message envelope.</summary>
+    public const string MessageId = "message-id";
+
+    /// <summary>Identifier shared by messages that belong to the same logical flow.</summary>
+    public const string CorrelationId = "correlation-id";
+
+    /// <summary>Identifier of the message or operation that caused this message.</summary>
+    public const string CausationId = "causation-id";
+
+    /// <summary>Stable key used by idempotent receivers to detect duplicates.</summary>
+    public const string IdempotencyKey = "idempotency-key";
+
+    /// <summary>Payload content type, such as <c>application/json</c>.</summary>
+    public const string ContentType = "content-type";
+
+    /// <summary>Logical reply address for request/reply workflows.</summary>
+    public const string ReplyTo = "reply-to";
+
+    /// <summary>Timestamp recorded when the message was created or accepted.</summary>
+    public const string Timestamp = "timestamp";
+}

--- a/src/PatternKit.Core/Messaging/MessageHeaders.cs
+++ b/src/PatternKit.Core/Messaging/MessageHeaders.cs
@@ -1,0 +1,240 @@
+using System.Collections;
+
+namespace PatternKit.Messaging;
+
+/// <summary>
+/// Immutable message metadata for in-process messaging and enterprise integration patterns.
+/// </summary>
+/// <remarks>
+/// Header names are compared with <see cref="StringComparer.OrdinalIgnoreCase"/> so transport-style
+/// names such as <c>Correlation-Id</c> and <c>correlation-id</c> resolve to the same value.
+/// </remarks>
+public sealed class MessageHeaders : IReadOnlyDictionary<string, object?>
+{
+    private static readonly StringComparer HeaderComparer = StringComparer.OrdinalIgnoreCase;
+    private readonly Dictionary<string, object?> _values;
+
+    /// <summary>An empty immutable header collection.</summary>
+    public static MessageHeaders Empty { get; } = new();
+
+    /// <summary>
+    /// Creates an empty header collection.
+    /// </summary>
+    public MessageHeaders()
+        : this(new Dictionary<string, object?>(HeaderComparer), clone: false)
+    {
+    }
+
+    /// <summary>
+    /// Creates a header collection from existing values.
+    /// </summary>
+    /// <param name="values">The values to copy into the immutable collection.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when a header name is null, empty, or whitespace.</exception>
+    public MessageHeaders(IEnumerable<KeyValuePair<string, object?>> values)
+        : this(CopyFrom(values), clone: false)
+    {
+    }
+
+    private MessageHeaders(Dictionary<string, object?> values, bool clone)
+    {
+        _values = clone ? CopyFrom(values) : values;
+    }
+
+    /// <inheritdoc />
+    public int Count => _values.Count;
+
+    /// <inheritdoc />
+    public IEnumerable<string> Keys => _values.Keys;
+
+    /// <inheritdoc />
+    public IEnumerable<object?> Values => _values.Values;
+
+    /// <inheritdoc />
+    public object? this[string key] => _values[key];
+
+    /// <summary>Gets the well-known message identifier header when present.</summary>
+    public string? MessageId => GetString(MessageHeaderNames.MessageId);
+
+    /// <summary>Gets the well-known correlation identifier header when present.</summary>
+    public string? CorrelationId => GetString(MessageHeaderNames.CorrelationId);
+
+    /// <summary>Gets the well-known causation identifier header when present.</summary>
+    public string? CausationId => GetString(MessageHeaderNames.CausationId);
+
+    /// <summary>Gets the well-known idempotency key header when present.</summary>
+    public string? IdempotencyKey => GetString(MessageHeaderNames.IdempotencyKey);
+
+    /// <summary>Gets the well-known content type header when present.</summary>
+    public string? ContentType => GetString(MessageHeaderNames.ContentType);
+
+    /// <summary>Gets the well-known reply address header when present.</summary>
+    public string? ReplyTo => GetString(MessageHeaderNames.ReplyTo);
+
+    /// <summary>Gets the well-known timestamp header when present and parseable.</summary>
+    public DateTimeOffset? Timestamp => TryGetDateTimeOffset(MessageHeaderNames.Timestamp, out var timestamp) ? timestamp : null;
+
+    /// <summary>
+    /// Returns a new header collection with <paramref name="name"/> set to <paramref name="value"/>.
+    /// </summary>
+    public MessageHeaders With(string name, object? value)
+    {
+        ValidateName(name);
+        var copy = new Dictionary<string, object?>(_values, HeaderComparer)
+        {
+            [name] = value
+        };
+
+        return new MessageHeaders(copy, clone: false);
+    }
+
+    /// <summary>
+    /// Returns a new header collection without <paramref name="name"/>.
+    /// </summary>
+    public MessageHeaders Without(string name)
+    {
+        ValidateName(name);
+        if (!_values.ContainsKey(name))
+            return this;
+
+        var copy = new Dictionary<string, object?>(_values, HeaderComparer);
+        copy.Remove(name);
+        return copy.Count == 0 ? Empty : new MessageHeaders(copy, clone: false);
+    }
+
+    /// <summary>Returns a new collection with <see cref="MessageHeaderNames.MessageId"/> set.</summary>
+    public MessageHeaders WithMessageId(string messageId) => WithRequiredString(MessageHeaderNames.MessageId, messageId);
+
+    /// <summary>Returns a new collection with <see cref="MessageHeaderNames.CorrelationId"/> set.</summary>
+    public MessageHeaders WithCorrelationId(string correlationId) => WithRequiredString(MessageHeaderNames.CorrelationId, correlationId);
+
+    /// <summary>Returns a new collection with <see cref="MessageHeaderNames.CausationId"/> set.</summary>
+    public MessageHeaders WithCausationId(string causationId) => WithRequiredString(MessageHeaderNames.CausationId, causationId);
+
+    /// <summary>Returns a new collection with <see cref="MessageHeaderNames.IdempotencyKey"/> set.</summary>
+    public MessageHeaders WithIdempotencyKey(string idempotencyKey) => WithRequiredString(MessageHeaderNames.IdempotencyKey, idempotencyKey);
+
+    /// <summary>Returns a new collection with <see cref="MessageHeaderNames.ContentType"/> set.</summary>
+    public MessageHeaders WithContentType(string contentType) => WithRequiredString(MessageHeaderNames.ContentType, contentType);
+
+    /// <summary>Returns a new collection with <see cref="MessageHeaderNames.ReplyTo"/> set.</summary>
+    public MessageHeaders WithReplyTo(string replyTo) => WithRequiredString(MessageHeaderNames.ReplyTo, replyTo);
+
+    /// <summary>Returns a new collection with <see cref="MessageHeaderNames.Timestamp"/> set.</summary>
+    public MessageHeaders WithTimestamp(DateTimeOffset timestamp) => With(MessageHeaderNames.Timestamp, timestamp);
+
+    /// <inheritdoc />
+    public bool ContainsKey(string key) => _values.ContainsKey(key);
+
+    /// <inheritdoc />
+    public bool TryGetValue(string key, out object? value) => _values.TryGetValue(key, out value);
+
+    /// <summary>
+    /// Attempts to read a header as <typeparamref name="T"/>.
+    /// </summary>
+    public bool TryGet<T>(string name, out T? value)
+    {
+        if (_values.TryGetValue(name, out var raw) && raw is T typed)
+        {
+            value = typed;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets a string header value when present. Non-string values are converted with <see cref="object.ToString"/>.
+    /// </summary>
+    public string? GetString(string name)
+    {
+        if (!_values.TryGetValue(name, out var value) || value is null)
+            return null;
+
+        return value as string ?? value.ToString();
+    }
+
+    /// <summary>
+    /// Attempts to read a header as a <see cref="Guid"/> or parse a string header as a <see cref="Guid"/>.
+    /// </summary>
+    public bool TryGetGuid(string name, out Guid value)
+    {
+        if (_values.TryGetValue(name, out var raw))
+        {
+            if (raw is Guid guid)
+            {
+                value = guid;
+                return true;
+            }
+
+            if (raw is string text && Guid.TryParse(text, out value))
+                return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to read a header as a <see cref="DateTimeOffset"/> or parse a string header.
+    /// </summary>
+    public bool TryGetDateTimeOffset(string name, out DateTimeOffset value)
+    {
+        if (_values.TryGetValue(name, out var raw))
+        {
+            if (raw is DateTimeOffset dto)
+            {
+                value = dto;
+                return true;
+            }
+
+            if (raw is DateTime dateTime)
+            {
+                value = new DateTimeOffset(dateTime);
+                return true;
+            }
+
+            if (raw is string text && DateTimeOffset.TryParse(text, out value))
+                return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => _values.GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private MessageHeaders WithRequiredString(string name, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Header value cannot be null, empty, or whitespace.", nameof(value));
+
+        return With(name, value);
+    }
+
+    private static Dictionary<string, object?> CopyFrom(IEnumerable<KeyValuePair<string, object?>> values)
+    {
+        if (values is null)
+            throw new ArgumentNullException(nameof(values));
+
+        var copy = new Dictionary<string, object?>(HeaderComparer);
+        foreach (var pair in values)
+        {
+            ValidateName(pair.Key);
+            copy[pair.Key] = pair.Value;
+        }
+
+        return copy.Count == 0 ? new Dictionary<string, object?>(HeaderComparer) : copy;
+    }
+
+    private static void ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Header name cannot be null, empty, or whitespace.", nameof(name));
+    }
+}

--- a/src/PatternKit.Examples/Messaging/MessageEnvelopeExample.cs
+++ b/src/PatternKit.Examples/Messaging/MessageEnvelopeExample.cs
@@ -1,0 +1,54 @@
+using PatternKit.Messaging;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Demonstrates immutable message enrichment and execution context metadata.
+/// </summary>
+public static class MessageEnvelopeExample
+{
+    /// <summary>
+    /// Builds an enriched message and context, returning the metadata needed by tests and docs.
+    /// </summary>
+    public static Summary Run()
+    {
+        var message = Message<OrderAccepted>
+            .Create(new OrderAccepted("order-42", 199.95m))
+            .WithMessageId("msg-100")
+            .WithCorrelationId("order-42")
+            .WithCausationId("checkout-7")
+            .WithIdempotencyKey("order-42:accepted")
+            .WithContentType("application/vnd.patternkit.order+json");
+
+        var context = MessageContext
+            .From(message)
+            .WithHeader("route", "billing")
+            .WithItem("attempt", 1);
+
+        context.TryGetItem<int>("attempt", out var attempt);
+
+        return new Summary(
+            message.Payload.OrderId,
+            message.Headers.MessageId!,
+            message.Headers.CorrelationId!,
+            message.Headers.CausationId!,
+            message.Headers.IdempotencyKey!,
+            message.Headers.ContentType!,
+            context.Headers.GetString("route")!,
+            attempt);
+    }
+}
+
+/// <summary>Example payload for the message envelope demo.</summary>
+public sealed record OrderAccepted(string OrderId, decimal Total);
+
+/// <summary>Example output for the message envelope demo.</summary>
+public sealed record Summary(
+    string OrderId,
+    string MessageId,
+    string CorrelationId,
+    string CausationId,
+    string IdempotencyKey,
+    string ContentType,
+    string Route,
+    int Attempt);

--- a/test/PatternKit.Examples.Tests/Messaging/MessageEnvelopeExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/MessageEnvelopeExampleTests.cs
@@ -1,0 +1,21 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class MessageEnvelopeExampleTests
+{
+    [Fact]
+    public void Run_ReturnsExpectedEnvelopeAndContextMetadata()
+    {
+        var summary = MessageEnvelopeExample.Run();
+
+        Assert.Equal("order-42", summary.OrderId);
+        Assert.Equal("msg-100", summary.MessageId);
+        Assert.Equal("order-42", summary.CorrelationId);
+        Assert.Equal("checkout-7", summary.CausationId);
+        Assert.Equal("order-42:accepted", summary.IdempotencyKey);
+        Assert.Equal("application/vnd.patternkit.order+json", summary.ContentType);
+        Assert.Equal("billing", summary.Route);
+        Assert.Equal(1, summary.Attempt);
+    }
+}

--- a/test/PatternKit.Tests/Messaging/MessageContextTests.cs
+++ b/test/PatternKit.Tests/Messaging/MessageContextTests.cs
@@ -1,0 +1,147 @@
+using PatternKit.Messaging;
+
+namespace PatternKit.Tests.Messaging;
+
+public sealed class MessageContextTests
+{
+    [Fact]
+    public void Empty_HasEmptyHeadersAndItems()
+    {
+        Assert.Same(MessageHeaders.Empty, MessageContext.Empty.Headers);
+        Assert.Empty(MessageContext.Empty.Items);
+    }
+
+    [Fact]
+    public void From_CopiesMessageHeaders()
+    {
+        var message = Message<string>.Create("hello").WithCorrelationId("corr-1");
+        var context = MessageContext.From(message);
+
+        Assert.Same(message.Headers, context.Headers);
+        Assert.Equal("corr-1", context.Headers.CorrelationId);
+    }
+
+    [Fact]
+    public void From_RejectsNullMessage()
+    {
+        Assert.Throws<ArgumentNullException>(() => MessageContext.From<string>(null!));
+    }
+
+    [Fact]
+    public void Constructor_AcceptsHeadersAndCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var headers = MessageHeaders.Empty.WithCorrelationId("corr-1");
+
+        var context = new MessageContext(headers, cts.Token);
+
+        Assert.Same(headers, context.Headers);
+        Assert.Equal(cts.Token, context.CancellationToken);
+    }
+
+    [Fact]
+    public void WithHeader_ReturnsNewContext_WithoutMutatingOriginal()
+    {
+        var original = MessageContext.Empty;
+        var updated = original.WithHeader("tenant", "north");
+
+        Assert.False(original.Headers.ContainsKey("tenant"));
+        Assert.Equal("north", updated.Headers.GetString("tenant"));
+    }
+
+    [Fact]
+    public void WithHeaders_ReplacesHeaders()
+    {
+        var headers = MessageHeaders.Empty.WithCorrelationId("corr-1");
+        var context = MessageContext.Empty.WithHeaders(headers);
+
+        Assert.Same(headers, context.Headers);
+    }
+
+    [Fact]
+    public void WithHeaders_RejectsNullHeaders()
+    {
+        Assert.Throws<ArgumentNullException>(() => MessageContext.Empty.WithHeaders(null!));
+    }
+
+    [Fact]
+    public void WithItem_ReturnsNewContext_WithoutMutatingOriginal()
+    {
+        var original = MessageContext.Empty;
+        var updated = original.WithItem("attempt", 2);
+
+        Assert.Empty(original.Items);
+        Assert.True(updated.TryGetItem<int>("attempt", out var attempt));
+        Assert.Equal(2, attempt);
+    }
+
+    [Fact]
+    public void WithoutItem_RemovesItem_WithoutMutatingOriginal()
+    {
+        var original = MessageContext.Empty.WithItem("attempt", 2);
+        var updated = original.WithoutItem("attempt");
+
+        Assert.True(original.TryGetItem<int>("attempt", out _));
+        Assert.False(updated.TryGetItem<int>("attempt", out _));
+    }
+
+    [Fact]
+    public void WithoutItem_MissingItem_ReturnsSameInstance()
+    {
+        var context = MessageContext.Empty.WithItem("attempt", 2);
+
+        Assert.Same(context, context.WithoutItem("missing"));
+    }
+
+    [Fact]
+    public void TryGetItem_ReturnsFalseForMissingOrWrongType()
+    {
+        var context = MessageContext.Empty.WithItem("attempt", 2);
+
+        Assert.False(context.TryGetItem<int>("missing", out var missing));
+        Assert.False(context.TryGetItem<string>("attempt", out var wrongType));
+        Assert.Equal(0, missing);
+        Assert.Null(wrongType);
+    }
+
+    [Fact]
+    public void WithCancellation_ReturnsNewContextWithSameHeadersAndItems()
+    {
+        using var cts = new CancellationTokenSource();
+        var context = MessageContext.Empty
+            .WithHeader("tenant", "north")
+            .WithItem("attempt", 2);
+
+        var updated = context.WithCancellation(cts.Token);
+
+        Assert.Equal(cts.Token, updated.CancellationToken);
+        Assert.Same(context.Headers, updated.Headers);
+        Assert.True(updated.TryGetItem<int>("attempt", out var attempt));
+        Assert.Equal(2, attempt);
+    }
+
+    [Fact]
+    public void Items_AreReadOnlySnapshot()
+    {
+        var context = MessageContext.Empty.WithItem("attempt", 2);
+
+        Assert.Throws<NotSupportedException>(() =>
+            ((IDictionary<string, object?>)context.Items).Add("other", 3));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void WithItem_RejectsInvalidKeys(string key)
+    {
+        Assert.Throws<ArgumentException>(() => MessageContext.Empty.WithItem(key, 1));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void WithoutItem_RejectsInvalidKeys(string key)
+    {
+        Assert.Throws<ArgumentException>(() => MessageContext.Empty.WithoutItem(key));
+    }
+}

--- a/test/PatternKit.Tests/Messaging/MessageHeadersTests.cs
+++ b/test/PatternKit.Tests/Messaging/MessageHeadersTests.cs
@@ -1,0 +1,241 @@
+using System.Collections;
+using PatternKit.Messaging;
+
+namespace PatternKit.Tests.Messaging;
+
+public sealed class MessageHeadersTests
+{
+    [Fact]
+    public void Empty_HasNoValues()
+    {
+        Assert.Empty(MessageHeaders.Empty);
+        Assert.Null(MessageHeaders.Empty.MessageId);
+    }
+
+    [Fact]
+    public void Constructor_CreatesEmptyCollection()
+    {
+        var headers = new MessageHeaders();
+
+        Assert.True(headers.Count == 0);
+        Assert.Empty(headers.Keys);
+        Assert.Empty(headers.Values);
+    }
+
+    [Fact]
+    public void With_ReturnsNewCollection_WithoutMutatingOriginal()
+    {
+        var original = MessageHeaders.Empty;
+        var updated = original.With("tenant", "north");
+
+        Assert.False(original.ContainsKey("tenant"));
+        Assert.True(updated.ContainsKey("tenant"));
+        Assert.Equal("north", updated.GetString("tenant"));
+    }
+
+    [Fact]
+    public void Headers_AreCaseInsensitive()
+    {
+        var headers = MessageHeaders.Empty.With("Correlation-Id", "corr-1");
+
+        Assert.True(headers.ContainsKey("correlation-id"));
+        Assert.Equal("corr-1", headers.CorrelationId);
+    }
+
+    [Fact]
+    public void WellKnownHeaders_AreExposedAsProperties()
+    {
+        var timestamp = DateTimeOffset.Parse("2026-05-13T08:00:00Z");
+
+        var headers = MessageHeaders.Empty
+            .WithMessageId("msg-1")
+            .WithCorrelationId("corr-1")
+            .WithCausationId("cause-1")
+            .WithIdempotencyKey("idem-1")
+            .WithContentType("application/json")
+            .WithReplyTo("queue:reply")
+            .WithTimestamp(timestamp);
+
+        Assert.Equal("msg-1", headers.MessageId);
+        Assert.Equal("corr-1", headers.CorrelationId);
+        Assert.Equal("cause-1", headers.CausationId);
+        Assert.Equal("idem-1", headers.IdempotencyKey);
+        Assert.Equal("application/json", headers.ContentType);
+        Assert.Equal("queue:reply", headers.ReplyTo);
+        Assert.Equal(timestamp, headers.Timestamp);
+    }
+
+    [Fact]
+    public void Indexer_And_TryGetValue_ReadExistingValue()
+    {
+        var headers = MessageHeaders.Empty.With("tenant", "north");
+
+        Assert.Equal("north", headers["tenant"]);
+        Assert.True(headers.TryGetValue("tenant", out var value));
+        Assert.Equal("north", value);
+    }
+
+    [Fact]
+    public void Without_RemovesExistingValue_WithoutMutatingOriginal()
+    {
+        var original = MessageHeaders.Empty.With("tenant", "north");
+        var updated = original.Without("tenant");
+
+        Assert.True(original.ContainsKey("tenant"));
+        Assert.False(updated.ContainsKey("tenant"));
+        Assert.Same(MessageHeaders.Empty, updated);
+    }
+
+    [Fact]
+    public void Without_MissingValue_ReturnsSameInstance()
+    {
+        var headers = MessageHeaders.Empty.With("tenant", "north");
+
+        Assert.Same(headers, headers.Without("missing"));
+    }
+
+    [Fact]
+    public void Constructor_CopiesInputDictionary()
+    {
+        var source = new Dictionary<string, object?> { ["tenant"] = "north" };
+        var headers = new MessageHeaders(source);
+
+        source["tenant"] = "south";
+
+        Assert.Equal("north", headers.GetString("tenant"));
+    }
+
+    [Fact]
+    public void Constructor_RejectsNullInput()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MessageHeaders(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Constructor_RejectsInvalidHeaderNames(string name)
+    {
+        var values = new[] { new KeyValuePair<string, object?>(name, "value") };
+
+        Assert.Throws<ArgumentException>(() => new MessageHeaders(values));
+    }
+
+    [Fact]
+    public void TryGet_ReadsTypedValues()
+    {
+        var headers = MessageHeaders.Empty.With("attempt", 3);
+
+        Assert.True(headers.TryGet<int>("attempt", out var attempt));
+        Assert.Equal(3, attempt);
+        Assert.False(headers.TryGet<string>("attempt", out _));
+    }
+
+    [Fact]
+    public void GetString_ConvertsNonStringValues()
+    {
+        var headers = MessageHeaders.Empty.With("attempt", 3);
+
+        Assert.Equal("3", headers.GetString("attempt"));
+    }
+
+    [Fact]
+    public void GetString_ReturnsNullForMissingOrNullValues()
+    {
+        var headers = MessageHeaders.Empty.With("empty", null);
+
+        Assert.Null(headers.GetString("missing"));
+        Assert.Null(headers.GetString("empty"));
+    }
+
+    [Fact]
+    public void TryGetGuid_ReadsGuidAndStringValues()
+    {
+        var id = Guid.NewGuid();
+        var headers = MessageHeaders.Empty
+            .With("typed", id)
+            .With("text", id.ToString("D"));
+
+        Assert.True(headers.TryGetGuid("typed", out var typed));
+        Assert.True(headers.TryGetGuid("text", out var text));
+        Assert.Equal(id, typed);
+        Assert.Equal(id, text);
+    }
+
+    [Fact]
+    public void TryGetGuid_ReturnsFalseForMissingOrInvalidValues()
+    {
+        var headers = MessageHeaders.Empty.With("operation-id", "not-a-guid");
+
+        Assert.False(headers.TryGetGuid("missing", out var missing));
+        Assert.False(headers.TryGetGuid("operation-id", out var invalid));
+        Assert.Equal(Guid.Empty, missing);
+        Assert.Equal(Guid.Empty, invalid);
+    }
+
+    [Fact]
+    public void TryGetDateTimeOffset_ReadsDateTimeOffsetDateTimeAndStringValues()
+    {
+        var timestamp = DateTimeOffset.Parse("2026-05-13T08:00:00Z");
+        var dateTime = timestamp.UtcDateTime;
+        var headers = MessageHeaders.Empty
+            .With("dto", timestamp)
+            .With("date", dateTime)
+            .With("text", timestamp.ToString("O"));
+
+        Assert.True(headers.TryGetDateTimeOffset("dto", out var dto));
+        Assert.True(headers.TryGetDateTimeOffset("date", out var date));
+        Assert.True(headers.TryGetDateTimeOffset("text", out var text));
+        Assert.Equal(timestamp, dto);
+        Assert.Equal(new DateTimeOffset(dateTime), date);
+        Assert.Equal(timestamp, text);
+    }
+
+    [Fact]
+    public void Timestamp_ReturnsNullWhenHeaderIsMissingOrInvalid()
+    {
+        Assert.Null(MessageHeaders.Empty.Timestamp);
+        Assert.Null(MessageHeaders.Empty.With(MessageHeaderNames.Timestamp, "not-a-date").Timestamp);
+    }
+
+    [Fact]
+    public void TryGetDateTimeOffset_ReturnsFalseForMissingOrInvalidValues()
+    {
+        var headers = MessageHeaders.Empty.With("accepted-at", "not-a-date");
+
+        Assert.False(headers.TryGetDateTimeOffset("missing", out var missing));
+        Assert.False(headers.TryGetDateTimeOffset("accepted-at", out var invalid));
+        Assert.Equal(default, missing);
+        Assert.Equal(default, invalid);
+    }
+
+    [Fact]
+    public void Enumerators_ReturnHeaderPairs()
+    {
+        var headers = MessageHeaders.Empty.With("tenant", "north");
+
+        Assert.Contains(headers, pair => pair.Key == "tenant" && (string?)pair.Value == "north");
+
+        var enumerator = ((IEnumerable)headers).GetEnumerator();
+        Assert.True(enumerator.MoveNext());
+        var pair = Assert.IsType<KeyValuePair<string, object?>>(enumerator.Current);
+        Assert.Equal("tenant", pair.Key);
+        Assert.Equal("north", pair.Value);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void With_RejectsInvalidHeaderNames(string name)
+    {
+        Assert.Throws<ArgumentException>(() => MessageHeaders.Empty.With(name, "value"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void WellKnownStringHeaders_RejectInvalidValues(string value)
+    {
+        Assert.Throws<ArgumentException>(() => MessageHeaders.Empty.WithCorrelationId(value));
+    }
+}

--- a/test/PatternKit.Tests/Messaging/MessageTests.cs
+++ b/test/PatternKit.Tests/Messaging/MessageTests.cs
@@ -1,0 +1,109 @@
+using PatternKit.Messaging;
+
+namespace PatternKit.Tests.Messaging;
+
+public sealed class MessageTests
+{
+    [Fact]
+    public void Create_UsesEmptyHeaders()
+    {
+        var message = Message<string>.Create("hello");
+
+        Assert.Equal("hello", message.Payload);
+        Assert.Same(MessageHeaders.Empty, message.Headers);
+    }
+
+    [Fact]
+    public void WithPayload_PreservesHeaders()
+    {
+        var message = Message<string>.Create("hello").WithCorrelationId("corr-1");
+        var mapped = message.WithPayload(42);
+
+        Assert.Equal(42, mapped.Payload);
+        Assert.Same(message.Headers, mapped.Headers);
+        Assert.Equal("corr-1", mapped.Headers.CorrelationId);
+    }
+
+    [Fact]
+    public void WithHeaders_ReplacesHeaders()
+    {
+        var headers = MessageHeaders.Empty.WithMessageId("msg-1");
+        var message = Message<string>.Create("hello").WithHeaders(headers);
+
+        Assert.Same(headers, message.Headers);
+        Assert.Equal("msg-1", message.Headers.MessageId);
+    }
+
+    [Fact]
+    public void WithHeaders_RejectsNullHeaders()
+    {
+        var message = Message<string>.Create("hello");
+
+        Assert.Throws<ArgumentNullException>(() => message.WithHeaders(null!));
+    }
+
+    [Fact]
+    public void Enrich_AppliesHeaderTransformation()
+    {
+        var message = Message<string>.Create("hello")
+            .Enrich(headers => headers
+                .WithCorrelationId("corr-1")
+                .WithCausationId("cause-1"));
+
+        Assert.Equal("corr-1", message.Headers.CorrelationId);
+        Assert.Equal("cause-1", message.Headers.CausationId);
+    }
+
+    [Fact]
+    public void Enrich_RejectsNullDelegate()
+    {
+        var message = Message<string>.Create("hello");
+
+        Assert.Throws<ArgumentNullException>(() => message.Enrich(null!));
+    }
+
+    [Fact]
+    public void Enrich_RejectsNullHeaders()
+    {
+        var message = Message<string>.Create("hello");
+
+        Assert.Throws<InvalidOperationException>(() => message.Enrich(_ => null!));
+    }
+
+    [Fact]
+    public void WellKnownHeaderHelpers_ReturnNewMessage()
+    {
+        var original = Message<string>.Create("hello");
+        var updated = original
+            .WithMessageId("msg-1")
+            .WithCorrelationId("corr-1")
+            .WithCausationId("cause-1")
+            .WithIdempotencyKey("idem-1")
+            .WithContentType("application/json")
+            .WithReplyTo("queue:reply");
+
+        Assert.Null(original.Headers.MessageId);
+        Assert.Equal("msg-1", updated.Headers.MessageId);
+        Assert.Equal("corr-1", updated.Headers.CorrelationId);
+        Assert.Equal("cause-1", updated.Headers.CausationId);
+        Assert.Equal("idem-1", updated.Headers.IdempotencyKey);
+        Assert.Equal("application/json", updated.Headers.ContentType);
+        Assert.Equal("queue:reply", updated.Headers.ReplyTo);
+    }
+
+    [Fact]
+    public void WithHeader_AddsCustomHeader()
+    {
+        var message = Message<string>.Create("hello").WithHeader("tenant", "north");
+
+        Assert.Equal("north", message.Headers.GetString("tenant"));
+    }
+
+    [Fact]
+    public void WithReplyTo_AddsReplyAddress()
+    {
+        var message = Message<string>.Create("hello").WithReplyTo("queue:reply");
+
+        Assert.Equal("queue:reply", message.Headers.ReplyTo);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds immutable `Message<TPayload>`, `MessageHeaders`, `MessageHeaderNames`, and `MessageContext` primitives for enterprise integration patterns.
- Adds a compiled messaging example plus tests.
- Documents message envelope/context usage and wires the messaging section into the PatternKit DocFX TOC.

Closes #172.

## Validation
- `dotnet test PatternKit.slnx --configuration Release --no-restore`
- `dotnet test PatternKit.slnx --configuration Release --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[PatternKit*]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests]*" -- RunConfiguration.TestSessionTimeout=900000`
- `dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true` after clearing test hosts: 0 warnings, 0 errors
- `docfx metadata docs\docfx.json`: 0 warnings, 0 errors
- `docfx build docs\docfx.json`: 0 warnings, 0 errors
- `git diff --cached --check`