### PR TITLE
feat: add enterprise message routing primitives

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -145,6 +145,9 @@ If you’re looking for end-to-end, production-shaped demos, check the **Example
 - **[Message Envelope and Context](messaging/message-envelope.md)**
   Immutable payload envelopes, headers, and execution context for enterprise integration patterns.
 
+- **[Enterprise Message Routing](messaging/message-routing.md)**
+  Content router, recipient list, splitter, and aggregator primitives for deterministic in-process flows.
+
 - **[TypeDispatcher](behavioral/type-dispatcher/index.md)**
   Type-safe runtime dispatch that routes objects to handlers based on their concrete type.
 

--- a/docs/patterns/messaging/README.md
+++ b/docs/patterns/messaging/README.md
@@ -8,6 +8,12 @@ This section covers messaging and event-driven patterns in PatternKit.
 
 [Learn More](message-envelope.md)
 
+## Enterprise Message Routing
+
+Content router, recipient list, splitter, and aggregator primitives model common Enterprise Integration Patterns for deterministic in-process workflows.
+
+[Learn More](message-routing.md)
+
 ## Mediator (Source Generated)
 
 A **zero-dependency**, **source-generated Mediator pattern** implementation for commands, notifications, and streams.
@@ -64,6 +70,7 @@ var result = await dispatcher.Send<CreateUser, UserCreated>(
 The Source-Generated Mediator complements other PatternKit patterns:
 
 - **[Message Envelope and Context](message-envelope.md)** - Shared metadata for routers, routing slips, sagas, mailboxes, and idempotent receivers
+- **[Enterprise Message Routing](message-routing.md)** - Content-based router, recipient list, splitter, and aggregator primitives
 - **[Runtime Mediator](../behavioral/mediator/index.md)** - Pre-built mediator with PatternKit runtime (use for application code)
 - **Observer** - For reactive event handling and pub/sub
 - **Command** - For encapsulating requests as objects

--- a/docs/patterns/messaging/message-routing.md
+++ b/docs/patterns/messaging/message-routing.md
@@ -1,0 +1,106 @@
+# Enterprise Message Routing
+
+PatternKit messaging routing primitives model common Enterprise Integration Patterns for in-process workflows. They are small fluent builders over delegates, designed to compose with `Message<TPayload>` and `MessageContext`.
+
+These APIs do not provide broker delivery, persistence, or cross-process guarantees. Use them behind your transport, queue consumer, API handler, background worker, or generated dispatcher when the message is already in your process.
+
+## Content-Based Router
+
+`ContentRouter<TPayload, TResult>` selects the first matching route.
+
+```csharp
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+var router = ContentRouter<Order, string>.Create()
+    .When((m, _) => m.Payload.Total > 100m).Then((_, _) => "priority")
+    .Default((_, _) => "standard")
+    .Build();
+
+var route = router.Route(Message<Order>.Create(new Order("order-1", 150m)));
+```
+
+Use `AsyncContentRouter<TPayload, TResult>` when predicates or handlers need async work.
+
+## Recipient List
+
+`RecipientList<TPayload>` sends a message to every matching recipient in registration order and returns the names that received it.
+
+```csharp
+var delivered = new List<string>();
+
+var recipients = RecipientList<Order>.Create()
+    .To("audit", (_, _) => delivered.Add("audit"))
+    .When("billing", (m, _) => m.Payload.Total > 0m)
+    .Then((_, _) => delivered.Add("billing"))
+    .Build();
+
+var result = recipients.Dispatch(Message<Order>.Create(new Order("order-1", 150m)));
+```
+
+Use `AsyncRecipientList<TPayload>` for async recipient handlers.
+
+## Splitter
+
+`Splitter<TPayload, TItem>` turns one message into item messages. Child messages preserve the parent headers. When the parent has a message id and no causation id, child messages set `CausationId` to the parent `MessageId`.
+
+```csharp
+var splitter = Splitter<Order, LineItem>.Create()
+    .Use((m, _) => m.Payload.Lines)
+    .Build();
+
+var lineMessages = splitter.Split(orderMessage);
+```
+
+## Aggregator
+
+`Aggregator<TKey, TItem, TResult>` groups messages in memory until a completion policy is satisfied, then projects the completed group into a result and removes it from the open groups.
+
+```csharp
+var aggregator = Aggregator<string, LineItem, decimal>.Create()
+    .KeyBy((m, _) => m.Headers.CorrelationId ?? "missing")
+    .CompleteWhen((_, messages, _) => messages.Count == 2)
+    .Project((_, messages, _) => messages.Sum(m => m.Payload.Amount))
+    .Build();
+
+var result = aggregator.Add(lineMessage);
+if (result.Completed)
+{
+    Console.WriteLine(result.Result);
+}
+```
+
+Duplicate message ids are ignored by default. Use `DuplicateMessagePolicy.Replace` or `DuplicateMessagePolicy.Include` when a workflow needs different behavior.
+
+## Choosing Boundaries
+
+Use these primitives for:
+
+- deterministic in-process routing
+- composing handlers behind a queue consumer or HTTP endpoint
+- testable routing rules without broker dependencies
+- dynamic flows that still need clear, explicit code
+
+Use external infrastructure for:
+
+- durable queues
+- retry after process restart
+- competing consumers
+- exactly-once or at-least-once delivery contracts
+- transactional outbox persistence
+
+## API
+
+- <xref:PatternKit.Messaging.Routing.ContentRouter`2>
+- <xref:PatternKit.Messaging.Routing.AsyncContentRouter`2>
+- <xref:PatternKit.Messaging.Routing.RecipientList`1>
+- <xref:PatternKit.Messaging.Routing.AsyncRecipientList`1>
+- <xref:PatternKit.Messaging.Routing.Splitter`2>
+- <xref:PatternKit.Messaging.Routing.Aggregator`3>
+- <xref:PatternKit.Messaging.Routing.AggregationResult`2>
+- <xref:PatternKit.Messaging.Routing.DuplicateMessagePolicy>
+
+## Example Source
+
+- `src/PatternKit.Examples/Messaging/MessageRoutingExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/MessageRoutingExampleTests.cs`

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -297,6 +297,8 @@
       items:
         - name: Message Envelope and Context
           href: messaging/message-envelope.md
+        - name: Enterprise Message Routing
+          href: messaging/message-routing.md
         - name: Source-Generated Dispatcher
           href: messaging/dispatcher.md
     - name: Type-Dispatcher

--- a/src/PatternKit.Core/Messaging/Routing/AggregationResult.cs
+++ b/src/PatternKit.Core/Messaging/Routing/AggregationResult.cs
@@ -1,0 +1,32 @@
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Result returned after adding a message to an aggregator.
+/// </summary>
+public sealed class AggregationResult<TKey, TResult>
+    where TKey : notnull
+{
+    private AggregationResult(TKey key, int count, bool accepted, bool completed, TResult? result)
+        => (Key, Count, Accepted, Completed, Result) = (key, count, accepted, completed, result);
+
+    /// <summary>The aggregation key.</summary>
+    public TKey Key { get; }
+
+    /// <summary>Number of messages currently in the group snapshot.</summary>
+    public int Count { get; }
+
+    /// <summary><see langword="true"/> when the added message was accepted into the group.</summary>
+    public bool Accepted { get; }
+
+    /// <summary><see langword="true"/> when this add completed the group.</summary>
+    public bool Completed { get; }
+
+    /// <summary>The completed result, or <see langword="default"/> while pending.</summary>
+    public TResult? Result { get; }
+
+    internal static AggregationResult<TKey, TResult> Pending(TKey key, int count, bool accepted)
+        => new(key, count, accepted, completed: false, result: default);
+
+    internal static AggregationResult<TKey, TResult> Complete(TKey key, int count, bool accepted, TResult result)
+        => new(key, count, accepted, completed: true, result);
+}

--- a/src/PatternKit.Core/Messaging/Routing/Aggregator.cs
+++ b/src/PatternKit.Core/Messaging/Routing/Aggregator.cs
@@ -1,0 +1,173 @@
+using System.Collections.ObjectModel;
+
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// In-process aggregator that collects related messages until a completion policy is satisfied.
+/// </summary>
+public sealed class Aggregator<TKey, TItem, TResult>
+    where TKey : notnull
+{
+    /// <summary>Selects the aggregation key for a message.</summary>
+    public delegate TKey KeySelector(Message<TItem> message, MessageContext context);
+
+    /// <summary>Determines whether a group is complete.</summary>
+    public delegate bool CompletionPolicy(TKey key, IReadOnlyList<Message<TItem>> messages, MessageContext context);
+
+    /// <summary>Creates the result for a completed group.</summary>
+    public delegate TResult ResultFactory(TKey key, IReadOnlyList<Message<TItem>> messages, MessageContext context);
+
+    private readonly object _gate = new();
+    private readonly Dictionary<TKey, Group> _groups = new();
+    private readonly KeySelector _keySelector;
+    private readonly CompletionPolicy _completionPolicy;
+    private readonly ResultFactory _resultFactory;
+    private readonly DuplicateMessagePolicy _duplicatePolicy;
+
+    private Aggregator(
+        KeySelector keySelector,
+        CompletionPolicy completionPolicy,
+        ResultFactory resultFactory,
+        DuplicateMessagePolicy duplicatePolicy)
+        => (_keySelector, _completionPolicy, _resultFactory, _duplicatePolicy) =
+            (keySelector, completionPolicy, resultFactory, duplicatePolicy);
+
+    /// <summary>
+    /// Adds a message to its group and returns a completed result when the completion policy is satisfied.
+    /// </summary>
+    public AggregationResult<TKey, TResult> Add(Message<TItem> message, MessageContext? context = null)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = context ?? MessageContext.From(message);
+        var key = _keySelector(message, effectiveContext);
+        IReadOnlyList<Message<TItem>>? completedSnapshot = null;
+        bool accepted;
+        lock (_gate)
+        {
+            if (!_groups.TryGetValue(key, out var group))
+            {
+                group = new Group();
+                _groups.Add(key, group);
+            }
+
+            accepted = group.Add(message, _duplicatePolicy);
+            var snapshot = group.Snapshot();
+            if (!_completionPolicy(key, snapshot, effectiveContext))
+                return AggregationResult<TKey, TResult>.Pending(key, snapshot.Count, accepted);
+
+            _groups.Remove(key);
+            completedSnapshot = snapshot;
+        }
+
+        return AggregationResult<TKey, TResult>.Complete(
+            key,
+            completedSnapshot.Count,
+            accepted,
+            _resultFactory(key, completedSnapshot, effectiveContext));
+    }
+
+    /// <summary>Returns the number of currently open groups.</summary>
+    public int OpenGroupCount
+    {
+        get
+        {
+            lock (_gate)
+                return _groups.Count;
+        }
+    }
+
+    /// <summary>Creates a new aggregator builder.</summary>
+    public static Builder Create() => new();
+
+    private sealed class Group
+    {
+        private readonly List<Message<TItem>> _messages = new();
+        private readonly HashSet<string> _messageIds = new(StringComparer.Ordinal);
+
+        internal bool Add(Message<TItem> message, DuplicateMessagePolicy duplicatePolicy)
+        {
+            var messageId = message.Headers.MessageId;
+            if (messageId is null)
+            {
+                _messages.Add(message);
+                return true;
+            }
+
+            if (_messageIds.Add(messageId))
+            {
+                _messages.Add(message);
+                return true;
+            }
+
+            if (duplicatePolicy == DuplicateMessagePolicy.Include)
+            {
+                _messages.Add(message);
+                return true;
+            }
+
+            if (duplicatePolicy == DuplicateMessagePolicy.Replace)
+            {
+                for (var i = 0; i < _messages.Count; i++)
+                {
+                    if (_messages[i].Headers.MessageId == messageId)
+                    {
+                        _messages[i] = message;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        internal IReadOnlyList<Message<TItem>> Snapshot()
+            => new ReadOnlyCollection<Message<TItem>>(_messages.ToArray());
+    }
+
+    /// <summary>Fluent builder for <see cref="Aggregator{TKey,TItem,TResult}"/>.</summary>
+    public sealed class Builder
+    {
+        private KeySelector? _keySelector;
+        private CompletionPolicy? _completionPolicy;
+        private ResultFactory? _resultFactory;
+        private DuplicateMessagePolicy _duplicatePolicy = DuplicateMessagePolicy.Ignore;
+
+        /// <summary>Sets the aggregation key selector.</summary>
+        public Builder KeyBy(KeySelector keySelector)
+        {
+            _keySelector = keySelector ?? throw new ArgumentNullException(nameof(keySelector));
+            return this;
+        }
+
+        /// <summary>Sets the completion policy.</summary>
+        public Builder CompleteWhen(CompletionPolicy completionPolicy)
+        {
+            _completionPolicy = completionPolicy ?? throw new ArgumentNullException(nameof(completionPolicy));
+            return this;
+        }
+
+        /// <summary>Sets the result factory.</summary>
+        public Builder Project(ResultFactory resultFactory)
+        {
+            _resultFactory = resultFactory ?? throw new ArgumentNullException(nameof(resultFactory));
+            return this;
+        }
+
+        /// <summary>Sets duplicate handling for messages with the same message id.</summary>
+        public Builder Duplicates(DuplicateMessagePolicy duplicatePolicy)
+        {
+            _duplicatePolicy = duplicatePolicy;
+            return this;
+        }
+
+        /// <summary>Builds an immutable aggregator.</summary>
+        public Aggregator<TKey, TItem, TResult> Build()
+            => new(
+                _keySelector ?? throw new InvalidOperationException("An aggregation key selector is required."),
+                _completionPolicy ?? throw new InvalidOperationException("An aggregation completion policy is required."),
+                _resultFactory ?? throw new InvalidOperationException("An aggregation result factory is required."),
+                _duplicatePolicy);
+    }
+}

--- a/src/PatternKit.Core/Messaging/Routing/AsyncContentRouter.cs
+++ b/src/PatternKit.Core/Messaging/Routing/AsyncContentRouter.cs
@@ -1,0 +1,111 @@
+using PatternKit.Common;
+
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Async content-based router that selects the first matching route for a message.
+/// </summary>
+public sealed class AsyncContentRouter<TPayload, TResult>
+{
+    /// <summary>Async predicate used to decide whether a route matches.</summary>
+    public delegate ValueTask<bool> RoutePredicate(Message<TPayload> message, MessageContext context, CancellationToken cancellationToken);
+
+    /// <summary>Async handler executed for the first matching route.</summary>
+    public delegate ValueTask<TResult> RouteHandler(Message<TPayload> message, MessageContext context, CancellationToken cancellationToken);
+
+    private readonly RoutePredicate[] _predicates;
+    private readonly RouteHandler[] _handlers;
+    private readonly RouteHandler? _default;
+
+    private AsyncContentRouter(RoutePredicate[] predicates, RouteHandler[] handlers, RouteHandler? @default)
+        => (_predicates, _handlers, _default) = (predicates, handlers, @default);
+
+    /// <summary>
+    /// Routes <paramref name="message"/> to the first matching async handler.
+    /// </summary>
+    public async ValueTask<TResult> RouteAsync(
+        Message<TPayload> message,
+        MessageContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = CreateContext(message, context, cancellationToken);
+        for (var i = 0; i < _predicates.Length; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (await _predicates[i](message, effectiveContext, cancellationToken).ConfigureAwait(false))
+                return await _handlers[i](message, effectiveContext, cancellationToken).ConfigureAwait(false);
+        }
+
+        return _default is not null
+            ? await _default(message, effectiveContext, cancellationToken).ConfigureAwait(false)
+            : Throw.NoStrategyMatched<TResult>();
+    }
+
+    /// <summary>Creates a new async content router builder.</summary>
+    public static Builder Create() => new();
+
+    private static MessageContext CreateContext(
+        Message<TPayload> message,
+        MessageContext? context,
+        CancellationToken cancellationToken)
+    {
+        if (context is null)
+            return MessageContext.From(message, cancellationToken);
+
+        return cancellationToken.CanBeCanceled
+            ? context.WithCancellation(cancellationToken)
+            : context;
+    }
+
+    /// <summary>Fluent builder for <see cref="AsyncContentRouter{TPayload,TResult}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<RoutePredicate> _predicates = new(8);
+        private readonly List<RouteHandler> _handlers = new(8);
+        private RouteHandler? _default;
+
+        /// <summary>Adds an async route predicate.</summary>
+        public WhenBuilder When(RoutePredicate predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return new WhenBuilder(this, predicate);
+        }
+
+        /// <summary>Sets the default async route handler.</summary>
+        public Builder Default(RouteHandler handler)
+        {
+            _default = handler ?? throw new ArgumentNullException(nameof(handler));
+            return this;
+        }
+
+        /// <summary>Builds an immutable router.</summary>
+        public AsyncContentRouter<TPayload, TResult> Build()
+            => new(_predicates.ToArray(), _handlers.ToArray(), _default);
+
+        /// <summary>Fluent route continuation.</summary>
+        public sealed class WhenBuilder
+        {
+            private readonly Builder _owner;
+            private readonly RoutePredicate _predicate;
+
+            internal WhenBuilder(Builder owner, RoutePredicate predicate)
+                => (_owner, _predicate) = (owner, predicate);
+
+            /// <summary>Adds the handler for the current predicate.</summary>
+            public Builder Then(RouteHandler handler)
+            {
+                if (handler is null)
+                    throw new ArgumentNullException(nameof(handler));
+
+                _owner._predicates.Add(_predicate);
+                _owner._handlers.Add(handler);
+                return _owner;
+            }
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Routing/AsyncRecipientList.cs
+++ b/src/PatternKit.Core/Messaging/Routing/AsyncRecipientList.cs
@@ -1,0 +1,121 @@
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Async Recipient List pattern that dispatches a message to every matching recipient in order.
+/// </summary>
+public sealed class AsyncRecipientList<TPayload>
+{
+    /// <summary>Async predicate used to decide whether a recipient should receive a message.</summary>
+    public delegate ValueTask<bool> RecipientPredicate(Message<TPayload> message, MessageContext context, CancellationToken cancellationToken);
+
+    /// <summary>Async recipient handler invoked for matching recipients.</summary>
+    public delegate ValueTask RecipientHandler(Message<TPayload> message, MessageContext context, CancellationToken cancellationToken);
+
+    private readonly Recipient[] _recipients;
+
+    private AsyncRecipientList(Recipient[] recipients) => _recipients = recipients;
+
+    /// <summary>
+    /// Dispatches <paramref name="message"/> to every matching recipient in registration order.
+    /// </summary>
+    public async ValueTask<RecipientListResult> DispatchAsync(
+        Message<TPayload> message,
+        MessageContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = CreateContext(message, context, cancellationToken);
+        var delivered = new List<string>(_recipients.Length);
+        foreach (var recipient in _recipients)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!await recipient.Predicate(message, effectiveContext, cancellationToken).ConfigureAwait(false))
+                continue;
+
+            await recipient.Handler(message, effectiveContext, cancellationToken).ConfigureAwait(false);
+            delivered.Add(recipient.Name);
+        }
+
+        return new RecipientListResult(delivered);
+    }
+
+    /// <summary>Creates a new async recipient list builder.</summary>
+    public static Builder Create() => new();
+
+    private static MessageContext CreateContext(
+        Message<TPayload> message,
+        MessageContext? context,
+        CancellationToken cancellationToken)
+    {
+        if (context is null)
+            return MessageContext.From(message, cancellationToken);
+
+        return cancellationToken.CanBeCanceled
+            ? context.WithCancellation(cancellationToken)
+            : context;
+    }
+
+    private sealed class Recipient
+    {
+        internal Recipient(string name, RecipientPredicate predicate, RecipientHandler handler)
+            => (Name, Predicate, Handler) = (name, predicate, handler);
+
+        internal string Name { get; }
+
+        internal RecipientPredicate Predicate { get; }
+
+        internal RecipientHandler Handler { get; }
+    }
+
+    /// <summary>Fluent builder for <see cref="AsyncRecipientList{TPayload}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<Recipient> _recipients = new(8);
+
+        /// <summary>Adds a recipient that receives every message.</summary>
+        public Builder To(string name, RecipientHandler handler)
+            => When(name, static (_, _, _) => new ValueTask<bool>(true)).Then(handler);
+
+        /// <summary>Adds a conditional recipient.</summary>
+        public WhenBuilder When(string name, RecipientPredicate predicate)
+        {
+            ValidateName(name);
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return new WhenBuilder(this, name, predicate);
+        }
+
+        /// <summary>Builds an immutable async recipient list.</summary>
+        public AsyncRecipientList<TPayload> Build() => new(_recipients.ToArray());
+
+        private static void ValidateName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Recipient name cannot be null, empty, or whitespace.", nameof(name));
+        }
+
+        /// <summary>Fluent recipient continuation.</summary>
+        public sealed class WhenBuilder
+        {
+            private readonly Builder _owner;
+            private readonly string _name;
+            private readonly RecipientPredicate _predicate;
+
+            internal WhenBuilder(Builder owner, string name, RecipientPredicate predicate)
+                => (_owner, _name, _predicate) = (owner, name, predicate);
+
+            /// <summary>Adds the recipient handler.</summary>
+            public Builder Then(RecipientHandler handler)
+            {
+                if (handler is null)
+                    throw new ArgumentNullException(nameof(handler));
+
+                _owner._recipients.Add(new Recipient(_name, _predicate, handler));
+                return _owner;
+            }
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Routing/ContentRouter.cs
+++ b/src/PatternKit.Core/Messaging/Routing/ContentRouter.cs
@@ -1,0 +1,92 @@
+using PatternKit.Common;
+
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Content-based router that selects the first matching route for a message.
+/// </summary>
+public sealed class ContentRouter<TPayload, TResult>
+{
+    /// <summary>Predicate used to decide whether a route matches.</summary>
+    public delegate bool RoutePredicate(Message<TPayload> message, MessageContext context);
+
+    /// <summary>Handler executed for the first matching route.</summary>
+    public delegate TResult RouteHandler(Message<TPayload> message, MessageContext context);
+
+    private readonly RoutePredicate[] _predicates;
+    private readonly RouteHandler[] _handlers;
+    private readonly RouteHandler? _default;
+
+    private ContentRouter(RoutePredicate[] predicates, RouteHandler[] handlers, RouteHandler? @default)
+        => (_predicates, _handlers, _default) = (predicates, handlers, @default);
+
+    /// <summary>
+    /// Routes <paramref name="message"/> to the first matching handler.
+    /// </summary>
+    public TResult Route(Message<TPayload> message, MessageContext? context = null)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = context ?? MessageContext.From(message);
+        for (var i = 0; i < _predicates.Length; i++)
+            if (_predicates[i](message, effectiveContext))
+                return _handlers[i](message, effectiveContext);
+
+        return _default is not null
+            ? _default(message, effectiveContext)
+            : Throw.NoStrategyMatched<TResult>();
+    }
+
+    /// <summary>Creates a new content router builder.</summary>
+    public static Builder Create() => new();
+
+    /// <summary>Fluent builder for <see cref="ContentRouter{TPayload,TResult}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<RoutePredicate> _predicates = new(8);
+        private readonly List<RouteHandler> _handlers = new(8);
+        private RouteHandler? _default;
+
+        /// <summary>Adds a route predicate.</summary>
+        public WhenBuilder When(RoutePredicate predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return new WhenBuilder(this, predicate);
+        }
+
+        /// <summary>Sets the default route handler.</summary>
+        public Builder Default(RouteHandler handler)
+        {
+            _default = handler ?? throw new ArgumentNullException(nameof(handler));
+            return this;
+        }
+
+        /// <summary>Builds an immutable router.</summary>
+        public ContentRouter<TPayload, TResult> Build()
+            => new(_predicates.ToArray(), _handlers.ToArray(), _default);
+
+        /// <summary>Fluent route continuation.</summary>
+        public sealed class WhenBuilder
+        {
+            private readonly Builder _owner;
+            private readonly RoutePredicate _predicate;
+
+            internal WhenBuilder(Builder owner, RoutePredicate predicate)
+                => (_owner, _predicate) = (owner, predicate);
+
+            /// <summary>Adds the handler for the current predicate.</summary>
+            public Builder Then(RouteHandler handler)
+            {
+                if (handler is null)
+                    throw new ArgumentNullException(nameof(handler));
+
+                _owner._predicates.Add(_predicate);
+                _owner._handlers.Add(handler);
+                return _owner;
+            }
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Routing/DuplicateMessagePolicy.cs
+++ b/src/PatternKit.Core/Messaging/Routing/DuplicateMessagePolicy.cs
@@ -1,0 +1,16 @@
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Duplicate handling for aggregator groups when messages share the same message id.
+/// </summary>
+public enum DuplicateMessagePolicy
+{
+    /// <summary>Keep the first message and ignore later duplicates.</summary>
+    Ignore,
+
+    /// <summary>Replace the existing message with the later duplicate.</summary>
+    Replace,
+
+    /// <summary>Include duplicate messages in the group.</summary>
+    Include
+}

--- a/src/PatternKit.Core/Messaging/Routing/RecipientList.cs
+++ b/src/PatternKit.Core/Messaging/Routing/RecipientList.cs
@@ -1,0 +1,104 @@
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Recipient List pattern that dispatches a message to every matching recipient.
+/// </summary>
+public sealed class RecipientList<TPayload>
+{
+    /// <summary>Predicate used to decide whether a recipient should receive a message.</summary>
+    public delegate bool RecipientPredicate(Message<TPayload> message, MessageContext context);
+
+    /// <summary>Recipient handler invoked for matching recipients.</summary>
+    public delegate void RecipientHandler(Message<TPayload> message, MessageContext context);
+
+    private readonly Recipient[] _recipients;
+
+    private RecipientList(Recipient[] recipients) => _recipients = recipients;
+
+    /// <summary>
+    /// Dispatches <paramref name="message"/> to every matching recipient in registration order.
+    /// </summary>
+    public RecipientListResult Dispatch(Message<TPayload> message, MessageContext? context = null)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = context ?? MessageContext.From(message);
+        var delivered = new List<string>(_recipients.Length);
+        foreach (var recipient in _recipients)
+        {
+            if (!recipient.Predicate(message, effectiveContext))
+                continue;
+
+            recipient.Handler(message, effectiveContext);
+            delivered.Add(recipient.Name);
+        }
+
+        return new RecipientListResult(delivered);
+    }
+
+    /// <summary>Creates a new recipient list builder.</summary>
+    public static Builder Create() => new();
+
+    private sealed class Recipient
+    {
+        internal Recipient(string name, RecipientPredicate predicate, RecipientHandler handler)
+            => (Name, Predicate, Handler) = (name, predicate, handler);
+
+        internal string Name { get; }
+
+        internal RecipientPredicate Predicate { get; }
+
+        internal RecipientHandler Handler { get; }
+    }
+
+    /// <summary>Fluent builder for <see cref="RecipientList{TPayload}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<Recipient> _recipients = new(8);
+
+        /// <summary>Adds a recipient that receives every message.</summary>
+        public Builder To(string name, RecipientHandler handler)
+            => When(name, static (_, _) => true).Then(handler);
+
+        /// <summary>Adds a conditional recipient.</summary>
+        public WhenBuilder When(string name, RecipientPredicate predicate)
+        {
+            ValidateName(name);
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return new WhenBuilder(this, name, predicate);
+        }
+
+        /// <summary>Builds an immutable recipient list.</summary>
+        public RecipientList<TPayload> Build() => new(_recipients.ToArray());
+
+        private static void ValidateName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Recipient name cannot be null, empty, or whitespace.", nameof(name));
+        }
+
+        /// <summary>Fluent recipient continuation.</summary>
+        public sealed class WhenBuilder
+        {
+            private readonly Builder _owner;
+            private readonly string _name;
+            private readonly RecipientPredicate _predicate;
+
+            internal WhenBuilder(Builder owner, string name, RecipientPredicate predicate)
+                => (_owner, _name, _predicate) = (owner, name, predicate);
+
+            /// <summary>Adds the recipient handler.</summary>
+            public Builder Then(RecipientHandler handler)
+            {
+                if (handler is null)
+                    throw new ArgumentNullException(nameof(handler));
+
+                _owner._recipients.Add(new Recipient(_name, _predicate, handler));
+                return _owner;
+            }
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Routing/RecipientListResult.cs
+++ b/src/PatternKit.Core/Messaging/Routing/RecipientListResult.cs
@@ -1,0 +1,26 @@
+using System.Collections.ObjectModel;
+
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Result returned after dispatching a message through a recipient list.
+/// </summary>
+public sealed class RecipientListResult
+{
+    /// <summary>
+    /// Creates a recipient list result.
+    /// </summary>
+    public RecipientListResult(IEnumerable<string> deliveredRecipients)
+    {
+        if (deliveredRecipients is null)
+            throw new ArgumentNullException(nameof(deliveredRecipients));
+
+        DeliveredRecipients = new ReadOnlyCollection<string>(deliveredRecipients.ToArray());
+    }
+
+    /// <summary>Recipient names that received the message, in dispatch order.</summary>
+    public IReadOnlyList<string> DeliveredRecipients { get; }
+
+    /// <summary>Number of recipients that received the message.</summary>
+    public int Count => DeliveredRecipients.Count;
+}

--- a/src/PatternKit.Core/Messaging/Routing/Splitter.cs
+++ b/src/PatternKit.Core/Messaging/Routing/Splitter.cs
@@ -1,0 +1,62 @@
+using System.Collections.ObjectModel;
+
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Splitter pattern that turns one message into zero or more item messages.
+/// </summary>
+public sealed class Splitter<TPayload, TItem>
+{
+    /// <summary>Splits the source message into item payloads.</summary>
+    public delegate IEnumerable<TItem> SplitHandler(Message<TPayload> message, MessageContext context);
+
+    private readonly SplitHandler _handler;
+
+    private Splitter(SplitHandler handler) => _handler = handler;
+
+    /// <summary>
+    /// Splits <paramref name="message"/> into item envelopes that preserve correlation metadata.
+    /// </summary>
+    public IReadOnlyList<Message<TItem>> Split(Message<TPayload> message, MessageContext? context = null)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = context ?? MessageContext.From(message);
+        var items = _handler(message, effectiveContext) ?? throw new InvalidOperationException("Splitter returned null.");
+        var result = new List<Message<TItem>>();
+        foreach (var item in items)
+            result.Add(new Message<TItem>(item, CreateChildHeaders(message.Headers)));
+
+        return new ReadOnlyCollection<Message<TItem>>(result);
+    }
+
+    /// <summary>Creates a splitter builder.</summary>
+    public static Builder Create() => new();
+
+    private static MessageHeaders CreateChildHeaders(MessageHeaders parentHeaders)
+    {
+        var headers = parentHeaders;
+        if (parentHeaders.MessageId is { Length: > 0 } messageId && parentHeaders.CausationId is null)
+            headers = headers.WithCausationId(messageId);
+
+        return headers;
+    }
+
+    /// <summary>Fluent builder for <see cref="Splitter{TPayload,TItem}"/>.</summary>
+    public sealed class Builder
+    {
+        private SplitHandler? _handler;
+
+        /// <summary>Sets the split handler.</summary>
+        public Builder Use(SplitHandler handler)
+        {
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            return this;
+        }
+
+        /// <summary>Builds an immutable splitter.</summary>
+        public Splitter<TPayload, TItem> Build()
+            => new(_handler ?? throw new InvalidOperationException("A splitter handler is required."));
+    }
+}

--- a/src/PatternKit.Examples/Messaging/MessageRoutingExample.cs
+++ b/src/PatternKit.Examples/Messaging/MessageRoutingExample.cs
@@ -1,0 +1,80 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Demonstrates in-process enterprise message routing primitives.
+/// </summary>
+public static class MessageRoutingExample
+{
+    /// <summary>
+    /// Runs a small order routing flow through router, recipient list, splitter, and aggregator.
+    /// </summary>
+    public static RoutingSummary Run()
+    {
+        var order = new RoutedOrder("order-42", "enterprise", [
+            new RoutedLine("sku-1", 30m),
+            new RoutedLine("sku-2", 70m)
+        ]);
+
+        var message = Message<RoutedOrder>
+            .Create(order)
+            .WithMessageId("msg-order-42")
+            .WithCorrelationId(order.Id);
+
+        var route = ContentRouter<RoutedOrder, string>.Create()
+            .When((m, _) => m.Payload.CustomerTier == "enterprise").Then((_, _) => "priority")
+            .Default((_, _) => "standard")
+            .Build()
+            .Route(message);
+
+        var recipients = new List<string>();
+        var recipientList = RecipientList<RoutedOrder>.Create()
+            .To("audit", (_, _) => recipients.Add("audit"))
+            .When("billing", (m, _) => m.Payload.Lines.Count > 0).Then((_, _) => recipients.Add("billing"))
+            .Build();
+
+        var recipientResult = recipientList.Dispatch(message);
+
+        var lineMessages = Splitter<RoutedOrder, RoutedLine>.Create()
+            .Use((m, _) => m.Payload.Lines)
+            .Build()
+            .Split(message);
+
+        var aggregator = Aggregator<string, RoutedLine, decimal>.Create()
+            .KeyBy((m, _) => m.Headers.CorrelationId ?? m.Payload.Sku)
+            .CompleteWhen((_, messages, _) => messages.Count == lineMessages.Count)
+            .Project((_, messages, _) => messages.Sum(m => m.Payload.Amount))
+            .Build();
+
+        decimal total = 0m;
+        foreach (var line in lineMessages)
+        {
+            var result = aggregator.Add(line.WithMessageId($"line:{line.Payload.Sku}"));
+            if (result.Completed)
+                total = result.Result;
+        }
+
+        return new RoutingSummary(
+            route,
+            recipientResult.DeliveredRecipients.ToArray(),
+            lineMessages.Count,
+            total,
+            lineMessages[0].Headers.CausationId!);
+    }
+}
+
+/// <summary>Example order payload routed by the messaging demo.</summary>
+public sealed record RoutedOrder(string Id, string CustomerTier, IReadOnlyList<RoutedLine> Lines);
+
+/// <summary>Example split item payload.</summary>
+public sealed record RoutedLine(string Sku, decimal Amount);
+
+/// <summary>Example output for the enterprise message routing demo.</summary>
+public sealed record RoutingSummary(
+    string Route,
+    IReadOnlyList<string> Recipients,
+    int SplitCount,
+    decimal AggregatedTotal,
+    string CausationId);

--- a/test/PatternKit.Examples.Tests/Messaging/MessageRoutingExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/MessageRoutingExampleTests.cs
@@ -1,0 +1,18 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class MessageRoutingExampleTests
+{
+    [Fact]
+    public void Run_ComposesEnterpriseRoutingPrimitives()
+    {
+        var summary = MessageRoutingExample.Run();
+
+        Assert.Equal("priority", summary.Route);
+        Assert.Equal(["audit", "billing"], summary.Recipients);
+        Assert.Equal(2, summary.SplitCount);
+        Assert.Equal(100m, summary.AggregatedTotal);
+        Assert.Equal("msg-order-42", summary.CausationId);
+    }
+}

--- a/test/PatternKit.Tests/Messaging/Routing/AggregatorTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/AggregatorTests.cs
@@ -1,0 +1,144 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Tests.Messaging.Routing;
+
+public sealed class AggregatorTests
+{
+    [Fact]
+    public void Add_ReturnsPendingUntilCompletionPolicyMatches()
+    {
+        var aggregator = CreateCountAggregator(2);
+
+        var first = aggregator.Add(Item("order-1", "msg-1", 10m));
+        var second = aggregator.Add(Item("order-1", "msg-2", 15m));
+
+        Assert.False(first.Completed);
+        Assert.True(first.Accepted);
+        Assert.Equal("order-1", first.Key);
+        Assert.Equal(1, first.Count);
+        Assert.Equal(default, first.Result);
+        Assert.True(second.Completed);
+        Assert.True(second.Accepted);
+        Assert.Equal("order-1", second.Key);
+        Assert.Equal(2, second.Count);
+        Assert.Equal(25m, second.Result);
+        Assert.Equal(0, aggregator.OpenGroupCount);
+    }
+
+    [Fact]
+    public void Add_GroupsMessagesBySelectedKey()
+    {
+        var aggregator = CreateCountAggregator(2);
+
+        var first = aggregator.Add(Item("order-1", "msg-1", 10m));
+        var second = aggregator.Add(Item("order-2", "msg-2", 15m));
+
+        Assert.False(first.Completed);
+        Assert.False(second.Completed);
+        Assert.Equal(2, aggregator.OpenGroupCount);
+    }
+
+    [Fact]
+    public void Add_IgnoresDuplicateMessageIdsByDefault()
+    {
+        var aggregator = CreateCountAggregator(2);
+
+        var first = aggregator.Add(Item("order-1", "msg-1", 10m));
+        var duplicate = aggregator.Add(Item("order-1", "msg-1", 15m));
+
+        Assert.True(first.Accepted);
+        Assert.False(duplicate.Accepted);
+        Assert.False(duplicate.Completed);
+        Assert.Equal(1, duplicate.Count);
+    }
+
+    [Fact]
+    public void Add_CanReplaceDuplicateMessageIds()
+    {
+        var aggregator = CreateCountAggregator(2, DuplicateMessagePolicy.Replace);
+
+        aggregator.Add(Item("order-1", "msg-1", 10m));
+        aggregator.Add(Item("order-1", "msg-1", 15m));
+        var result = aggregator.Add(Item("order-1", "msg-2", 5m));
+
+        Assert.True(result.Completed);
+        Assert.Equal(20m, result.Result);
+    }
+
+    [Fact]
+    public void Add_CanIncludeDuplicateMessageIds()
+    {
+        var aggregator = CreateCountAggregator(2, DuplicateMessagePolicy.Include);
+
+        aggregator.Add(Item("order-1", "msg-1", 10m));
+        var result = aggregator.Add(Item("order-1", "msg-1", 15m));
+
+        Assert.True(result.Completed);
+        Assert.Equal(25m, result.Result);
+    }
+
+    [Fact]
+    public void Add_AllowsMessagesWithoutMessageIds()
+    {
+        var aggregator = Aggregator<string, InvoiceLine, decimal>.Create()
+            .KeyBy((m, _) => m.Payload.OrderId)
+            .CompleteWhen((_, messages, _) => messages.Count == 2)
+            .Project((_, messages, _) => messages.Sum(m => m.Payload.Amount))
+            .Build();
+
+        aggregator.Add(Message<InvoiceLine>.Create(new InvoiceLine("order-1", 10m)));
+        var result = aggregator.Add(Message<InvoiceLine>.Create(new InvoiceLine("order-1", 15m)));
+
+        Assert.True(result.Completed);
+        Assert.Equal(25m, result.Result);
+    }
+
+    [Fact]
+    public void Add_RejectsNullMessage()
+    {
+        var aggregator = CreateCountAggregator(1);
+
+        Assert.Throws<ArgumentNullException>(() => aggregator.Add(null!));
+    }
+
+    [Fact]
+    public void Builder_RequiresAllDelegates()
+    {
+        Assert.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create().Build());
+        Assert.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create()
+            .KeyBy((m, _) => m.Payload.OrderId)
+            .Build());
+        Assert.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create()
+            .KeyBy((m, _) => m.Payload.OrderId)
+            .CompleteWhen((_, _, _) => true)
+            .Build());
+    }
+
+    [Fact]
+    public void Builder_RejectsNullDelegates()
+    {
+        var builder = Aggregator<string, InvoiceLine, decimal>.Create();
+
+        Assert.Throws<ArgumentNullException>(() => builder.KeyBy(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.Project(null!));
+    }
+
+    private static Aggregator<string, InvoiceLine, decimal> CreateCountAggregator(
+        int count,
+        DuplicateMessagePolicy duplicatePolicy = DuplicateMessagePolicy.Ignore)
+        => Aggregator<string, InvoiceLine, decimal>.Create()
+            .KeyBy((m, _) => m.Payload.OrderId)
+            .CompleteWhen((_, messages, _) => messages.Count == count)
+            .Project((_, messages, _) => messages.Sum(m => m.Payload.Amount))
+            .Duplicates(duplicatePolicy)
+            .Build();
+
+    private static Message<InvoiceLine> Item(string orderId, string messageId, decimal amount)
+        => Message<InvoiceLine>
+            .Create(new InvoiceLine(orderId, amount))
+            .WithMessageId(messageId);
+
+    private sealed record InvoiceLine(string OrderId, decimal Amount);
+}

--- a/test/PatternKit.Tests/Messaging/Routing/ContentRouterTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/ContentRouterTests.cs
@@ -1,0 +1,184 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Tests.Messaging.Routing;
+
+public sealed class ContentRouterTests
+{
+    [Fact]
+    public void Route_UsesFirstMatchingRoute()
+    {
+        var router = ContentRouter<Order, string>.Create()
+            .When((m, _) => m.Payload.Total > 100).Then((_, _) => "priority")
+            .When((_, _) => true).Then((_, _) => "standard")
+            .Build();
+
+        var result = router.Route(Message<Order>.Create(new Order("o-1", 150m)));
+
+        Assert.Equal("priority", result);
+    }
+
+    [Fact]
+    public void Route_UsesDefaultWhenNothingMatches()
+    {
+        var router = ContentRouter<Order, string>.Create()
+            .When((m, _) => m.Payload.Total < 0).Then((_, _) => "invalid")
+            .Default((_, _) => "default")
+            .Build();
+
+        var result = router.Route(Message<Order>.Create(new Order("o-1", 10m)));
+
+        Assert.Equal("default", result);
+    }
+
+    [Fact]
+    public void Route_ThrowsWhenNothingMatchesAndNoDefaultExists()
+    {
+        var router = ContentRouter<Order, string>.Create()
+            .When((m, _) => m.Payload.Total < 0).Then((_, _) => "invalid")
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => router.Route(Message<Order>.Create(new Order("o-1", 10m))));
+    }
+
+    [Fact]
+    public void Route_PassesContextToPredicateAndHandler()
+    {
+        var router = ContentRouter<Order, string>.Create()
+            .When((_, ctx) => ctx.Headers.CorrelationId == "corr-1")
+            .Then((m, ctx) => $"{ctx.Headers.CorrelationId}:{m.Payload.Id}")
+            .Build();
+
+        var message = Message<Order>.Create(new Order("o-1", 10m));
+        var context = new MessageContext(MessageHeaders.Empty.WithCorrelationId("corr-1"));
+
+        Assert.Equal("corr-1:o-1", router.Route(message, context));
+    }
+
+    [Fact]
+    public void Builder_RejectsNullDelegates()
+    {
+        var builder = ContentRouter<Order, string>.Create();
+
+        Assert.Throws<ArgumentNullException>(() => builder.When(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.Default(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.When((_, _) => true).Then(null!));
+    }
+
+    [Fact]
+    public void Route_RejectsNullMessage()
+    {
+        var router = ContentRouter<Order, string>.Create()
+            .Default((_, _) => "default")
+            .Build();
+
+        Assert.Throws<ArgumentNullException>(() => router.Route(null!));
+    }
+
+    [Fact]
+    public async Task AsyncRoute_UsesFirstMatchingRoute()
+    {
+        var router = AsyncContentRouter<Order, string>.Create()
+            .When((m, _, _) => new ValueTask<bool>(m.Payload.Total > 100)).Then((_, _, _) => new ValueTask<string>("priority"))
+            .When((_, _, _) => new ValueTask<bool>(true)).Then((_, _, _) => new ValueTask<string>("standard"))
+            .Build();
+
+        var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 150m)));
+
+        Assert.Equal("priority", result);
+    }
+
+    [Fact]
+    public async Task AsyncRoute_UsesDefaultWhenNothingMatches()
+    {
+        var router = AsyncContentRouter<Order, string>.Create()
+            .When((m, _, _) => new ValueTask<bool>(m.Payload.Total < 0)).Then((_, _, _) => new ValueTask<string>("invalid"))
+            .Default((_, _, _) => new ValueTask<string>("default"))
+            .Build();
+
+        var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)));
+
+        Assert.Equal("default", result);
+    }
+
+    [Fact]
+    public async Task AsyncRoute_ObservesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var router = AsyncContentRouter<Order, string>.Create()
+            .When((_, _, _) => new ValueTask<bool>(true)).Then((_, _, _) => new ValueTask<string>("never"))
+            .Build();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)), cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task AsyncRoute_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
+    {
+        using var cts = new CancellationTokenSource();
+        var seenToken = CancellationToken.None;
+        var router = AsyncContentRouter<Order, string>.Create()
+            .Default((_, ctx, token) =>
+            {
+                seenToken = ctx.CancellationToken;
+                return new ValueTask<string>(token == CancellationToken.None ? "ok" : "unexpected");
+            })
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, cts.Token);
+
+        var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)), context);
+
+        Assert.Equal("ok", result);
+        Assert.Equal(cts.Token, seenToken);
+    }
+
+    [Fact]
+    public async Task AsyncRoute_UsesExplicitCancellationTokenOverProvidedContext()
+    {
+        using var contextCts = new CancellationTokenSource();
+        using var callCts = new CancellationTokenSource();
+        var router = AsyncContentRouter<Order, CancellationToken>.Create()
+            .Default((_, ctx, _) => new ValueTask<CancellationToken>(ctx.CancellationToken))
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, contextCts.Token);
+
+        var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)), context, callCts.Token);
+
+        Assert.Equal(callCts.Token, result);
+    }
+
+    [Fact]
+    public async Task AsyncRoute_ThrowsWhenNothingMatchesAndNoDefaultExists()
+    {
+        var router = AsyncContentRouter<Order, string>.Create()
+            .When((m, _, _) => new ValueTask<bool>(m.Payload.Total < 0)).Then((_, _, _) => new ValueTask<string>("invalid"))
+            .Build();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m))));
+    }
+
+    [Fact]
+    public void AsyncBuilder_RejectsNullDelegates()
+    {
+        var builder = AsyncContentRouter<Order, string>.Create();
+
+        Assert.Throws<ArgumentNullException>(() => builder.When(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.Default(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.When((_, _, _) => new ValueTask<bool>(true)).Then(null!));
+    }
+
+    [Fact]
+    public async Task AsyncRoute_RejectsNullMessage()
+    {
+        var router = AsyncContentRouter<Order, string>.Create()
+            .Default((_, _, _) => new ValueTask<string>("default"))
+            .Build();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await router.RouteAsync(null!));
+    }
+
+    private sealed record Order(string Id, decimal Total);
+}

--- a/test/PatternKit.Tests/Messaging/Routing/RecipientListTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/RecipientListTests.cs
@@ -1,0 +1,186 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Tests.Messaging.Routing;
+
+public sealed class RecipientListTests
+{
+    [Fact]
+    public void Dispatch_SendsToMatchingRecipientsInOrder()
+    {
+        var log = new List<string>();
+        var list = RecipientList<Order>.Create()
+            .When("audit", (_, _) => true).Then((_, _) => log.Add("audit"))
+            .When("billing", (m, _) => m.Payload.Total > 0).Then((_, _) => log.Add("billing"))
+            .When("fraud", (m, _) => m.Payload.Total > 500).Then((_, _) => log.Add("fraud"))
+            .Build();
+
+        var result = list.Dispatch(Message<Order>.Create(new Order("o-1", 100m)));
+
+        Assert.Equal(["audit", "billing"], log);
+        Assert.Equal(["audit", "billing"], result.DeliveredRecipients);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void Dispatch_ReturnsEmptyResultWhenNoRecipientsMatch()
+    {
+        var list = RecipientList<Order>.Create()
+            .When("fraud", (m, _) => m.Payload.Total > 500).Then((_, _) => { })
+            .Build();
+
+        var result = list.Dispatch(Message<Order>.Create(new Order("o-1", 100m)));
+
+        Assert.Empty(result.DeliveredRecipients);
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void To_AddsUnconditionalRecipient()
+    {
+        var delivered = false;
+        var list = RecipientList<Order>.Create()
+            .To("audit", (_, _) => delivered = true)
+            .Build();
+
+        var result = list.Dispatch(Message<Order>.Create(new Order("o-1", 100m)));
+
+        Assert.True(delivered);
+        Assert.Equal(["audit"], result.DeliveredRecipients);
+    }
+
+    [Fact]
+    public void Dispatch_RejectsNullMessage()
+    {
+        var list = RecipientList<Order>.Create().To("audit", (_, _) => { }).Build();
+
+        Assert.Throws<ArgumentNullException>(() => list.Dispatch(null!));
+    }
+
+    [Fact]
+    public void Builder_RejectsInvalidArguments()
+    {
+        var builder = RecipientList<Order>.Create();
+
+        Assert.Throws<ArgumentException>(() => builder.When("", (_, _) => true));
+        Assert.Throws<ArgumentNullException>(() => builder.When("audit", null!));
+        Assert.Throws<ArgumentNullException>(() => builder.To("audit", null!));
+        Assert.Throws<ArgumentNullException>(() => builder.When("audit", (_, _) => true).Then(null!));
+    }
+
+    [Fact]
+    public void RecipientListResult_CopiesDeliveredRecipients()
+    {
+        var delivered = new List<string> { "audit" };
+        var result = new RecipientListResult(delivered);
+
+        delivered.Add("billing");
+
+        Assert.Equal(["audit"], result.DeliveredRecipients);
+    }
+
+    [Fact]
+    public void RecipientListResult_RejectsNullRecipients()
+    {
+        Assert.Throws<ArgumentNullException>(() => new RecipientListResult(null!));
+    }
+
+    [Fact]
+    public async Task AsyncDispatch_SendsToMatchingRecipientsInOrder()
+    {
+        var log = new List<string>();
+        var list = AsyncRecipientList<Order>.Create()
+            .When("audit", (_, _, _) => new ValueTask<bool>(true)).Then((_, _, _) =>
+            {
+                log.Add("audit");
+                return ValueTask.CompletedTask;
+            })
+            .When("billing", (m, _, _) => new ValueTask<bool>(m.Payload.Total > 0)).Then((_, _, _) =>
+            {
+                log.Add("billing");
+                return ValueTask.CompletedTask;
+            })
+            .Build();
+
+        var result = await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)));
+
+        Assert.Equal(["audit", "billing"], log);
+        Assert.Equal(["audit", "billing"], result.DeliveredRecipients);
+    }
+
+    [Fact]
+    public async Task AsyncDispatch_ObservesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var list = AsyncRecipientList<Order>.Create()
+            .To("audit", (_, _, _) => ValueTask.CompletedTask)
+            .Build();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)), cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task AsyncDispatch_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
+    {
+        using var cts = new CancellationTokenSource();
+        var seenToken = CancellationToken.None;
+        var list = AsyncRecipientList<Order>.Create()
+            .To("audit", (_, ctx, token) =>
+            {
+                seenToken = ctx.CancellationToken;
+                Assert.Equal(CancellationToken.None, token);
+                return ValueTask.CompletedTask;
+            })
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, cts.Token);
+
+        await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)), context);
+
+        Assert.Equal(cts.Token, seenToken);
+    }
+
+    [Fact]
+    public async Task AsyncDispatch_UsesExplicitCancellationTokenOverProvidedContext()
+    {
+        using var contextCts = new CancellationTokenSource();
+        using var callCts = new CancellationTokenSource();
+        var seenToken = CancellationToken.None;
+        var list = AsyncRecipientList<Order>.Create()
+            .To("audit", (_, ctx, _) =>
+            {
+                seenToken = ctx.CancellationToken;
+                return ValueTask.CompletedTask;
+            })
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, contextCts.Token);
+
+        await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)), context, callCts.Token);
+
+        Assert.Equal(callCts.Token, seenToken);
+    }
+
+    [Fact]
+    public async Task AsyncDispatch_RejectsNullMessage()
+    {
+        var list = AsyncRecipientList<Order>.Create()
+            .To("audit", (_, _, _) => ValueTask.CompletedTask)
+            .Build();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await list.DispatchAsync(null!));
+    }
+
+    [Fact]
+    public void AsyncBuilder_RejectsInvalidArguments()
+    {
+        var builder = AsyncRecipientList<Order>.Create();
+
+        Assert.Throws<ArgumentException>(() => builder.When("", (_, _, _) => new ValueTask<bool>(true)));
+        Assert.Throws<ArgumentNullException>(() => builder.When("audit", null!));
+        Assert.Throws<ArgumentNullException>(() => builder.To("audit", null!));
+        Assert.Throws<ArgumentNullException>(() => builder.When("audit", (_, _, _) => new ValueTask<bool>(true)).Then(null!));
+    }
+
+    private sealed record Order(string Id, decimal Total);
+}

--- a/test/PatternKit.Tests/Messaging/Routing/SplitterTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/SplitterTests.cs
@@ -1,0 +1,89 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Tests.Messaging.Routing;
+
+public sealed class SplitterTests
+{
+    [Fact]
+    public void Split_ReturnsItemMessages()
+    {
+        var splitter = Splitter<Order, LineItem>.Create()
+            .Use((m, _) => m.Payload.Items)
+            .Build();
+
+        var message = new Message<Order>(
+            new Order("o-1", [new LineItem("a"), new LineItem("b")]),
+            MessageHeaders.Empty.WithMessageId("msg-1").WithCorrelationId("corr-1"));
+
+        var parts = splitter.Split(message);
+
+        Assert.Equal(2, parts.Count);
+        Assert.Equal("a", parts[0].Payload.Sku);
+        Assert.Equal("corr-1", parts[0].Headers.CorrelationId);
+        Assert.Equal("msg-1", parts[0].Headers.CausationId);
+    }
+
+    [Fact]
+    public void Split_PreservesExistingCausationId()
+    {
+        var splitter = Splitter<Order, LineItem>.Create()
+            .Use((m, _) => m.Payload.Items)
+            .Build();
+        var message = new Message<Order>(
+            new Order("o-1", [new LineItem("a")]),
+            MessageHeaders.Empty.WithMessageId("msg-1").WithCausationId("cause-1"));
+
+        var parts = splitter.Split(message);
+
+        Assert.Equal("cause-1", parts[0].Headers.CausationId);
+    }
+
+    [Fact]
+    public void Split_AllowsEmptyResults()
+    {
+        var splitter = Splitter<Order, LineItem>.Create()
+            .Use((_, _) => [])
+            .Build();
+
+        var parts = splitter.Split(Message<Order>.Create(new Order("o-1", [])));
+
+        Assert.Empty(parts);
+    }
+
+    [Fact]
+    public void Split_RejectsNullMessage()
+    {
+        var splitter = Splitter<Order, LineItem>.Create()
+            .Use((m, _) => m.Payload.Items)
+            .Build();
+
+        Assert.Throws<ArgumentNullException>(() => splitter.Split(null!));
+    }
+
+    [Fact]
+    public void Split_RejectsNullHandlerResult()
+    {
+        var splitter = Splitter<Order, LineItem>.Create()
+            .Use((_, _) => null!)
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => splitter.Split(Message<Order>.Create(new Order("o-1", []))));
+    }
+
+    [Fact]
+    public void Builder_RequiresHandler()
+    {
+        Assert.Throws<InvalidOperationException>(() => Splitter<Order, LineItem>.Create().Build());
+    }
+
+    [Fact]
+    public void Builder_RejectsNullHandler()
+    {
+        Assert.Throws<ArgumentNullException>(() => Splitter<Order, LineItem>.Create().Use(null!));
+    }
+
+    private sealed record Order(string Id, IReadOnlyList<LineItem> Items);
+
+    private sealed record LineItem(string Sku);
+}


### PR DESCRIPTION
## Summary
- add enterprise message routing primitives for content-based routing, recipient lists, splitting, and aggregation
- add sync and async fluent builders plus duplicate message handling for aggregators
- document the routing APIs with DocFX xrefs and add a compiled example

## Validation
- dotnet test PatternKit.slnx --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test PatternKit.slnx --configuration Release --no-build --collect:XPlat_Code_Coverage
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- docfx metadata docs\docfx.json
- docfx build docs\docfx.json
- git diff --check

Closes #173