### PR TITLE
feat: add saga process manager runtime and generator

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -151,6 +151,9 @@ If you’re looking for end-to-end, production-shaped demos, check the **Example
 - **[Routing Slip](messaging/routing-slip.md)**
   Runtime and source-generated ordered itineraries that record message progress in headers.
 
+- **[Saga / Process Manager](messaging/saga.md)**
+  Runtime and source-generated process managers for typed message transitions over explicit state.
+
 - **[TypeDispatcher](behavioral/type-dispatcher/index.md)**
   Type-safe runtime dispatch that routes objects to handlers based on their concrete type.
 

--- a/docs/patterns/messaging/README.md
+++ b/docs/patterns/messaging/README.md
@@ -20,6 +20,12 @@ Runtime and source-generated routing slip factories execute named message itiner
 
 [Learn More](routing-slip.md)
 
+## Saga / Process Manager
+
+Runtime and source-generated process managers coordinate typed message transitions over explicit saga state.
+
+[Learn More](saga.md)
+
 ## Mediator (Source Generated)
 
 A **zero-dependency**, **source-generated Mediator pattern** implementation for commands, notifications, and streams.
@@ -78,6 +84,7 @@ The Source-Generated Mediator complements other PatternKit patterns:
 - **[Message Envelope and Context](message-envelope.md)** - Shared metadata for routers, routing slips, sagas, mailboxes, and idempotent receivers
 - **[Enterprise Message Routing](message-routing.md)** - Content-based router, recipient list, splitter, and aggregator primitives
 - **[Routing Slip](routing-slip.md)** - Ordered message itineraries with fluent runtime and source-generated factories
+- **[Saga / Process Manager](saga.md)** - Typed message transitions over explicit long-running process state
 - **[Runtime Mediator](../behavioral/mediator/index.md)** - Pre-built mediator with PatternKit runtime (use for application code)
 - **Observer** - For reactive event handling and pub/sub
 - **Command** - For encapsulating requests as objects

