### PR TITLE
feat: add routing slip runtime and generator

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -148,6 +148,9 @@ If you’re looking for end-to-end, production-shaped demos, check the **Example
 - **[Enterprise Message Routing](messaging/message-routing.md)**
   Content router, recipient list, splitter, and aggregator primitives for deterministic in-process flows.
 
+- **[Routing Slip](messaging/routing-slip.md)**
+  Runtime and source-generated ordered itineraries that record message progress in headers.
+
 - **[TypeDispatcher](behavioral/type-dispatcher/index.md)**
   Type-safe runtime dispatch that routes objects to handlers based on their concrete type.
 

--- a/docs/patterns/messaging/README.md
+++ b/docs/patterns/messaging/README.md
@@ -14,6 +14,12 @@ Content router, recipient list, splitter, and aggregator primitives model common
 
 [Learn More](message-routing.md)
 
+## Routing Slip
+
+Runtime and source-generated routing slip factories execute named message itineraries in order and record progress in message headers.
+
+[Learn More](routing-slip.md)
+
 ## Mediator (Source Generated)
 
 A **zero-dependency**, **source-generated Mediator pattern** implementation for commands, notifications, and streams.
@@ -71,6 +77,7 @@ The Source-Generated Mediator complements other PatternKit patterns:
 
 - **[Message Envelope and Context](message-envelope.md)** - Shared metadata for routers, routing slips, sagas, mailboxes, and idempotent receivers
 - **[Enterprise Message Routing](message-routing.md)** - Content-based router, recipient list, splitter, and aggregator primitives
+- **[Routing Slip](routing-slip.md)** - Ordered message itineraries with fluent runtime and source-generated factories
 - **[Runtime Mediator](../behavioral/mediator/index.md)** - Pre-built mediator with PatternKit runtime (use for application code)
 - **Observer** - For reactive event handling and pub/sub
 - **Command** - For encapsulating requests as objects

--- a/docs/patterns/messaging/routing-slip.md
+++ b/docs/patterns/messaging/routing-slip.md
@@ -1,0 +1,93 @@
+# Routing Slip
+
+The Routing Slip pattern carries an ordered itinerary with a message and executes each named step in sequence. PatternKit provides a runtime fluent API and a source generator for static, compile-time validated slip factories.
+
+Use routing slips when the workflow is dynamic enough to be modeled as an itinerary, but still runs inside one process behind a queue consumer, API handler, background worker, or dispatcher handler.
+
+These APIs do not persist workflow progress across process restarts and do not provide broker delivery guarantees. Use durable workflow infrastructure when a slip must survive process failure.
+
+## Runtime API
+
+```csharp
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+var slip = RoutingSlip<Order>.Create()
+    .Step("validate", (message, context) => message)
+    .Step("ship", (message, context) => message)
+    .Build();
+
+var result = slip.Execute(Message<Order>.Create(order));
+```
+
+`RoutingSlip<TPayload>` executes each step synchronously and returns a `RoutingSlipResult<TPayload>` with the final message and completed step names.
+
+`AsyncRoutingSlip<TPayload>` provides the same itinerary model for asynchronous handlers:
+
+```csharp
+var slip = AsyncRoutingSlip<Order>.Create()
+    .Step("validate", (message, context, cancellationToken) => new ValueTask<Message<Order>>(message))
+    .Build();
+```
+
+## Headers
+
+Routing slips write progress into message headers:
+
+- `MessageHeaderNames.RoutingSlip` contains the itinerary names.
+- `MessageHeaderNames.RoutingSlipIndex` contains the current step index during execution and the completed count after execution.
+- `MessageHeaderNames.RoutingSlipCompleted` contains the completed step names after execution.
+
+Handlers receive a `MessageContext` whose headers match the current message state before that step runs.
+
+## Source Generator
+
+Use `[GenerateRoutingSlip]` on a partial class or struct, then mark static step methods with `[RoutingSlipStep]`.
+
+```csharp
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+[GenerateRoutingSlip(typeof(Order))]
+public static partial class OrderSlip
+{
+    [RoutingSlipStep("validate", 10)]
+    private static Message<Order> Validate(Message<Order> message, MessageContext context) => message;
+
+    [RoutingSlipStep("ship", 20)]
+    private static Message<Order> Ship(Message<Order> message, MessageContext context) => message;
+}
+
+var result = OrderSlip.Create().Execute(Message<Order>.Create(order));
+```
+
+Generated sync steps must be static and have this shape:
+
+```csharp
+Message<TPayload> Step(Message<TPayload> message, MessageContext context)
+```
+
+Generated async steps must be static and have this shape:
+
+```csharp
+ValueTask<Message<TPayload>> StepAsync(
+    Message<TPayload> message,
+    MessageContext context,
+    CancellationToken cancellationToken)
+```
+
+The generator orders steps by `RoutingSlipStepAttribute.Order` and emits diagnostics for non-partial slip types, missing steps, and invalid step signatures.
+
+## API
+
+- <xref:PatternKit.Messaging.Routing.RoutingSlip`1>
+- <xref:PatternKit.Messaging.Routing.AsyncRoutingSlip`1>
+- <xref:PatternKit.Messaging.Routing.RoutingSlipResult`1>
+- <xref:PatternKit.Messaging.MessageHeaderNames>
+- <xref:PatternKit.Generators.Messaging.GenerateRoutingSlipAttribute>
+- <xref:PatternKit.Generators.Messaging.RoutingSlipStepAttribute>
+
+## Example Source
+
+- `src/PatternKit.Examples/Messaging/RoutingSlipExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/RoutingSlipExampleTests.cs`

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -299,6 +299,8 @@
           href: messaging/message-envelope.md
         - name: Enterprise Message Routing
           href: messaging/message-routing.md
+        - name: Routing Slip
+          href: messaging/routing-slip.md
         - name: Source-Generated Dispatcher
           href: messaging/dispatcher.md
     - name: Type-Dispatcher

--- a/src/PatternKit.Core/Messaging/MessageHeaderNames.cs
+++ b/src/PatternKit.Core/Messaging/MessageHeaderNames.cs
@@ -25,4 +25,13 @@ public static class MessageHeaderNames
 
     /// <summary>Timestamp recorded when the message was created or accepted.</summary>
     public const string Timestamp = "timestamp";
+
+    /// <summary>Routing slip itinerary carried with a message.</summary>
+    public const string RoutingSlip = "routing-slip";
+
+    /// <summary>Zero-based index of the next or current routing slip step.</summary>
+    public const string RoutingSlipIndex = "routing-slip-index";
+
+    /// <summary>Names of routing slip steps completed by the current process.</summary>
+    public const string RoutingSlipCompleted = "routing-slip-completed";
 }

--- a/src/PatternKit.Core/Messaging/Routing/AsyncRoutingSlip.cs
+++ b/src/PatternKit.Core/Messaging/Routing/AsyncRoutingSlip.cs
@@ -1,0 +1,110 @@
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Async in-process Routing Slip pattern that executes named steps in order over a message.
+/// </summary>
+public sealed class AsyncRoutingSlip<TPayload>
+{
+    /// <summary>Async step handler used by a routing slip.</summary>
+    public delegate ValueTask<Message<TPayload>> StepHandler(
+        Message<TPayload> message,
+        MessageContext context,
+        CancellationToken cancellationToken);
+
+    private readonly Step[] _steps;
+
+    private AsyncRoutingSlip(Step[] steps) => _steps = steps;
+
+    /// <summary>
+    /// Executes every configured async step and returns the final message with routing progress headers.
+    /// </summary>
+    public async ValueTask<RoutingSlipResult<TPayload>> ExecuteAsync(
+        Message<TPayload> message,
+        MessageContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var itinerary = _steps.Select(step => step.Name).ToArray();
+        var current = InitializeHeaders(message, itinerary);
+        var effectiveContext = CreateContext(current, context, cancellationToken);
+        var completed = new List<string>(_steps.Length);
+
+        for (var i = 0; i < _steps.Length; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var step = _steps[i];
+            current = UpdateProgress(current, i);
+            current = await step.Handler(current, effectiveContext.WithHeaders(current.Headers), cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Routing slip step '{step.Name}' returned null.");
+            completed.Add(step.Name);
+        }
+
+        current = current.Enrich(headers => headers
+            .With(MessageHeaderNames.RoutingSlipIndex, _steps.Length)
+            .With(MessageHeaderNames.RoutingSlipCompleted, completed.ToArray()));
+
+        return new RoutingSlipResult<TPayload>(current, completed);
+    }
+
+    /// <summary>Creates a new async routing slip builder.</summary>
+    public static Builder Create() => new();
+
+    private static MessageContext CreateContext(
+        Message<TPayload> message,
+        MessageContext? context,
+        CancellationToken cancellationToken)
+    {
+        if (context is null)
+            return MessageContext.From(message, cancellationToken);
+
+        return cancellationToken.CanBeCanceled
+            ? context.WithCancellation(cancellationToken)
+            : context;
+    }
+
+    private static Message<TPayload> InitializeHeaders(Message<TPayload> message, IReadOnlyList<string> itinerary)
+        => message.Enrich(headers => headers
+            .With(MessageHeaderNames.RoutingSlip, itinerary.ToArray())
+            .With(MessageHeaderNames.RoutingSlipIndex, 0)
+            .Without(MessageHeaderNames.RoutingSlipCompleted));
+
+    private static Message<TPayload> UpdateProgress(Message<TPayload> message, int index)
+        => message.WithHeader(MessageHeaderNames.RoutingSlipIndex, index);
+
+    private sealed class Step
+    {
+        internal Step(string name, StepHandler handler) => (Name, Handler) = (name, handler);
+
+        internal string Name { get; }
+
+        internal StepHandler Handler { get; }
+    }
+
+    /// <summary>Fluent builder for <see cref="AsyncRoutingSlip{TPayload}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<Step> _steps = new();
+
+        /// <summary>Adds a named async step to the itinerary.</summary>
+        public Builder Step(string name, StepHandler handler)
+        {
+            ValidateName(name);
+            if (handler is null)
+                throw new ArgumentNullException(nameof(handler));
+
+            _steps.Add(new Step(name, handler));
+            return this;
+        }
+
+        /// <summary>Builds an immutable async routing slip.</summary>
+        public AsyncRoutingSlip<TPayload> Build() => new(_steps.ToArray());
+
+        private static void ValidateName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Routing slip step name cannot be null, empty, or whitespace.", nameof(name));
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Routing/RoutingSlip.cs
+++ b/src/PatternKit.Core/Messaging/Routing/RoutingSlip.cs
@@ -1,0 +1,90 @@
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// In-process Routing Slip pattern that executes named steps in order over a message.
+/// </summary>
+public sealed class RoutingSlip<TPayload>
+{
+    /// <summary>Step handler used by a routing slip.</summary>
+    public delegate Message<TPayload> StepHandler(Message<TPayload> message, MessageContext context);
+
+    private readonly Step[] _steps;
+
+    private RoutingSlip(Step[] steps) => _steps = steps;
+
+    /// <summary>
+    /// Executes every configured step and returns the final message with routing progress headers.
+    /// </summary>
+    public RoutingSlipResult<TPayload> Execute(Message<TPayload> message, MessageContext? context = null)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var itinerary = _steps.Select(step => step.Name).ToArray();
+        var current = InitializeHeaders(message, itinerary);
+        var effectiveContext = context ?? MessageContext.From(current);
+        var completed = new List<string>(_steps.Length);
+
+        for (var i = 0; i < _steps.Length; i++)
+        {
+            var step = _steps[i];
+            current = UpdateProgress(current, i);
+            current = step.Handler(current, effectiveContext.WithHeaders(current.Headers))
+                ?? throw new InvalidOperationException($"Routing slip step '{step.Name}' returned null.");
+            completed.Add(step.Name);
+        }
+
+        current = current.Enrich(headers => headers
+            .With(MessageHeaderNames.RoutingSlipIndex, _steps.Length)
+            .With(MessageHeaderNames.RoutingSlipCompleted, completed.ToArray()));
+
+        return new RoutingSlipResult<TPayload>(current, completed);
+    }
+
+    /// <summary>Creates a new routing slip builder.</summary>
+    public static Builder Create() => new();
+
+    private static Message<TPayload> InitializeHeaders(Message<TPayload> message, IReadOnlyList<string> itinerary)
+        => message.Enrich(headers => headers
+            .With(MessageHeaderNames.RoutingSlip, itinerary.ToArray())
+            .With(MessageHeaderNames.RoutingSlipIndex, 0)
+            .Without(MessageHeaderNames.RoutingSlipCompleted));
+
+    private static Message<TPayload> UpdateProgress(Message<TPayload> message, int index)
+        => message.WithHeader(MessageHeaderNames.RoutingSlipIndex, index);
+
+    private sealed class Step
+    {
+        internal Step(string name, StepHandler handler) => (Name, Handler) = (name, handler);
+
+        internal string Name { get; }
+
+        internal StepHandler Handler { get; }
+    }
+
+    /// <summary>Fluent builder for <see cref="RoutingSlip{TPayload}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<Step> _steps = new();
+
+        /// <summary>Adds a named step to the itinerary.</summary>
+        public Builder Step(string name, StepHandler handler)
+        {
+            ValidateName(name);
+            if (handler is null)
+                throw new ArgumentNullException(nameof(handler));
+
+            _steps.Add(new Step(name, handler));
+            return this;
+        }
+
+        /// <summary>Builds an immutable routing slip.</summary>
+        public RoutingSlip<TPayload> Build() => new(_steps.ToArray());
+
+        private static void ValidateName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Routing slip step name cannot be null, empty, or whitespace.", nameof(name));
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Routing/RoutingSlipResult.cs
+++ b/src/PatternKit.Core/Messaging/Routing/RoutingSlipResult.cs
@@ -1,0 +1,23 @@
+namespace PatternKit.Messaging.Routing;
+
+/// <summary>
+/// Result returned after executing a routing slip.
+/// </summary>
+public sealed class RoutingSlipResult<TPayload>
+{
+    /// <summary>Creates a routing slip execution result.</summary>
+    public RoutingSlipResult(Message<TPayload> message, IEnumerable<string> completedSteps)
+    {
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        CompletedSteps = completedSteps?.ToArray() ?? throw new ArgumentNullException(nameof(completedSteps));
+    }
+
+    /// <summary>The final message after all completed steps.</summary>
+    public Message<TPayload> Message { get; }
+
+    /// <summary>Step names completed during execution.</summary>
+    public IReadOnlyList<string> CompletedSteps { get; }
+
+    /// <summary>The number of completed steps.</summary>
+    public int Count => CompletedSteps.Count;
+}

--- a/src/PatternKit.Examples/Messaging/RoutingSlipExample.cs
+++ b/src/PatternKit.Examples/Messaging/RoutingSlipExample.cs
@@ -1,0 +1,45 @@
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Demonstrates generated routing slip factories over in-process message steps.
+/// </summary>
+public static class RoutingSlipExample
+{
+    /// <summary>Runs a generated order fulfillment routing slip.</summary>
+    public static RoutingSlipSummary Run()
+    {
+        var result = OrderFulfillmentSlip.Create()
+            .Execute(Message<FulfillmentOrder>.Create(new FulfillmentOrder("order-42", "new")));
+
+        return new RoutingSlipSummary(
+            result.Message.Payload.Status,
+            result.CompletedSteps.ToArray(),
+            result.Message.Headers.GetString(MessageHeaderNames.RoutingSlipIndex)!);
+    }
+}
+
+/// <summary>Generated routing slip demo payload.</summary>
+public sealed record FulfillmentOrder(string Id, string Status);
+
+/// <summary>Generated routing slip demo summary.</summary>
+public sealed record RoutingSlipSummary(string Status, IReadOnlyList<string> Steps, string RoutingIndex);
+
+/// <summary>Generated routing slip demo itinerary.</summary>
+[GenerateRoutingSlip(typeof(FulfillmentOrder))]
+public static partial class OrderFulfillmentSlip
+{
+    [RoutingSlipStep("validate", 10)]
+    private static Message<FulfillmentOrder> Validate(Message<FulfillmentOrder> message, MessageContext context)
+        => message.WithPayload(message.Payload with { Status = "validated" });
+
+    [RoutingSlipStep("reserve-inventory", 20)]
+    private static Message<FulfillmentOrder> ReserveInventory(Message<FulfillmentOrder> message, MessageContext context)
+        => message.WithPayload(message.Payload with { Status = $"{message.Payload.Status},reserved" });
+
+    [RoutingSlipStep("ship", 30)]
+    private static Message<FulfillmentOrder> Ship(Message<FulfillmentOrder> message, MessageContext context)
+        => message.WithPayload(message.Payload with { Status = $"{message.Payload.Status},shipped" });
+}

--- a/src/PatternKit.Generators.Abstractions/Messaging/RoutingSlipAttributes.cs
+++ b/src/PatternKit.Generators.Abstractions/Messaging/RoutingSlipAttributes.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace PatternKit.Generators.Messaging;
+
+/// <summary>
+/// Generates typed factory methods for a routing slip class.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+public sealed class GenerateRoutingSlipAttribute : Attribute
+{
+    /// <summary>Creates a routing slip generator attribute.</summary>
+    public GenerateRoutingSlipAttribute(Type payloadType)
+    {
+        PayloadType = payloadType ?? throw new ArgumentNullException(nameof(payloadType));
+    }
+
+    /// <summary>Message payload type processed by generated routing slips.</summary>
+    public Type PayloadType { get; }
+
+    /// <summary>Name of the generated sync factory method.</summary>
+    public string FactoryName { get; set; } = "Create";
+
+    /// <summary>Name of the generated async factory method.</summary>
+    public string AsyncFactoryName { get; set; } = "CreateAsync";
+}
+
+/// <summary>
+/// Marks a static method as a generated routing slip step.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class RoutingSlipStepAttribute : Attribute
+{
+    /// <summary>Creates a routing slip step attribute.</summary>
+    public RoutingSlipStepAttribute(string name, int order)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Routing slip step name cannot be null, empty, or whitespace.", nameof(name));
+
+        Name = name;
+        Order = order;
+    }
+
+    /// <summary>Step name written into the routing slip itinerary.</summary>
+    public string Name { get; }
+
+    /// <summary>Step order in the generated routing slip itinerary.</summary>
+    public int Order { get; }
+}

--- a/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
@@ -158,3 +158,6 @@ PKST010 | PatternKit.Generators.State | Error | Nested types not supported for S
 PKOBS001 | PatternKit.Generators.Observer | Error | Type marked with [Observer] must be partial
 PKOBS002 | PatternKit.Generators.Observer | Error | Unable to extract payload type from [Observer] attribute
 PKOBS003 | PatternKit.Generators.Observer | Warning | Unsupported observer type or configuration
+PKRS001 | PatternKit.Generators.Messaging | Error | Routing slip type must be partial
+PKRS002 | PatternKit.Generators.Messaging | Error | Routing slip has no steps
+PKRS003 | PatternKit.Generators.Messaging | Error | Routing slip step signature is invalid

--- a/src/PatternKit.Generators/Messaging/RoutingSlipGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/RoutingSlipGenerator.cs
@@ -1,0 +1,259 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace PatternKit.Generators.Messaging;
+
+[Generator]
+public sealed class RoutingSlipGenerator : IIncrementalGenerator
+{
+    private static readonly DiagnosticDescriptor MustBePartial = new(
+        "PKRS001",
+        "Routing slip type must be partial",
+        "Type '{0}' is marked with [GenerateRoutingSlip] but is not declared as partial",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor MissingSteps = new(
+        "PKRS002",
+        "Routing slip has no steps",
+        "Type '{0}' is marked with [GenerateRoutingSlip] but does not declare any [RoutingSlipStep] methods",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor InvalidStep = new(
+        "PKRS003",
+        "Routing slip step signature is invalid",
+        "Routing slip step '{0}' must be static and return Message<TPayload> or ValueTask<Message<TPayload>> with the required message/context parameters",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var candidates = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "PatternKit.Generators.Messaging.GenerateRoutingSlipAttribute",
+            static (node, _) => node is TypeDeclarationSyntax,
+            static (ctx, _) => (Type: (INamedTypeSymbol)ctx.TargetSymbol, Node: (TypeDeclarationSyntax)ctx.TargetNode, Attributes: ctx.Attributes));
+
+        context.RegisterSourceOutput(candidates, static (spc, candidate) =>
+        {
+            var attr = candidate.Attributes.FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.GenerateRoutingSlipAttribute");
+            if (attr is null)
+                return;
+
+            Generate(spc, candidate.Type, candidate.Node, attr);
+        });
+    }
+
+    private static void Generate(
+        SourceProductionContext context,
+        INamedTypeSymbol type,
+        TypeDeclarationSyntax node,
+        AttributeData attribute)
+    {
+        if (!node.Modifiers.Any(static modifier => modifier.Text == "partial"))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustBePartial, node.Identifier.GetLocation(), type.Name));
+            return;
+        }
+
+        var payloadType = attribute.ConstructorArguments.Length == 1
+            ? attribute.ConstructorArguments[0].Value as INamedTypeSymbol
+            : null;
+        if (payloadType is null)
+            return;
+
+        var hasStepAttributes = type.GetMembers().OfType<IMethodSymbol>().Any(static method =>
+            method.GetAttributes().Any(static attr =>
+                attr.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.RoutingSlipStepAttribute"));
+        var steps = GetSteps(type, payloadType, context);
+        if (steps.Length == 0)
+        {
+            if (!hasStepAttributes)
+                context.ReportDiagnostic(Diagnostic.Create(MissingSteps, node.Identifier.GetLocation(), type.Name));
+            return;
+        }
+
+        var syncSteps = steps.Where(static step => !step.IsAsync).OrderBy(static step => step.Order).ThenBy(static step => step.Name).ToArray();
+        var asyncSteps = steps.Where(static step => step.IsAsync).OrderBy(static step => step.Order).ThenBy(static step => step.Name).ToArray();
+        var config = new RoutingSlipConfig(
+            GetNamedString(attribute, "FactoryName") ?? "Create",
+            GetNamedString(attribute, "AsyncFactoryName") ?? "CreateAsync");
+
+        context.AddSource($"{type.Name}.RoutingSlip.g.cs", SourceText.From(GenerateSource(type, payloadType, syncSteps, asyncSteps, config), Encoding.UTF8));
+    }
+
+    private static ImmutableArray<RoutingStep> GetSteps(
+        INamedTypeSymbol type,
+        INamedTypeSymbol payloadType,
+        SourceProductionContext context)
+    {
+        var builder = ImmutableArray.CreateBuilder<RoutingStep>();
+        foreach (var method in type.GetMembers().OfType<IMethodSymbol>())
+        {
+            var attr = method.GetAttributes().FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.RoutingSlipStepAttribute");
+            if (attr is null)
+                continue;
+
+            if (!TryGetStep(method, payloadType, attr, out var step))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(InvalidStep, method.Locations.FirstOrDefault(), method.Name));
+                continue;
+            }
+
+            builder.Add(step);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static bool TryGetStep(
+        IMethodSymbol method,
+        INamedTypeSymbol payloadType,
+        AttributeData attribute,
+        out RoutingStep step)
+    {
+        step = default;
+        if (!method.IsStatic || attribute.ConstructorArguments.Length != 2)
+            return false;
+
+        var name = attribute.ConstructorArguments[0].Value as string;
+        var order = attribute.ConstructorArguments[1].Value as int? ?? 0;
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        var syncReturn = IsMessageOfPayload(method.ReturnType, payloadType);
+        var asyncReturn = IsValueTaskOfMessage(method.ReturnType, payloadType);
+        if (!syncReturn && !asyncReturn)
+            return false;
+
+        if (syncReturn && method.Parameters.Length == 2 &&
+            IsMessageOfPayload(method.Parameters[0].Type, payloadType) &&
+            method.Parameters[1].Type.ToDisplayString() == "PatternKit.Messaging.MessageContext")
+        {
+            step = new RoutingStep(name!, order, method.Name, isAsync: false);
+            return true;
+        }
+
+        if (asyncReturn && method.Parameters.Length == 3 &&
+            IsMessageOfPayload(method.Parameters[0].Type, payloadType) &&
+            method.Parameters[1].Type.ToDisplayString() == "PatternKit.Messaging.MessageContext" &&
+            method.Parameters[2].Type.ToDisplayString() == "System.Threading.CancellationToken")
+        {
+            step = new RoutingStep(name!, order, method.Name, isAsync: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsMessageOfPayload(ITypeSymbol type, INamedTypeSymbol payloadType)
+        => type is INamedTypeSymbol named &&
+           named.ConstructedFrom.ToDisplayString() == "PatternKit.Messaging.Message<TPayload>" &&
+           SymbolEqualityComparer.Default.Equals(named.TypeArguments[0], payloadType);
+
+    private static bool IsValueTaskOfMessage(ITypeSymbol type, INamedTypeSymbol payloadType)
+        => type is INamedTypeSymbol named &&
+           named.ConstructedFrom.ToDisplayString() == "System.Threading.Tasks.ValueTask<TResult>" &&
+           named.TypeArguments.Length == 1 &&
+           IsMessageOfPayload(named.TypeArguments[0], payloadType);
+
+    private static string GenerateSource(
+        INamedTypeSymbol type,
+        INamedTypeSymbol payloadType,
+        IReadOnlyList<RoutingStep> syncSteps,
+        IReadOnlyList<RoutingStep> asyncSteps,
+        RoutingSlipConfig config)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+
+        var ns = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString();
+        if (ns is not null)
+        {
+            sb.Append("namespace ").Append(ns).AppendLine(";");
+            sb.AppendLine();
+        }
+
+        sb.Append("partial ").Append(GetKind(type)).Append(' ').Append(type.Name).AppendLine();
+        sb.AppendLine("{");
+        if (syncSteps.Count > 0)
+        {
+            sb.Append("    public static global::PatternKit.Messaging.Routing.RoutingSlip<")
+                .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+                .Append("> ")
+                .Append(config.FactoryName)
+                .AppendLine("()");
+            sb.AppendLine("        => global::PatternKit.Messaging.Routing.RoutingSlip<" + payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + ">.Create()");
+            foreach (var step in syncSteps)
+                sb.Append("            .Step(\"").Append(Escape(step.Name)).Append("\", ").Append(step.MethodName).AppendLine(")");
+            sb.AppendLine("            .Build();");
+            sb.AppendLine();
+        }
+
+        if (asyncSteps.Count > 0)
+        {
+            sb.Append("    public static global::PatternKit.Messaging.Routing.AsyncRoutingSlip<")
+                .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+                .Append("> ")
+                .Append(config.AsyncFactoryName)
+                .AppendLine("()");
+            sb.AppendLine("        => global::PatternKit.Messaging.Routing.AsyncRoutingSlip<" + payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + ">.Create()");
+            foreach (var step in asyncSteps)
+                sb.Append("            .Step(\"").Append(Escape(step.Name)).Append("\", ").Append(step.MethodName).AppendLine(")");
+            sb.AppendLine("            .Build();");
+        }
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string GetKind(INamedTypeSymbol type)
+        => type.TypeKind == TypeKind.Struct ? "struct" : "class";
+
+    private static string Escape(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    private static string? GetNamedString(AttributeData attribute, string name)
+    {
+        foreach (var argument in attribute.NamedArguments)
+            if (argument.Key == name)
+                return argument.Value.Value as string;
+
+        return null;
+    }
+
+    private readonly struct RoutingStep
+    {
+        public RoutingStep(string name, int order, string methodName, bool isAsync)
+            => (Name, Order, MethodName, IsAsync) = (name, order, methodName, isAsync);
+
+        public string Name { get; }
+
+        public int Order { get; }
+
+        public string MethodName { get; }
+
+        public bool IsAsync { get; }
+    }
+
+    private readonly struct RoutingSlipConfig
+    {
+        public RoutingSlipConfig(string factoryName, string asyncFactoryName)
+            => (FactoryName, AsyncFactoryName) = (factoryName, asyncFactoryName);
+
+        public string FactoryName { get; }
+
+        public string AsyncFactoryName { get; }
+    }
+}

--- a/test/PatternKit.Examples.Tests/Messaging/RoutingSlipExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/RoutingSlipExampleTests.cs
@@ -1,0 +1,16 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class RoutingSlipExampleTests
+{
+    [Fact]
+    public void Run_UsesGeneratedRoutingSlipFactory()
+    {
+        var summary = RoutingSlipExample.Run();
+
+        Assert.Equal("validated,reserved,shipped", summary.Status);
+        Assert.Equal(["validate", "reserve-inventory", "ship"], summary.Steps);
+        Assert.Equal("3", summary.RoutingIndex);
+    }
+}

--- a/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
@@ -69,6 +69,8 @@ public sealed class AbstractionsAttributeCoverageTests
         { typeof(BreadthFirstAttribute), AttributeTargets.Method, false, false },
         { typeof(TraversalChildrenAttribute), AttributeTargets.Method, false, false },
         { typeof(GenerateDispatcherAttribute), AttributeTargets.Assembly, false, true },
+        { typeof(GenerateRoutingSlipAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(RoutingSlipStepAttribute), AttributeTargets.Method, false, false },
         { typeof(ObserverAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
         { typeof(ObserverHubAttribute), AttributeTargets.Class, false, false },
         { typeof(ObservedEventAttribute), AttributeTargets.Property, false, false },
@@ -298,6 +300,12 @@ public sealed class AbstractionsAttributeCoverageTests
             IncludeStreaming = false,
             Visibility = GeneratedVisibility.Internal
         };
+        var routingSlip = new GenerateRoutingSlipAttribute(typeof(string))
+        {
+            FactoryName = "Build",
+            AsyncFactoryName = "BuildAsync"
+        };
+        var routingStep = new RoutingSlipStepAttribute("validate", 10);
 
         Assert.Equal(typeof(string), flyweight.KeyType);
         Assert.Equal("SymbolCache", flyweight.CacheTypeName);
@@ -312,6 +320,13 @@ public sealed class AbstractionsAttributeCoverageTests
         Assert.True(dispatcher.IncludeObjectOverloads);
         Assert.False(dispatcher.IncludeStreaming);
         Assert.Equal(GeneratedVisibility.Internal, dispatcher.Visibility);
+        Assert.Equal(typeof(string), routingSlip.PayloadType);
+        Assert.Equal("Build", routingSlip.FactoryName);
+        Assert.Equal("BuildAsync", routingSlip.AsyncFactoryName);
+        Assert.Equal("validate", routingStep.Name);
+        Assert.Equal(10, routingStep.Order);
+        Assert.Throws<ArgumentNullException>(() => new GenerateRoutingSlipAttribute(null!));
+        Assert.Throws<ArgumentException>(() => new RoutingSlipStepAttribute("", 1));
         Assert.IsType<FlyweightFactoryAttribute>(new FlyweightFactoryAttribute());
         Assert.IsType<IteratorStepAttribute>(new IteratorStepAttribute());
         Assert.IsType<TraversalIteratorAttribute>(new TraversalIteratorAttribute());

--- a/test/PatternKit.Generators.Tests/RoutingSlipGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/RoutingSlipGeneratorTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using PatternKit.Generators.Messaging;
+
+namespace PatternKit.Generators.Tests;
+
+public sealed class RoutingSlipGeneratorTests
+{
+    [Fact]
+    public void GeneratesSyncRoutingSlipFactory()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Status);
+
+            [GenerateRoutingSlip(typeof(Order), FactoryName = "Build")]
+            public static partial class OrderSlip
+            {
+                [RoutingSlipStep("ship", 20)]
+                private static Message<Order> Ship(Message<Order> message, MessageContext context)
+                    => message.WithPayload(message.Payload with { Status = message.Payload.Status + ",ship" });
+
+                [RoutingSlipStep("validate", 10)]
+                private static Message<Order> Validate(Message<Order> message, MessageContext context)
+                    => message.WithPayload(message.Payload with { Status = "validate" });
+            }
+
+            public static class Demo
+            {
+                public static string Run()
+                {
+                    var result = OrderSlip.Build().Execute(Message<Order>.Create(new Order("new")));
+                    return result.Message.Payload.Status;
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesSyncRoutingSlipFactory));
+        var gen = new RoutingSlipGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
+        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        Assert.Equal("OrderSlip.RoutingSlip.g.cs", generated.HintName);
+        var text = generated.SourceText.ToString();
+        Assert.Contains(".Step(\"validate\", Validate)", text);
+        Assert.Contains(".Step(\"ship\", Ship)", text);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void GeneratesAsyncRoutingSlipFactory()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Status);
+
+            [GenerateRoutingSlip(typeof(Order), AsyncFactoryName = "BuildAsync")]
+            public static partial class OrderSlip
+            {
+                [RoutingSlipStep("validate", 10)]
+                private static ValueTask<Message<Order>> ValidateAsync(Message<Order> message, MessageContext context, CancellationToken cancellationToken)
+                    => new ValueTask<Message<Order>>(message.WithPayload(message.Payload with { Status = "validate" }));
+            }
+
+            public static class Demo
+            {
+                public static async Task<string> Run()
+                {
+                    var result = await OrderSlip.BuildAsync().ExecuteAsync(Message<Order>.Create(new Order("new")));
+                    return result.Message.Payload.Status;
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesAsyncRoutingSlipFactory));
+        var gen = new RoutingSlipGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
+        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        Assert.Contains("AsyncRoutingSlip<global::MyApp.Order>", generated.SourceText.ToString());
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForNonPartialSlip()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Status);
+
+            [GenerateRoutingSlip(typeof(Order))]
+            public static class OrderSlip
+            {
+                [RoutingSlipStep("validate", 10)]
+                private static Message<Order> Validate(Message<Order> message, MessageContext context) => message;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForNonPartialSlip));
+        var gen = new RoutingSlipGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKRS001", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForMissingSteps()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Status);
+
+            [GenerateRoutingSlip(typeof(Order))]
+            public static partial class OrderSlip;
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForMissingSteps));
+        var gen = new RoutingSlipGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKRS002", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForInvalidStepSignature()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Status);
+
+            [GenerateRoutingSlip(typeof(Order))]
+            public static partial class OrderSlip
+            {
+                [RoutingSlipStep("validate", 10)]
+                private static Order Validate(Message<Order> message, MessageContext context) => message.Payload;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidStepSignature));
+        var gen = new RoutingSlipGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKRS003", diagnostic.Id);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, string assemblyName)
+        => RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName,
+            extra: MetadataReference.CreateFromFile(typeof(PatternKit.Messaging.Message<>).Assembly.Location));
+}

--- a/test/PatternKit.Tests/Messaging/Routing/RoutingSlipTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/RoutingSlipTests.cs
@@ -1,0 +1,217 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Tests.Messaging.Routing;
+
+public sealed class RoutingSlipTests
+{
+    [Fact]
+    public void Execute_RunsStepsInOrderAndReturnsFinalMessage()
+    {
+        var log = new List<string>();
+        var slip = RoutingSlip<Order>.Create()
+            .Step("validate", (m, ctx) =>
+            {
+                log.Add($"{ctx.Headers.GetString(MessageHeaderNames.RoutingSlipIndex)}:validate");
+                return m.WithPayload(m.Payload with { Status = "validated" });
+            })
+            .Step("reserve", (m, ctx) =>
+            {
+                log.Add($"{ctx.Headers.GetString(MessageHeaderNames.RoutingSlipIndex)}:reserve");
+                return m.WithPayload(m.Payload with { Status = $"{m.Payload.Status},reserved" });
+            })
+            .Build();
+
+        var result = slip.Execute(Message<Order>.Create(new Order("order-1", "new")));
+
+        Assert.Equal("validated,reserved", result.Message.Payload.Status);
+        Assert.Equal(["0:validate", "1:reserve"], log);
+        Assert.Equal(["validate", "reserve"], result.CompletedSteps);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void Execute_WritesItineraryProgressAndCompletedHeaders()
+    {
+        var slip = RoutingSlip<Order>.Create()
+            .Step("validate", (m, _) => m)
+            .Step("ship", (m, _) => m)
+            .Build();
+
+        var result = slip.Execute(Message<Order>.Create(new Order("order-1", "new")));
+
+        Assert.True(result.Message.Headers.TryGet<string[]>(MessageHeaderNames.RoutingSlip, out var itinerary));
+        Assert.True(result.Message.Headers.TryGet<string[]>(MessageHeaderNames.RoutingSlipCompleted, out var completed));
+        Assert.Equal(["validate", "ship"], itinerary!);
+        Assert.Equal(["validate", "ship"], completed!);
+        Assert.Equal(2, result.Message.Headers[MessageHeaderNames.RoutingSlipIndex]);
+    }
+
+    [Fact]
+    public void Execute_ClearsPreviousCompletedHeader()
+    {
+        var slip = RoutingSlip<Order>.Create()
+            .Step("validate", (m, _) => m)
+            .Build();
+        var message = Message<Order>
+            .Create(new Order("order-1", "new"))
+            .WithHeader(MessageHeaderNames.RoutingSlipCompleted, new[] { "old" });
+
+        var result = slip.Execute(message);
+
+        Assert.Equal(["validate"], Assert.IsType<string[]>(result.Message.Headers[MessageHeaderNames.RoutingSlipCompleted]));
+    }
+
+    [Fact]
+    public void Execute_AllowsEmptyItinerary()
+    {
+        var message = Message<Order>.Create(new Order("order-1", "new"));
+        var result = RoutingSlip<Order>.Create().Build().Execute(message);
+
+        Assert.Same(message.Payload, result.Message.Payload);
+        Assert.Empty(result.CompletedSteps);
+        Assert.Equal(0, result.Message.Headers[MessageHeaderNames.RoutingSlipIndex]);
+    }
+
+    [Fact]
+    public void Execute_RejectsNullMessage()
+    {
+        var slip = RoutingSlip<Order>.Create().Build();
+
+        Assert.Throws<ArgumentNullException>(() => slip.Execute(null!));
+    }
+
+    [Fact]
+    public void Execute_RejectsNullStepResult()
+    {
+        var slip = RoutingSlip<Order>.Create()
+            .Step("bad", (_, _) => null!)
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => slip.Execute(Message<Order>.Create(new Order("order-1", "new"))));
+    }
+
+    [Fact]
+    public void Builder_RejectsInvalidArguments()
+    {
+        var builder = RoutingSlip<Order>.Create();
+
+        Assert.Throws<ArgumentException>(() => builder.Step("", (m, _) => m));
+        Assert.Throws<ArgumentNullException>(() => builder.Step("validate", null!));
+    }
+
+    [Fact]
+    public void RoutingSlipResult_RejectsInvalidArgumentsAndCopiesSteps()
+    {
+        var steps = new List<string> { "validate" };
+        var result = new RoutingSlipResult<Order>(Message<Order>.Create(new Order("order-1", "new")), steps);
+
+        steps.Add("ship");
+
+        Assert.Equal(["validate"], result.CompletedSteps);
+        Assert.Throws<ArgumentNullException>(() => new RoutingSlipResult<Order>(null!, steps));
+        Assert.Throws<ArgumentNullException>(() => new RoutingSlipResult<Order>(Message<Order>.Create(new Order("order-1", "new")), null!));
+    }
+
+    [Fact]
+    public async Task AsyncExecute_RunsStepsInOrder()
+    {
+        var log = new List<string>();
+        var slip = AsyncRoutingSlip<Order>.Create()
+            .Step("validate", (m, _, _) =>
+            {
+                log.Add("validate");
+                return new ValueTask<Message<Order>>(m.WithPayload(m.Payload with { Status = "validated" }));
+            })
+            .Step("ship", (m, _, _) =>
+            {
+                log.Add("ship");
+                return new ValueTask<Message<Order>>(m.WithPayload(m.Payload with { Status = $"{m.Payload.Status},shipped" }));
+            })
+            .Build();
+
+        var result = await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")));
+
+        Assert.Equal(["validate", "ship"], log);
+        Assert.Equal("validated,shipped", result.Message.Payload.Status);
+        Assert.Equal(["validate", "ship"], result.CompletedSteps);
+    }
+
+    [Fact]
+    public async Task AsyncExecute_ObservesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var slip = AsyncRoutingSlip<Order>.Create()
+            .Step("validate", (m, _, _) => new ValueTask<Message<Order>>(m))
+            .Build();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")), cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task AsyncExecute_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
+    {
+        using var cts = new CancellationTokenSource();
+        var seenToken = CancellationToken.None;
+        var slip = AsyncRoutingSlip<Order>.Create()
+            .Step("validate", (m, ctx, token) =>
+            {
+                seenToken = ctx.CancellationToken;
+                Assert.Equal(CancellationToken.None, token);
+                return new ValueTask<Message<Order>>(m);
+            })
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, cts.Token);
+
+        await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")), context);
+
+        Assert.Equal(cts.Token, seenToken);
+    }
+
+    [Fact]
+    public async Task AsyncExecute_UsesExplicitCancellationTokenOverProvidedContext()
+    {
+        using var contextCts = new CancellationTokenSource();
+        using var callCts = new CancellationTokenSource();
+        var seenToken = CancellationToken.None;
+        var slip = AsyncRoutingSlip<Order>.Create()
+            .Step("validate", (m, ctx, _) =>
+            {
+                seenToken = ctx.CancellationToken;
+                return new ValueTask<Message<Order>>(m);
+            })
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, contextCts.Token);
+
+        await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")), context, callCts.Token);
+
+        Assert.Equal(callCts.Token, seenToken);
+    }
+
+    [Fact]
+    public async Task AsyncExecute_RejectsNullMessageAndStepResult()
+    {
+        var valid = AsyncRoutingSlip<Order>.Create().Build();
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await valid.ExecuteAsync(null!));
+
+        var invalid = AsyncRoutingSlip<Order>.Create()
+            .Step("bad", (_, _, _) => new ValueTask<Message<Order>>((Message<Order>)null!))
+            .Build();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await invalid.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new"))));
+    }
+
+    [Fact]
+    public void AsyncBuilder_RejectsInvalidArguments()
+    {
+        var builder = AsyncRoutingSlip<Order>.Create();
+
+        Assert.Throws<ArgumentException>(() => builder.Step("", (m, _, _) => new ValueTask<Message<Order>>(m)));
+        Assert.Throws<ArgumentNullException>(() => builder.Step("validate", null!));
+    }
+
+    private sealed record Order(string Id, string Status);
+}


### PR DESCRIPTION
## Summary
- add sync and async routing slip runtime primitives over Message<TPayload>
- add source-generator attributes and a RoutingSlipGenerator for compile-time slip factories
- add compiled examples, generator diagnostics, docs, and DocFX xrefs

## Validation
- dotnet test PatternKit.slnx --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test PatternKit.slnx --configuration Release --no-build --collect:XPlat_Code_Coverage
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- docfx metadata docs\docfx.json
- docfx build docs\docfx.json
- git diff --check

Closes #174