--- a/docs/patterns/messaging/saga.md
+++ b/docs/patterns/messaging/saga.md
@@ -1,0 +1,89 @@
+# Saga / Process Manager
+
+The Saga pattern coordinates a long-running business process by reacting to messages and advancing explicit state. PatternKit provides a small in-process saga runtime and a source generator for static, typed process-manager factories.
+
+Use these APIs when the saga state is already loaded by your application and message handling happens inside the current process. Persist state, concurrency tokens, retries, and transport delivery outside PatternKit when the workflow must survive process restarts.
+
+## Runtime API
+
+```csharp
+using PatternKit.Messaging;
+using PatternKit.Messaging.Sagas;
+
+var saga = Saga<OrderState>.Create()
+    .On<OrderSubmitted>().Then((state, message, context) =>
+        state with { OrderId = message.Payload.OrderId, Submitted = true })
+    .On<OrderPaid>().Then((state, message, context) =>
+        state with { Paid = true })
+    .CompleteWhen(state => state.Submitted && state.Paid)
+    .Build();
+
+var result = saga.Handle(state, Message<OrderSubmitted>.Create(submitted));
+```
+
+`Saga<TState>` only runs steps whose message type matches the handled message. Use `When<TMessage>` for guarded transitions.
+
+`AsyncSaga<TState>` supports asynchronous guards and handlers:
+
+```csharp
+var saga = AsyncSaga<OrderState>.Create()
+    .On<OrderSubmitted>().Then((state, message, context, cancellationToken) =>
+        new ValueTask<OrderState>(state with { Submitted = true }))
+    .Build();
+```
+
+## Source Generator
+
+Use `[GenerateSaga]` on a partial class or struct, then mark static step methods with `[SagaStep]`. Add `[SagaCompleteWhen]` to one static completion predicate when needed.
+
+```csharp
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+[GenerateSaga(typeof(OrderState))]
+public static partial class OrderSaga
+{
+    [SagaStep(typeof(OrderSubmitted), 10)]
+    private static OrderState Submit(
+        OrderState state,
+        Message<OrderSubmitted> message,
+        MessageContext context) => state with { Submitted = true };
+
+    [SagaCompleteWhen]
+    private static bool IsComplete(OrderState state) => state.Submitted;
+}
+
+var result = OrderSaga.Create().Handle(state, Message<OrderSubmitted>.Create(submitted));
+```
+
+Generated sync steps must be static and have this shape:
+
+```csharp
+TState Step(TState state, Message<TMessage> message, MessageContext context)
+```
+
+Generated async steps must be static and have this shape:
+
+```csharp
+ValueTask<TState> StepAsync(
+    TState state,
+    Message<TMessage> message,
+    MessageContext context,
+    CancellationToken cancellationToken)
+```
+
+The generator emits diagnostics for non-partial saga types, missing steps, invalid step signatures, and invalid completion predicates.
+
+## API
+
+- <xref:PatternKit.Messaging.Sagas.Saga`1>
+- <xref:PatternKit.Messaging.Sagas.AsyncSaga`1>
+- <xref:PatternKit.Messaging.Sagas.SagaResult`1>
+- <xref:PatternKit.Generators.Messaging.GenerateSagaAttribute>
+- <xref:PatternKit.Generators.Messaging.SagaStepAttribute>
+- <xref:PatternKit.Generators.Messaging.SagaCompleteWhenAttribute>
+
+## Example Source
+
+- `src/PatternKit.Examples/Messaging/SagaExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/SagaExampleTests.cs`

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -301,6 +301,8 @@
           href: messaging/message-routing.md
         - name: Routing Slip
           href: messaging/routing-slip.md
+        - name: Saga / Process Manager
+          href: messaging/saga.md
         - name: Source-Generated Dispatcher
           href: messaging/dispatcher.md
     - name: Type-Dispatcher

--- a/src/PatternKit.Core/Messaging/Sagas/AsyncSaga.cs
+++ b/src/PatternKit.Core/Messaging/Sagas/AsyncSaga.cs
@@ -1,0 +1,146 @@
+namespace PatternKit.Messaging.Sagas;
+
+/// <summary>
+/// Async in-process saga/process manager that routes typed messages to state transition handlers.
+/// </summary>
+public sealed class AsyncSaga<TState>
+{
+    /// <summary>Async predicate used to decide whether a typed saga step should handle a message.</summary>
+    public delegate ValueTask<bool> StepPredicate<TMessage>(
+        TState state,
+        Message<TMessage> message,
+        MessageContext context,
+        CancellationToken cancellationToken);
+
+    /// <summary>Async handler used to transition saga state for a typed message.</summary>
+    public delegate ValueTask<TState> StepHandler<TMessage>(
+        TState state,
+        Message<TMessage> message,
+        MessageContext context,
+        CancellationToken cancellationToken);
+
+    /// <summary>Predicate used to decide whether saga state is complete.</summary>
+    public delegate bool CompletionPredicate(TState state);
+
+    private readonly Step[] _steps;
+    private readonly CompletionPredicate _completeWhen;
+
+    private AsyncSaga(Step[] steps, CompletionPredicate completeWhen)
+        => (_steps, _completeWhen) = (steps, completeWhen);
+
+    /// <summary>
+    /// Handles <paramref name="message"/> and returns the resulting saga state.
+    /// </summary>
+    public async ValueTask<SagaResult<TState>> HandleAsync<TMessage>(
+        TState state,
+        Message<TMessage> message,
+        MessageContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = CreateContext(message, context, cancellationToken);
+        var current = state;
+        var matched = false;
+        foreach (var step in _steps)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (step.MessageType != typeof(TMessage))
+                continue;
+
+            var typed = (Step<TMessage>)step;
+            if (!await typed.Predicate(current, message, effectiveContext, cancellationToken).ConfigureAwait(false))
+                continue;
+
+            current = await typed.Handler(current, message, effectiveContext, cancellationToken).ConfigureAwait(false);
+            matched = true;
+        }
+
+        return new SagaResult<TState>(current, matched, _completeWhen(current));
+    }
+
+    /// <summary>Creates a new async saga builder.</summary>
+    public static Builder Create() => new();
+
+    private static MessageContext CreateContext<TMessage>(
+        Message<TMessage> message,
+        MessageContext? context,
+        CancellationToken cancellationToken)
+    {
+        if (context is null)
+            return MessageContext.From(message, cancellationToken);
+
+        return cancellationToken.CanBeCanceled
+            ? context.WithCancellation(cancellationToken)
+            : context;
+    }
+
+    private abstract class Step
+    {
+        protected Step(Type messageType) => MessageType = messageType;
+
+        internal Type MessageType { get; }
+    }
+
+    private sealed class Step<TMessage> : Step
+    {
+        internal Step(StepPredicate<TMessage> predicate, StepHandler<TMessage> handler)
+            : base(typeof(TMessage))
+            => (Predicate, Handler) = (predicate, handler);
+
+        internal StepPredicate<TMessage> Predicate { get; }
+
+        internal StepHandler<TMessage> Handler { get; }
+    }
+
+    /// <summary>Fluent builder for <see cref="AsyncSaga{TState}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<Step> _steps = new();
+        private CompletionPredicate _completeWhen = static _ => false;
+
+        /// <summary>Adds a typed message step.</summary>
+        public WhenBuilder<TMessage> On<TMessage>()
+            => new(this, static (_, _, _, _) => new ValueTask<bool>(true));
+
+        /// <summary>Adds a typed message step with an async guard predicate.</summary>
+        public WhenBuilder<TMessage> When<TMessage>(StepPredicate<TMessage> predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return new WhenBuilder<TMessage>(this, predicate);
+        }
+
+        /// <summary>Sets the saga completion predicate.</summary>
+        public Builder CompleteWhen(CompletionPredicate predicate)
+        {
+            _completeWhen = predicate ?? throw new ArgumentNullException(nameof(predicate));
+            return this;
+        }
+
+        /// <summary>Builds an immutable async saga process manager.</summary>
+        public AsyncSaga<TState> Build() => new(_steps.ToArray(), _completeWhen);
+
+        /// <summary>Fluent async step continuation.</summary>
+        public sealed class WhenBuilder<TMessage>
+        {
+            private readonly Builder _owner;
+            private readonly StepPredicate<TMessage> _predicate;
+
+            internal WhenBuilder(Builder owner, StepPredicate<TMessage> predicate)
+                => (_owner, _predicate) = (owner, predicate);
+
+            /// <summary>Adds the async state transition handler for this message type.</summary>
+            public Builder Then(StepHandler<TMessage> handler)
+            {
+                if (handler is null)
+                    throw new ArgumentNullException(nameof(handler));
+
+                _owner._steps.Add(new Step<TMessage>(_predicate, handler));
+                return _owner;
+            }
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Sagas/Saga.cs
+++ b/src/PatternKit.Core/Messaging/Sagas/Saga.cs
@@ -1,0 +1,123 @@
+namespace PatternKit.Messaging.Sagas;
+
+/// <summary>
+/// In-process saga/process manager that routes typed messages to state transition handlers.
+/// </summary>
+public sealed class Saga<TState>
+{
+    /// <summary>Predicate used to decide whether a typed saga step should handle a message.</summary>
+    public delegate bool StepPredicate<TMessage>(TState state, Message<TMessage> message, MessageContext context);
+
+    /// <summary>Handler used to transition saga state for a typed message.</summary>
+    public delegate TState StepHandler<TMessage>(TState state, Message<TMessage> message, MessageContext context);
+
+    /// <summary>Predicate used to decide whether saga state is complete.</summary>
+    public delegate bool CompletionPredicate(TState state);
+
+    private readonly Step[] _steps;
+    private readonly CompletionPredicate _completeWhen;
+
+    private Saga(Step[] steps, CompletionPredicate completeWhen)
+        => (_steps, _completeWhen) = (steps, completeWhen);
+
+    /// <summary>
+    /// Handles <paramref name="message"/> and returns the resulting saga state.
+    /// </summary>
+    public SagaResult<TState> Handle<TMessage>(
+        TState state,
+        Message<TMessage> message,
+        MessageContext? context = null)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = context ?? MessageContext.From(message);
+        var current = state;
+        var matched = false;
+        foreach (var step in _steps)
+        {
+            if (step.MessageType != typeof(TMessage))
+                continue;
+
+            var typed = (Step<TMessage>)step;
+            if (!typed.Predicate(current, message, effectiveContext))
+                continue;
+
+            current = typed.Handler(current, message, effectiveContext);
+            matched = true;
+        }
+
+        return new SagaResult<TState>(current, matched, _completeWhen(current));
+    }
+
+    /// <summary>Creates a new saga builder.</summary>
+    public static Builder Create() => new();
+
+    private abstract class Step
+    {
+        protected Step(Type messageType) => MessageType = messageType;
+
+        internal Type MessageType { get; }
+    }
+
+    private sealed class Step<TMessage> : Step
+    {
+        internal Step(StepPredicate<TMessage> predicate, StepHandler<TMessage> handler)
+            : base(typeof(TMessage))
+            => (Predicate, Handler) = (predicate, handler);
+
+        internal StepPredicate<TMessage> Predicate { get; }
+
+        internal StepHandler<TMessage> Handler { get; }
+    }
+
+    /// <summary>Fluent builder for <see cref="Saga{TState}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly List<Step> _steps = new();
+        private CompletionPredicate _completeWhen = static _ => false;
+
+        /// <summary>Adds a typed message step.</summary>
+        public WhenBuilder<TMessage> On<TMessage>()
+            => new(this, static (_, _, _) => true);
+
+        /// <summary>Adds a typed message step with a guard predicate.</summary>
+        public WhenBuilder<TMessage> When<TMessage>(StepPredicate<TMessage> predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return new WhenBuilder<TMessage>(this, predicate);
+        }
+
+        /// <summary>Sets the saga completion predicate.</summary>
+        public Builder CompleteWhen(CompletionPredicate predicate)
+        {
+            _completeWhen = predicate ?? throw new ArgumentNullException(nameof(predicate));
+            return this;
+        }
+
+        /// <summary>Builds an immutable saga process manager.</summary>
+        public Saga<TState> Build() => new(_steps.ToArray(), _completeWhen);
+
+        /// <summary>Fluent step continuation.</summary>
+        public sealed class WhenBuilder<TMessage>
+        {
+            private readonly Builder _owner;
+            private readonly StepPredicate<TMessage> _predicate;
+
+            internal WhenBuilder(Builder owner, StepPredicate<TMessage> predicate)
+                => (_owner, _predicate) = (owner, predicate);
+
+            /// <summary>Adds the state transition handler for this message type.</summary>
+            public Builder Then(StepHandler<TMessage> handler)
+            {
+                if (handler is null)
+                    throw new ArgumentNullException(nameof(handler));
+
+                _owner._steps.Add(new Step<TMessage>(_predicate, handler));
+                return _owner;
+            }
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Sagas/SagaResult.cs
+++ b/src/PatternKit.Core/Messaging/Sagas/SagaResult.cs
@@ -1,0 +1,20 @@
+namespace PatternKit.Messaging.Sagas;
+
+/// <summary>
+/// Result returned after a saga processes a message.
+/// </summary>
+public sealed class SagaResult<TState>
+{
+    /// <summary>Creates a saga result.</summary>
+    public SagaResult(TState state, bool matched, bool completed)
+        => (State, Matched, Completed) = (state, matched, completed);
+
+    /// <summary>The state after message processing.</summary>
+    public TState State { get; }
+
+    /// <summary><see langword="true"/> when at least one saga step handled the message.</summary>
+    public bool Matched { get; }
+
+    /// <summary><see langword="true"/> when the saga completion policy is satisfied.</summary>
+    public bool Completed { get; }
+}

--- a/src/PatternKit.Examples/Messaging/SagaExample.cs
+++ b/src/PatternKit.Examples/Messaging/SagaExample.cs
@@ -1,0 +1,52 @@
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Demonstrates a generated saga/process manager over order messages.
+/// </summary>
+public static class SagaExample
+{
+    /// <summary>Runs a small order saga.</summary>
+    public static SagaSummary Run()
+    {
+        var saga = OrderSaga.Create();
+        var started = saga.Handle(OrderSagaState.Empty, Message<OrderSubmitted>.Create(new OrderSubmitted("order-42")));
+        var paid = saga.Handle(started.State, Message<OrderPaid>.Create(new OrderPaid("order-42")));
+
+        return new SagaSummary(paid.State.OrderId!, paid.State.Submitted, paid.State.Paid, paid.Completed);
+    }
+}
+
+/// <summary>Example order saga state.</summary>
+public sealed record OrderSagaState(string? OrderId, bool Submitted, bool Paid)
+{
+    /// <summary>Initial example state.</summary>
+    public static OrderSagaState Empty { get; } = new(null, Submitted: false, Paid: false);
+}
+
+/// <summary>Example order-submitted message.</summary>
+public sealed record OrderSubmitted(string OrderId);
+
+/// <summary>Example order-paid message.</summary>
+public sealed record OrderPaid(string OrderId);
+
+/// <summary>Example saga output.</summary>
+public sealed record SagaSummary(string OrderId, bool Submitted, bool Paid, bool Completed);
+
+/// <summary>Generated example order saga.</summary>
+[GenerateSaga(typeof(OrderSagaState))]
+public static partial class OrderSaga
+{
+    [SagaStep(typeof(OrderSubmitted), 10)]
+    private static OrderSagaState Submit(OrderSagaState state, Message<OrderSubmitted> message, MessageContext context)
+        => state with { OrderId = message.Payload.OrderId, Submitted = true };
+
+    [SagaStep(typeof(OrderPaid), 20)]
+    private static OrderSagaState Pay(OrderSagaState state, Message<OrderPaid> message, MessageContext context)
+        => state.OrderId == message.Payload.OrderId ? state with { Paid = true } : state;
+
+    [SagaCompleteWhen]
+    private static bool IsComplete(OrderSagaState state) => state.Submitted && state.Paid;
+}

--- a/src/PatternKit.Generators.Abstractions/Messaging/SagaAttributes.cs
+++ b/src/PatternKit.Generators.Abstractions/Messaging/SagaAttributes.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace PatternKit.Generators.Messaging;
+
+/// <summary>
+/// Generates typed factory methods for a saga/process manager class.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+public sealed class GenerateSagaAttribute : Attribute
+{
+    /// <summary>Creates a saga generator attribute.</summary>
+    public GenerateSagaAttribute(Type stateType)
+    {
+        StateType = stateType ?? throw new ArgumentNullException(nameof(stateType));
+    }
+
+    /// <summary>Saga state type processed by generated factories.</summary>
+    public Type StateType { get; }
+
+    /// <summary>Name of the generated sync factory method.</summary>
+    public string FactoryName { get; set; } = "Create";
+
+    /// <summary>Name of the generated async factory method.</summary>
+    public string AsyncFactoryName { get; set; } = "CreateAsync";
+}
+
+/// <summary>
+/// Marks a static method as a generated saga step.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class SagaStepAttribute : Attribute
+{
+    /// <summary>Creates a saga step attribute.</summary>
+    public SagaStepAttribute(Type messageType, int order)
+    {
+        MessageType = messageType ?? throw new ArgumentNullException(nameof(messageType));
+        Order = order;
+    }
+
+    /// <summary>Message payload type handled by this step.</summary>
+    public Type MessageType { get; }
+
+    /// <summary>Step order in the generated saga builder.</summary>
+    public int Order { get; }
+}
+
+/// <summary>
+/// Marks a static method as the generated saga completion predicate.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class SagaCompleteWhenAttribute : Attribute;

--- a/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
@@ -161,3 +161,7 @@ PKOBS003 | PatternKit.Generators.Observer | Warning | Unsupported observer type 
 PKRS001 | PatternKit.Generators.Messaging | Error | Routing slip type must be partial
 PKRS002 | PatternKit.Generators.Messaging | Error | Routing slip has no steps
 PKRS003 | PatternKit.Generators.Messaging | Error | Routing slip step signature is invalid
+PKSG001 | PatternKit.Generators.Messaging | Error | Saga type must be partial
+PKSG002 | PatternKit.Generators.Messaging | Error | Saga has no steps
+PKSG003 | PatternKit.Generators.Messaging | Error | Saga step signature is invalid
+PKSG004 | PatternKit.Generators.Messaging | Error | Saga completion signature is invalid

--- a/src/PatternKit.Generators/Messaging/SagaGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/SagaGenerator.cs
@@ -1,0 +1,290 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace PatternKit.Generators.Messaging;
+
+[Generator]
+public sealed class SagaGenerator : IIncrementalGenerator
+{
+    private static readonly DiagnosticDescriptor MustBePartial = new(
+        "PKSG001",
+        "Saga type must be partial",
+        "Type '{0}' is marked with [GenerateSaga] but is not declared as partial",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor MissingSteps = new(
+        "PKSG002",
+        "Saga has no steps",
+        "Type '{0}' is marked with [GenerateSaga] but does not declare any [SagaStep] methods",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor InvalidStep = new(
+        "PKSG003",
+        "Saga step signature is invalid",
+        "Saga step '{0}' must be static and return TState or ValueTask<TState> with the required state/message/context parameters",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor InvalidCompletion = new(
+        "PKSG004",
+        "Saga completion signature is invalid",
+        "Saga completion method '{0}' must be static bool with one TState parameter",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var candidates = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "PatternKit.Generators.Messaging.GenerateSagaAttribute",
+            static (node, _) => node is TypeDeclarationSyntax,
+            static (ctx, _) => (Type: (INamedTypeSymbol)ctx.TargetSymbol, Node: (TypeDeclarationSyntax)ctx.TargetNode, Attributes: ctx.Attributes));
+
+        context.RegisterSourceOutput(candidates, static (spc, candidate) =>
+        {
+            var attr = candidate.Attributes.FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.GenerateSagaAttribute");
+            if (attr is null)
+                return;
+
+            Generate(spc, candidate.Type, candidate.Node, attr);
+        });
+    }
+
+    private static void Generate(
+        SourceProductionContext context,
+        INamedTypeSymbol type,
+        TypeDeclarationSyntax node,
+        AttributeData attribute)
+    {
+        if (!node.Modifiers.Any(static modifier => modifier.Text == "partial"))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustBePartial, node.Identifier.GetLocation(), type.Name));
+            return;
+        }
+
+        var stateType = attribute.ConstructorArguments.Length == 1
+            ? attribute.ConstructorArguments[0].Value as INamedTypeSymbol
+            : null;
+        if (stateType is null)
+            return;
+
+        var hasStepAttributes = type.GetMembers().OfType<IMethodSymbol>().Any(static method =>
+            method.GetAttributes().Any(static attr =>
+                attr.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.SagaStepAttribute"));
+        var steps = GetSteps(type, stateType, context);
+        if (steps.Length == 0)
+        {
+            if (!hasStepAttributes)
+                context.ReportDiagnostic(Diagnostic.Create(MissingSteps, node.Identifier.GetLocation(), type.Name));
+            return;
+        }
+
+        var completion = GetCompletion(type, stateType, context);
+        var syncSteps = steps.Where(static step => !step.IsAsync).OrderBy(static step => step.Order).ThenBy(static step => step.MethodName).ToArray();
+        var asyncSteps = steps.Where(static step => step.IsAsync).OrderBy(static step => step.Order).ThenBy(static step => step.MethodName).ToArray();
+        var config = new SagaConfig(
+            GetNamedString(attribute, "FactoryName") ?? "Create",
+            GetNamedString(attribute, "AsyncFactoryName") ?? "CreateAsync");
+
+        context.AddSource($"{type.Name}.Saga.g.cs", SourceText.From(GenerateSource(type, stateType, syncSteps, asyncSteps, completion, config), Encoding.UTF8));
+    }
+
+    private static ImmutableArray<SagaStep> GetSteps(
+        INamedTypeSymbol type,
+        INamedTypeSymbol stateType,
+        SourceProductionContext context)
+    {
+        var builder = ImmutableArray.CreateBuilder<SagaStep>();
+        foreach (var method in type.GetMembers().OfType<IMethodSymbol>())
+        {
+            var attr = method.GetAttributes().FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.SagaStepAttribute");
+            if (attr is null)
+                continue;
+
+            if (!TryGetStep(method, stateType, attr, out var step))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(InvalidStep, method.Locations.FirstOrDefault(), method.Name));
+                continue;
+            }
+
+            builder.Add(step);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static string? GetCompletion(
+        INamedTypeSymbol type,
+        INamedTypeSymbol stateType,
+        SourceProductionContext context)
+    {
+        foreach (var method in type.GetMembers().OfType<IMethodSymbol>())
+        {
+            if (!method.GetAttributes().Any(static attr =>
+                attr.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.SagaCompleteWhenAttribute"))
+                continue;
+
+            if (method.IsStatic &&
+                method.ReturnType.SpecialType == SpecialType.System_Boolean &&
+                method.Parameters.Length == 1 &&
+                SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, stateType))
+                return method.Name;
+
+            context.ReportDiagnostic(Diagnostic.Create(InvalidCompletion, method.Locations.FirstOrDefault(), method.Name));
+        }
+
+        return null;
+    }
+
+    private static bool TryGetStep(
+        IMethodSymbol method,
+        INamedTypeSymbol stateType,
+        AttributeData attribute,
+        out SagaStep step)
+    {
+        step = default;
+        if (!method.IsStatic || attribute.ConstructorArguments.Length != 2)
+            return false;
+
+        var messageType = attribute.ConstructorArguments[0].Value as INamedTypeSymbol;
+        var order = attribute.ConstructorArguments[1].Value as int? ?? 0;
+        if (messageType is null)
+            return false;
+
+        var syncReturn = SymbolEqualityComparer.Default.Equals(method.ReturnType, stateType);
+        var asyncReturn = IsValueTaskOfState(method.ReturnType, stateType);
+        if (!syncReturn && !asyncReturn)
+            return false;
+
+        if (syncReturn && method.Parameters.Length == 3 &&
+            SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, stateType) &&
+            IsMessageOf(method.Parameters[1].Type, messageType) &&
+            method.Parameters[2].Type.ToDisplayString() == "PatternKit.Messaging.MessageContext")
+        {
+            step = new SagaStep(messageType, order, method.Name, isAsync: false);
+            return true;
+        }
+
+        if (asyncReturn && method.Parameters.Length == 4 &&
+            SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, stateType) &&
+            IsMessageOf(method.Parameters[1].Type, messageType) &&
+            method.Parameters[2].Type.ToDisplayString() == "PatternKit.Messaging.MessageContext" &&
+            method.Parameters[3].Type.ToDisplayString() == "System.Threading.CancellationToken")
+        {
+            step = new SagaStep(messageType, order, method.Name, isAsync: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsMessageOf(ITypeSymbol type, INamedTypeSymbol messageType)
+        => type is INamedTypeSymbol named &&
+           named.ConstructedFrom.ToDisplayString() == "PatternKit.Messaging.Message<TPayload>" &&
+           SymbolEqualityComparer.Default.Equals(named.TypeArguments[0], messageType);
+
+    private static bool IsValueTaskOfState(ITypeSymbol type, INamedTypeSymbol stateType)
+        => type is INamedTypeSymbol named &&
+           named.ConstructedFrom.ToDisplayString() == "System.Threading.Tasks.ValueTask<TResult>" &&
+           named.TypeArguments.Length == 1 &&
+           SymbolEqualityComparer.Default.Equals(named.TypeArguments[0], stateType);
+
+    private static string GenerateSource(
+        INamedTypeSymbol type,
+        INamedTypeSymbol stateType,
+        IReadOnlyList<SagaStep> syncSteps,
+        IReadOnlyList<SagaStep> asyncSteps,
+        string? completionMethod,
+        SagaConfig config)
+    {
+        var stateName = stateType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+
+        if (!type.ContainingNamespace.IsGlobalNamespace)
+        {
+            sb.Append("namespace ").Append(type.ContainingNamespace.ToDisplayString()).AppendLine(";");
+            sb.AppendLine();
+        }
+
+        sb.Append("partial ").Append(GetKind(type)).Append(' ').Append(type.Name).AppendLine();
+        sb.AppendLine("{");
+        if (syncSteps.Count > 0)
+        {
+            sb.Append("    public static global::PatternKit.Messaging.Sagas.Saga<").Append(stateName).Append("> ")
+                .Append(config.FactoryName).AppendLine("()");
+            sb.AppendLine("        => global::PatternKit.Messaging.Sagas.Saga<" + stateName + ">.Create()");
+            foreach (var step in syncSteps)
+                sb.Append("            .On<").Append(step.MessageType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).Append(">().Then(").Append(step.MethodName).AppendLine(")");
+            if (completionMethod is not null)
+                sb.Append("            .CompleteWhen(").Append(completionMethod).AppendLine(")");
+            sb.AppendLine("            .Build();");
+            sb.AppendLine();
+        }
+
+        if (asyncSteps.Count > 0)
+        {
+            sb.Append("    public static global::PatternKit.Messaging.Sagas.AsyncSaga<").Append(stateName).Append("> ")
+                .Append(config.AsyncFactoryName).AppendLine("()");
+            sb.AppendLine("        => global::PatternKit.Messaging.Sagas.AsyncSaga<" + stateName + ">.Create()");
+            foreach (var step in asyncSteps)
+                sb.Append("            .On<").Append(step.MessageType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).Append(">().Then(").Append(step.MethodName).AppendLine(")");
+            if (completionMethod is not null)
+                sb.Append("            .CompleteWhen(").Append(completionMethod).AppendLine(")");
+            sb.AppendLine("            .Build();");
+        }
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string GetKind(INamedTypeSymbol type)
+        => type.TypeKind == TypeKind.Struct ? "struct" : "class";
+
+    private static string? GetNamedString(AttributeData attribute, string name)
+    {
+        foreach (var argument in attribute.NamedArguments)
+            if (argument.Key == name)
+                return argument.Value.Value as string;
+
+        return null;
+    }
+
+    private readonly struct SagaStep
+    {
+        public SagaStep(INamedTypeSymbol messageType, int order, string methodName, bool isAsync)
+            => (MessageType, Order, MethodName, IsAsync) = (messageType, order, methodName, isAsync);
+
+        public INamedTypeSymbol MessageType { get; }
+
+        public int Order { get; }
+
+        public string MethodName { get; }
+
+        public bool IsAsync { get; }
+    }
+
+    private readonly struct SagaConfig
+    {
+        public SagaConfig(string factoryName, string asyncFactoryName)
+            => (FactoryName, AsyncFactoryName) = (factoryName, asyncFactoryName);
+
+        public string FactoryName { get; }
+
+        public string AsyncFactoryName { get; }
+    }
+}

--- a/test/PatternKit.Examples.Tests/Messaging/SagaExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/SagaExampleTests.cs
@@ -1,0 +1,17 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class SagaExampleTests
+{
+    [Fact]
+    public void Run_UsesGeneratedSagaFactory()
+    {
+        var summary = SagaExample.Run();
+
+        Assert.Equal("order-42", summary.OrderId);
+        Assert.True(summary.Submitted);
+        Assert.True(summary.Paid);
+        Assert.True(summary.Completed);
+    }
+}

--- a/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
@@ -71,6 +71,9 @@ public sealed class AbstractionsAttributeCoverageTests
         { typeof(GenerateDispatcherAttribute), AttributeTargets.Assembly, false, true },
         { typeof(GenerateRoutingSlipAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
         { typeof(RoutingSlipStepAttribute), AttributeTargets.Method, false, false },
+        { typeof(GenerateSagaAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(SagaStepAttribute), AttributeTargets.Method, false, false },
+        { typeof(SagaCompleteWhenAttribute), AttributeTargets.Method, false, false },
         { typeof(ObserverAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
         { typeof(ObserverHubAttribute), AttributeTargets.Class, false, false },
         { typeof(ObservedEventAttribute), AttributeTargets.Property, false, false },
@@ -306,6 +309,12 @@ public sealed class AbstractionsAttributeCoverageTests
             AsyncFactoryName = "BuildAsync"
         };
         var routingStep = new RoutingSlipStepAttribute("validate", 10);
+        var saga = new GenerateSagaAttribute(typeof(int))
+        {
+            FactoryName = "BuildSaga",
+            AsyncFactoryName = "BuildSagaAsync"
+        };
+        var sagaStep = new SagaStepAttribute(typeof(decimal), 11);
 
         Assert.Equal(typeof(string), flyweight.KeyType);
         Assert.Equal("SymbolCache", flyweight.CacheTypeName);
@@ -325,8 +334,16 @@ public sealed class AbstractionsAttributeCoverageTests
         Assert.Equal("BuildAsync", routingSlip.AsyncFactoryName);
         Assert.Equal("validate", routingStep.Name);
         Assert.Equal(10, routingStep.Order);
+        Assert.Equal(typeof(int), saga.StateType);
+        Assert.Equal("BuildSaga", saga.FactoryName);
+        Assert.Equal("BuildSagaAsync", saga.AsyncFactoryName);
+        Assert.Equal(typeof(decimal), sagaStep.MessageType);
+        Assert.Equal(11, sagaStep.Order);
         Assert.Throws<ArgumentNullException>(() => new GenerateRoutingSlipAttribute(null!));
         Assert.Throws<ArgumentException>(() => new RoutingSlipStepAttribute("", 1));
+        Assert.Throws<ArgumentNullException>(() => new GenerateSagaAttribute(null!));
+        Assert.Throws<ArgumentNullException>(() => new SagaStepAttribute(null!, 1));
+        Assert.IsType<SagaCompleteWhenAttribute>(new SagaCompleteWhenAttribute());
         Assert.IsType<FlyweightFactoryAttribute>(new FlyweightFactoryAttribute());
         Assert.IsType<IteratorStepAttribute>(new IteratorStepAttribute());
         Assert.IsType<TraversalIteratorAttribute>(new TraversalIteratorAttribute());

--- a/test/PatternKit.Generators.Tests/SagaGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/SagaGeneratorTests.cs
@@ -1,0 +1,209 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using PatternKit.Generators.Messaging;
+
+namespace PatternKit.Generators.Tests;
+
+public sealed class SagaGeneratorTests
+{
+    [Fact]
+    public void GeneratesSyncSagaFactory()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record OrderState(string? Id, bool Started, bool Paid);
+            public sealed record Started(string OrderId);
+            public sealed record Paid(string OrderId);
+
+            [GenerateSaga(typeof(OrderState), FactoryName = "Build")]
+            public static partial class OrderSaga
+            {
+                [SagaStep(typeof(Paid), 20)]
+                private static OrderState Pay(OrderState state, Message<Paid> message, MessageContext context)
+                    => state with { Paid = true };
+
+                [SagaStep(typeof(Started), 10)]
+                private static OrderState Start(OrderState state, Message<Started> message, MessageContext context)
+                    => state with { Id = message.Payload.OrderId, Started = true };
+
+                [SagaCompleteWhen]
+                private static bool IsComplete(OrderState state) => state.Started && state.Paid;
+            }
+
+            public static class Demo
+            {
+                public static bool Run()
+                {
+                    var saga = OrderSaga.Build();
+                    var started = saga.Handle(new OrderState(null, false, false), Message<Started>.Create(new Started("order-1")));
+                    var paid = saga.Handle(started.State, Message<Paid>.Create(new Paid("order-1")));
+                    return paid.Completed;
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesSyncSagaFactory));
+        var gen = new SagaGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
+        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        var text = generated.SourceText.ToString();
+        Assert.Equal("OrderSaga.Saga.g.cs", generated.HintName);
+        Assert.Contains(".On<global::MyApp.Started>().Then(Start)", text);
+        Assert.Contains(".On<global::MyApp.Paid>().Then(Pay)", text);
+        Assert.Contains(".CompleteWhen(IsComplete)", text);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void GeneratesAsyncSagaFactory()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record OrderState(bool Started);
+            public sealed record Started(string OrderId);
+
+            [GenerateSaga(typeof(OrderState), AsyncFactoryName = "BuildAsync")]
+            public static partial class OrderSaga
+            {
+                [SagaStep(typeof(Started), 10)]
+                private static ValueTask<OrderState> StartAsync(OrderState state, Message<Started> message, MessageContext context, CancellationToken cancellationToken)
+                    => new ValueTask<OrderState>(state with { Started = true });
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesAsyncSagaFactory));
+        var gen = new SagaGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
+        Assert.Contains("AsyncSaga<global::MyApp.OrderState>", Assert.Single(run.Results.SelectMany(result => result.GeneratedSources)).SourceText.ToString());
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForNonPartialSaga()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record OrderState(bool Started);
+            public sealed record Started(string OrderId);
+
+            [GenerateSaga(typeof(OrderState))]
+            public static class OrderSaga
+            {
+                [SagaStep(typeof(Started), 10)]
+                private static OrderState Start(OrderState state, Message<Started> message, MessageContext context) => state;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForNonPartialSaga));
+        var gen = new SagaGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        Assert.Equal("PKSG001", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForMissingSteps()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+
+            namespace MyApp;
+
+            public sealed record OrderState(bool Started);
+
+            [GenerateSaga(typeof(OrderState))]
+            public static partial class OrderSaga;
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForMissingSteps));
+        var gen = new SagaGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        Assert.Equal("PKSG002", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForInvalidStepSignature()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record OrderState(bool Started);
+            public sealed record Started(string OrderId);
+
+            [GenerateSaga(typeof(OrderState))]
+            public static partial class OrderSaga
+            {
+                [SagaStep(typeof(Started), 10)]
+                private static Started Start(OrderState state, Message<Started> message, MessageContext context) => message.Payload;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidStepSignature));
+        var gen = new SagaGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        Assert.Equal("PKSG003", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForInvalidCompletionSignature()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record OrderState(bool Started);
+            public sealed record Started(string OrderId);
+
+            [GenerateSaga(typeof(OrderState))]
+            public static partial class OrderSaga
+            {
+                [SagaStep(typeof(Started), 10)]
+                private static OrderState Start(OrderState state, Message<Started> message, MessageContext context) => state;
+
+                [SagaCompleteWhen]
+                private static OrderState IsComplete(OrderState state) => state;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidCompletionSignature));
+        var gen = new SagaGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        Assert.Equal("PKSG004", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, string assemblyName)
+        => RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName,
+            extra: MetadataReference.CreateFromFile(typeof(PatternKit.Messaging.Message<>).Assembly.Location));
+}

--- a/test/PatternKit.Tests/Messaging/Sagas/SagaTests.cs
+++ b/test/PatternKit.Tests/Messaging/Sagas/SagaTests.cs
@@ -1,0 +1,197 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Sagas;
+
+namespace PatternKit.Tests.Messaging.Sagas;
+
+public sealed class SagaTests
+{
+    [Fact]
+    public void Handle_AppliesMatchingTypedStepsInOrder()
+    {
+        var saga = Saga<OrderState>.Create()
+            .On<OrderStarted>().Then((state, message, _) => state with { OrderId = message.Payload.OrderId, Started = true })
+            .On<PaymentAccepted>().Then((state, _, _) => state with { Paid = true })
+            .CompleteWhen(static state => state.Started && state.Paid)
+            .Build();
+
+        var started = saga.Handle(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")));
+        var paid = saga.Handle(started.State, Message<PaymentAccepted>.Create(new PaymentAccepted("order-1")));
+
+        Assert.True(started.Matched);
+        Assert.False(started.Completed);
+        Assert.Equal("order-1", started.State.OrderId);
+        Assert.True(paid.Matched);
+        Assert.True(paid.Completed);
+        Assert.True(paid.State.Paid);
+    }
+
+    [Fact]
+    public void Handle_UsesGuardPredicate()
+    {
+        var saga = Saga<OrderState>.Create()
+            .When<PaymentAccepted>((state, message, _) => state.OrderId == message.Payload.OrderId)
+            .Then((state, _, _) => state with { Paid = true })
+            .Build();
+
+        var result = saga.Handle(new OrderState("order-1", Started: true, Paid: false), Message<PaymentAccepted>.Create(new PaymentAccepted("order-2")));
+
+        Assert.False(result.Matched);
+        Assert.False(result.State.Paid);
+    }
+
+    [Fact]
+    public void Handle_ReturnsUnmatchedForUnknownMessageType()
+    {
+        var saga = Saga<OrderState>.Create()
+            .On<OrderStarted>().Then((state, _, _) => state with { Started = true })
+            .Build();
+
+        var result = saga.Handle(OrderState.Empty, Message<PaymentAccepted>.Create(new PaymentAccepted("order-1")));
+
+        Assert.False(result.Matched);
+        Assert.Equal(OrderState.Empty, result.State);
+    }
+
+    [Fact]
+    public void Handle_PassesMessageContext()
+    {
+        var saga = Saga<OrderState>.Create()
+            .On<OrderStarted>().Then((state, _, context) => state with { OrderId = context.Headers.CorrelationId })
+            .Build();
+        var message = Message<OrderStarted>.Create(new OrderStarted("order-1")).WithCorrelationId("corr-1");
+
+        var result = saga.Handle(OrderState.Empty, message);
+
+        Assert.Equal("corr-1", result.State.OrderId);
+    }
+
+    [Fact]
+    public void Handle_RejectsNullMessage()
+    {
+        var saga = Saga<OrderState>.Create().Build();
+
+        Assert.Throws<ArgumentNullException>(() => saga.Handle(OrderState.Empty, (Message<OrderStarted>)null!));
+    }
+
+    [Fact]
+    public void Builder_RejectsNullDelegates()
+    {
+        var builder = Saga<OrderState>.Create();
+
+        Assert.Throws<ArgumentNullException>(() => builder.When<OrderStarted>(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.On<OrderStarted>().Then(null!));
+    }
+
+    [Fact]
+    public async Task AsyncHandle_AppliesMatchingTypedStepsInOrder()
+    {
+        var saga = AsyncSaga<OrderState>.Create()
+            .On<OrderStarted>().Then((state, message, _, _) => new ValueTask<OrderState>(state with { OrderId = message.Payload.OrderId, Started = true }))
+            .On<PaymentAccepted>().Then((state, _, _, _) => new ValueTask<OrderState>(state with { Paid = true }))
+            .CompleteWhen(static state => state.Started && state.Paid)
+            .Build();
+
+        var started = await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")));
+        var paid = await saga.HandleAsync(started.State, Message<PaymentAccepted>.Create(new PaymentAccepted("order-1")));
+
+        Assert.True(started.Matched);
+        Assert.False(started.Completed);
+        Assert.True(paid.Completed);
+        Assert.True(paid.State.Paid);
+    }
+
+    [Fact]
+    public async Task AsyncHandle_UsesGuardPredicate()
+    {
+        var saga = AsyncSaga<OrderState>.Create()
+            .When<PaymentAccepted>((state, message, _, _) => new ValueTask<bool>(state.OrderId == message.Payload.OrderId))
+            .Then((state, _, _, _) => new ValueTask<OrderState>(state with { Paid = true }))
+            .Build();
+
+        var result = await saga.HandleAsync(new OrderState("order-1", Started: true, Paid: false), Message<PaymentAccepted>.Create(new PaymentAccepted("order-2")));
+
+        Assert.False(result.Matched);
+        Assert.False(result.State.Paid);
+    }
+
+    [Fact]
+    public async Task AsyncHandle_ObservesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var saga = AsyncSaga<OrderState>.Create()
+            .On<OrderStarted>().Then((state, _, _, _) => new ValueTask<OrderState>(state with { Started = true }))
+            .Build();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")), cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task AsyncHandle_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
+    {
+        using var cts = new CancellationTokenSource();
+        var seenToken = CancellationToken.None;
+        var saga = AsyncSaga<OrderState>.Create()
+            .On<OrderStarted>().Then((state, _, context, token) =>
+            {
+                seenToken = context.CancellationToken;
+                Assert.Equal(CancellationToken.None, token);
+                return new ValueTask<OrderState>(state);
+            })
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, cts.Token);
+
+        await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")), context);
+
+        Assert.Equal(cts.Token, seenToken);
+    }
+
+    [Fact]
+    public async Task AsyncHandle_UsesExplicitCancellationTokenOverProvidedContext()
+    {
+        using var contextCts = new CancellationTokenSource();
+        using var callCts = new CancellationTokenSource();
+        var seenToken = CancellationToken.None;
+        var saga = AsyncSaga<OrderState>.Create()
+            .On<OrderStarted>().Then((state, _, context, _) =>
+            {
+                seenToken = context.CancellationToken;
+                return new ValueTask<OrderState>(state);
+            })
+            .Build();
+        var context = new MessageContext(MessageHeaders.Empty, contextCts.Token);
+
+        await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")), context, callCts.Token);
+
+        Assert.Equal(callCts.Token, seenToken);
+    }
+
+    [Fact]
+    public async Task AsyncHandle_RejectsNullMessage()
+    {
+        var saga = AsyncSaga<OrderState>.Create().Build();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await saga.HandleAsync(OrderState.Empty, (Message<OrderStarted>)null!));
+    }
+
+    [Fact]
+    public void AsyncBuilder_RejectsNullDelegates()
+    {
+        var builder = AsyncSaga<OrderState>.Create();
+
+        Assert.Throws<ArgumentNullException>(() => builder.When<OrderStarted>(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.On<OrderStarted>().Then(null!));
+    }
+
+    private sealed record OrderState(string? OrderId, bool Started, bool Paid)
+    {
+        public static OrderState Empty { get; } = new(null, Started: false, Paid: false);
+    }
+
+    private sealed record OrderStarted(string OrderId);
+
+    private sealed record PaymentAccepted(string OrderId);
+}


### PR DESCRIPTION
## Summary
- add sync and async saga/process-manager runtime primitives over typed messages
- add source-generator attributes and SagaGenerator for compile-time saga factories
- add compiled examples, generator diagnostics, docs, and DocFX xrefs

## Validation
- dotnet test test\PatternKit.Tests\PatternKit.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test PatternKit.slnx --configuration Release --no-build --collect:XPlat_Code_Coverage
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- docfx metadata docs\docfx.json
- docfx build docs\docfx.json
- git diff --check

Closes #175