### PR TITLE
feat: add mailbox serialized inbox

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -154,6 +154,9 @@ If you’re looking for end-to-end, production-shaped demos, check the **Example
 - **[Saga / Process Manager](messaging/saga.md)**
   Runtime and source-generated process managers for typed message transitions over explicit state.
 
+- **[Mailbox](messaging/mailbox.md)**
+  Serialized in-process inboxes with bounded backpressure, error policy, and shutdown behavior.
+
 - **[TypeDispatcher](behavioral/type-dispatcher/index.md)**
   Type-safe runtime dispatch that routes objects to handlers based on their concrete type.
 

--- a/docs/patterns/messaging/README.md
+++ b/docs/patterns/messaging/README.md
@@ -26,6 +26,12 @@ Runtime and source-generated process managers coordinate typed message transitio
 
 [Learn More](saga.md)
 
+## Mailbox
+
+Bounded or unbounded in-process inboxes serialize async message handling through a single consumer, with explicit backpressure, error, lifecycle, and diagnostics policies.
+
+[Learn More](mailbox.md)
+
 ## Mediator (Source Generated)
 
 A **zero-dependency**, **source-generated Mediator pattern** implementation for commands, notifications, and streams.
@@ -85,6 +91,7 @@ The Source-Generated Mediator complements other PatternKit patterns:
 - **[Enterprise Message Routing](message-routing.md)** - Content-based router, recipient list, splitter, and aggregator primitives
 - **[Routing Slip](routing-slip.md)** - Ordered message itineraries with fluent runtime and source-generated factories
 - **[Saga / Process Manager](saga.md)** - Typed message transitions over explicit long-running process state
+- **[Mailbox](mailbox.md)** - Serialized in-process inbox with bounded backpressure and shutdown behavior
 - **[Runtime Mediator](../behavioral/mediator/index.md)** - Pre-built mediator with PatternKit runtime (use for application code)
 - **Observer** - For reactive event handling and pub/sub
 - **Command** - For encapsulating requests as objects

--- a/docs/patterns/messaging/mailbox.md
+++ b/docs/patterns/messaging/mailbox.md
@@ -1,0 +1,102 @@
+# Mailbox
+
+The Mailbox pattern gives one in-process consumer exclusive access to a stream of messages. PatternKit's mailbox is a lightweight serialized inbox for background workers, queue consumers, and application services that need ordered, non-concurrent handling without adopting an actor framework.
+
+Use a mailbox when work can stay in memory and must not run concurrently inside one process. Use an external queue or actor runtime when messages must survive process failure, cross process boundaries, rebalance across nodes, or participate in broker delivery guarantees.
+
+## Runtime API
+
+```csharp
+using PatternKit.Messaging;
+using PatternKit.Messaging.Mailboxes;
+
+using var mailbox = Mailbox<OrderWork>.Create(async (message, context, cancellationToken) =>
+    {
+        await HandleOrderAsync(message.Payload, cancellationToken);
+    })
+    .Bounded(capacity: 128, MailboxBackpressurePolicy.Wait)
+    .OnError(MailboxErrorPolicy.Continue)
+    .Build();
+
+await mailbox.StartAsync();
+await mailbox.PostAsync(Message<OrderWork>.Create(work));
+await mailbox.StopAsync();
+```
+
+`Mailbox<TPayload>` processes accepted messages through a single-consumer pump. Handlers never run concurrently for the same mailbox, and `StopAsync()` drains queued messages by default.
+
+## Capacity and Backpressure
+
+Mailboxes are unbounded unless configured with `Bounded`:
+
+```csharp
+var mailbox = Mailbox<OrderWork>.Create(handler)
+    .Bounded(32, MailboxBackpressurePolicy.Reject)
+    .Build();
+```
+
+Backpressure policies are explicit:
+
+- `Wait` waits for queue space or enqueue cancellation.
+- `Reject` returns `MailboxPostStatus.Rejected` when the queue is full.
+- `DropNewest` drops the incoming message.
+- `DropOldest` drops the oldest queued message and accepts the incoming message.
+
+`MailboxPostResult` reports whether a post was accepted, rejected, or dropped. Accepted messages receive a monotonic mailbox sequence number.
+
+## Error Handling
+
+By default, a handler failure stops the mailbox and drops queued messages. Configure `Continue` and an error handler when later messages should still run:
+
+```csharp
+var mailbox = Mailbox<OrderWork>.Create(handler)
+    .OnError(MailboxErrorPolicy.Continue, async (exception, message, context, cancellationToken) =>
+    {
+        await WriteDeadLetterAsync(message, exception, cancellationToken);
+    })
+    .Build();
+```
+
+Error callbacks are in-process hooks. They are useful for logs, dead-letter adapters, and counters, but they are not durable storage.
+
+## Lifecycle and Shutdown
+
+Call `StartAsync()` before posting. Call `StopAsync()` during shutdown:
+
+- `StopAsync()` stops accepting new posts and drains queued messages.
+- `StopAsync(drain: false)` drops queued messages and cancels the current handler through the handler cancellation token.
+
+Message contexts are preserved. If the supplied `MessageContext` has a cancellation token, the mailbox links it with the mailbox stop token before invoking the handler.
+
+## Metrics Hooks
+
+`OnEvent` exposes lightweight lifecycle, enqueue, processing, drop, and failure events without taking a dependency on a metrics library:
+
+```csharp
+var mailbox = Mailbox<OrderWork>.Create(handler)
+    .OnEvent(evt => counters.Record(evt.Kind, evt.QueuedCount))
+    .Build();
+```
+
+## Choosing Related Patterns
+
+- Use `Mailbox<TPayload>` when one in-process consumer must serialize work.
+- Use [Observer](../behavioral/observer/index.md) when subscribers react to notifications and independent handlers may run separately.
+- Use [Mediator](../behavioral/mediator/index.md) or [Source-Generated Dispatcher](dispatcher.md) when the goal is request/notification routing, not serialized queueing.
+- Use [Enterprise Message Routing](message-routing.md) when messages need deterministic route selection, fan-out, splitting, or aggregation.
+- Use external queues when durability, retries across process restarts, visibility timeouts, or cross-service delivery matter.
+
+## API
+
+- <xref:PatternKit.Messaging.Mailboxes.Mailbox`1>
+- <xref:PatternKit.Messaging.Mailboxes.MailboxBackpressurePolicy>
+- <xref:PatternKit.Messaging.Mailboxes.MailboxErrorPolicy>
+- <xref:PatternKit.Messaging.Mailboxes.MailboxPostResult>
+- <xref:PatternKit.Messaging.Mailboxes.MailboxPostStatus>
+- <xref:PatternKit.Messaging.Mailboxes.MailboxEvent>
+- <xref:PatternKit.Messaging.Mailboxes.MailboxEventKind>
+
+## Example Source
+
+- `src/PatternKit.Examples/Messaging/MailboxExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/MailboxExampleTests.cs`

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -303,6 +303,8 @@
           href: messaging/routing-slip.md
         - name: Saga / Process Manager
           href: messaging/saga.md
+        - name: Mailbox
+          href: messaging/mailbox.md
         - name: Source-Generated Dispatcher
           href: messaging/dispatcher.md
     - name: Type-Dispatcher

--- a/src/PatternKit.Core/Messaging/Mailboxes/Mailbox.cs
+++ b/src/PatternKit.Core/Messaging/Mailboxes/Mailbox.cs
@@ -1,0 +1,478 @@
+namespace PatternKit.Messaging.Mailboxes;
+
+/// <summary>
+/// In-process mailbox that serializes asynchronous message handling through a single consumer.
+/// </summary>
+/// <typeparam name="TPayload">The payload type accepted by the mailbox.</typeparam>
+public sealed class Mailbox<TPayload> : IDisposable
+{
+    /// <summary>Async message handler used by a mailbox.</summary>
+    public delegate ValueTask MessageHandler(
+        Message<TPayload> message,
+        MessageContext context,
+        CancellationToken cancellationToken);
+
+    /// <summary>Async error handler used when mailbox message handling fails.</summary>
+    public delegate ValueTask ErrorHandler(
+        Exception exception,
+        Message<TPayload> message,
+        MessageContext context,
+        CancellationToken cancellationToken);
+
+    private readonly object _gate = new();
+    private readonly Queue<Envelope> _queue = new();
+    private readonly SemaphoreSlim _available = new(0);
+    private readonly SemaphoreSlim? _waitSlots;
+    private readonly MessageHandler _handler;
+    private readonly ErrorHandler? _errorHandler;
+    private readonly Action<MailboxEvent>? _eventSink;
+    private readonly int? _capacity;
+    private readonly MailboxBackpressurePolicy _backpressurePolicy;
+    private readonly MailboxErrorPolicy _errorPolicy;
+    private CancellationTokenSource? _stopSource;
+    private Task? _pump;
+    private bool _accepting;
+    private bool _disposed;
+    private long _nextSequence;
+
+    private Mailbox(
+        MessageHandler handler,
+        int? capacity,
+        MailboxBackpressurePolicy backpressurePolicy,
+        MailboxErrorPolicy errorPolicy,
+        ErrorHandler? errorHandler,
+        Action<MailboxEvent>? eventSink)
+    {
+        _handler = handler;
+        _capacity = capacity;
+        _backpressurePolicy = backpressurePolicy;
+        _errorPolicy = errorPolicy;
+        _errorHandler = errorHandler;
+        _eventSink = eventSink;
+        _waitSlots = capacity is null || backpressurePolicy != MailboxBackpressurePolicy.Wait
+            ? null
+            : new SemaphoreSlim(capacity.Value, capacity.Value);
+    }
+
+    /// <summary>The configured bounded capacity, or null for an unbounded mailbox.</summary>
+    public int? Capacity => _capacity;
+
+    /// <summary>The current queued message count.</summary>
+    public int QueuedCount
+    {
+        get
+        {
+            lock (_gate)
+                return _queue.Count;
+        }
+    }
+
+    /// <summary>Gets whether the mailbox is accepting posts.</summary>
+    public bool IsAccepting
+    {
+        get
+        {
+            lock (_gate)
+                return _accepting;
+        }
+    }
+
+    /// <summary>Creates a mailbox builder with the supplied handler.</summary>
+    public static Builder Create(MessageHandler handler) => new(handler);
+
+    /// <summary>Starts the mailbox single-consumer pump.</summary>
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            if (_pump is { IsCompleted: false })
+                return default;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            _stopSource?.Dispose();
+            _stopSource = new CancellationTokenSource();
+            _accepting = true;
+            _pump = Task.Run(ProcessAsync);
+        }
+
+        Emit(MailboxEventKind.Started, 0);
+        return default;
+    }
+
+    /// <summary>
+    /// Posts a message to the mailbox.
+    /// </summary>
+    public async ValueTask<MailboxPostResult> PostAsync(
+        Message<TPayload> message,
+        MessageContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        ThrowIfDisposed();
+
+        if (_waitSlots is not null)
+            return await PostWithWaitAsync(message, context, cancellationToken).ConfigureAwait(false);
+
+        return PostWithoutWait(message, context, cancellationToken);
+    }
+
+    /// <summary>
+    /// Stops the mailbox and optionally drains queued messages before completing.
+    /// </summary>
+    public async ValueTask StopAsync(bool drain = true, CancellationToken cancellationToken = default)
+    {
+        Task? pump;
+        CancellationTokenSource? stopSource;
+
+        lock (_gate)
+        {
+            _accepting = false;
+            pump = _pump;
+            stopSource = _stopSource;
+
+            if (!drain)
+            {
+                while (_queue.Count > 0)
+                {
+                    var dropped = _queue.Dequeue();
+                    CompleteDropped(dropped, "mailbox-stopped");
+                }
+
+                stopSource?.Cancel();
+            }
+        }
+
+        _available.Release();
+
+        if (pump is not null)
+            await WaitForPumpAsync(pump, cancellationToken).ConfigureAwait(false);
+
+        stopSource?.Dispose();
+        lock (_gate)
+        {
+            if (ReferenceEquals(_stopSource, stopSource))
+                _stopSource = null;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _stopSource?.Cancel();
+        _available.Dispose();
+        _waitSlots?.Dispose();
+        _stopSource?.Dispose();
+    }
+
+    private async ValueTask<MailboxPostResult> PostWithWaitAsync(
+        Message<TPayload> message,
+        MessageContext? context,
+        CancellationToken cancellationToken)
+    {
+        await _waitSlots!.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            lock (_gate)
+            {
+                if (!_accepting)
+                {
+                    _waitSlots.Release();
+                    var rejected = MailboxPostResult.Rejected("mailbox-not-accepting");
+                    Emit(MailboxEventKind.Rejected, 0);
+                    return rejected;
+                }
+
+                return EnqueueCore(message, context, slotAcquired: true);
+            }
+        }
+        catch
+        {
+            _waitSlots.Release();
+            throw;
+        }
+    }
+
+    private MailboxPostResult PostWithoutWait(
+        Message<TPayload> message,
+        MessageContext? context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            if (!_accepting)
+            {
+                Emit(MailboxEventKind.Rejected, 0);
+                return MailboxPostResult.Rejected("mailbox-not-accepting");
+            }
+
+            if (_capacity is not null && _queue.Count >= _capacity.Value)
+                return HandleFullQueue(message, context);
+
+            return EnqueueCore(message, context, slotAcquired: false);
+        }
+    }
+
+    private MailboxPostResult HandleFullQueue(Message<TPayload> message, MessageContext? context)
+    {
+        switch (_backpressurePolicy)
+        {
+            case MailboxBackpressurePolicy.Reject:
+                Emit(MailboxEventKind.Rejected, 0);
+                return MailboxPostResult.Rejected("mailbox-full");
+            case MailboxBackpressurePolicy.DropNewest:
+                Emit(MailboxEventKind.Dropped, 0);
+                return MailboxPostResult.Dropped("mailbox-full");
+            case MailboxBackpressurePolicy.DropOldest:
+                var dropped = _queue.Dequeue();
+                CompleteDropped(dropped, "mailbox-full");
+                return EnqueueCore(message, context, slotAcquired: false);
+            default:
+                throw new InvalidOperationException($"Unsupported mailbox backpressure policy '{_backpressurePolicy}'.");
+        }
+    }
+
+    private MailboxPostResult EnqueueCore(Message<TPayload> message, MessageContext? context, bool slotAcquired)
+    {
+        var sequence = ++_nextSequence;
+        _queue.Enqueue(new Envelope(sequence, message, context, slotAcquired));
+        _available.Release();
+        Emit(MailboxEventKind.Accepted, sequence);
+        return MailboxPostResult.AcceptedResult(sequence);
+    }
+
+    private async Task ProcessAsync()
+    {
+        var stopToken = _stopSource!.Token;
+
+        try
+        {
+            while (true)
+            {
+                await _available.WaitAsync(stopToken).ConfigureAwait(false);
+
+                Envelope? envelope;
+                lock (_gate)
+                {
+                    if (_queue.Count == 0)
+                    {
+                        if (!_accepting)
+                            break;
+
+                        continue;
+                    }
+
+                    envelope = _queue.Dequeue();
+                }
+
+                ReleaseSlot(envelope);
+                await ProcessEnvelopeAsync(envelope, stopToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stopToken.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            Emit(MailboxEventKind.Stopped, 0);
+        }
+    }
+
+    private async ValueTask ProcessEnvelopeAsync(Envelope envelope, CancellationToken stopToken)
+    {
+        var context = envelope.Context ?? MessageContext.From(envelope.Message);
+
+        using var linked = CreateLinkedSource(context.CancellationToken, stopToken);
+        var processingToken = linked?.Token ?? context.CancellationToken;
+        var effectiveContext = processingToken.CanBeCanceled
+            ? context.WithCancellation(processingToken)
+            : context;
+
+        Emit(MailboxEventKind.ProcessingStarted, envelope.Sequence);
+
+        try
+        {
+            await _handler(envelope.Message, effectiveContext, processingToken).ConfigureAwait(false);
+            Emit(MailboxEventKind.ProcessingCompleted, envelope.Sequence);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException || !stopToken.IsCancellationRequested)
+        {
+            Emit(MailboxEventKind.Failed, envelope.Sequence, exception);
+
+            if (_errorHandler is not null)
+                await _errorHandler(exception, envelope.Message, effectiveContext, processingToken).ConfigureAwait(false);
+
+            if (_errorPolicy == MailboxErrorPolicy.Stop)
+                StopAfterFailure();
+        }
+    }
+
+    private void StopAfterFailure()
+    {
+        lock (_gate)
+        {
+            _accepting = false;
+            while (_queue.Count > 0)
+            {
+                var dropped = _queue.Dequeue();
+                CompleteDropped(dropped, "handler-failed");
+            }
+        }
+
+        _available.Release();
+    }
+
+    private void CompleteDropped(Envelope envelope, string reason)
+    {
+        _ = reason;
+        ReleaseSlot(envelope);
+        Emit(MailboxEventKind.Dropped, envelope.Sequence);
+    }
+
+    private void ReleaseSlot(Envelope envelope)
+    {
+        if (envelope.SlotAcquired)
+            _waitSlots?.Release();
+    }
+
+    private static CancellationTokenSource? CreateLinkedSource(CancellationToken contextToken, CancellationToken stopToken)
+    {
+        if (contextToken.CanBeCanceled && stopToken.CanBeCanceled)
+            return CancellationTokenSource.CreateLinkedTokenSource(contextToken, stopToken);
+
+        if (!contextToken.CanBeCanceled && stopToken.CanBeCanceled)
+            return CancellationTokenSource.CreateLinkedTokenSource(stopToken);
+
+        return null;
+    }
+
+    private static async Task WaitForPumpAsync(Task pump, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            await pump.ConfigureAwait(false);
+            return;
+        }
+
+        var delay = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        var completed = await Task.WhenAny(pump, delay).ConfigureAwait(false);
+        if (completed == delay)
+            cancellationToken.ThrowIfCancellationRequested();
+
+        await pump.ConfigureAwait(false);
+    }
+
+    private void Emit(MailboxEventKind kind, long sequence, Exception? exception = null)
+    {
+        var sink = _eventSink;
+        if (sink is null)
+            return;
+
+        int queued;
+        lock (_gate)
+            queued = _queue.Count;
+
+        try
+        {
+            sink(new MailboxEvent(kind, sequence, queued, exception));
+        }
+        catch
+        {
+            // Diagnostics hooks must not affect mailbox processing or backpressure state.
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
+    }
+
+    private sealed class Envelope
+    {
+        internal Envelope(long sequence, Message<TPayload> message, MessageContext? context, bool slotAcquired)
+        {
+            Sequence = sequence;
+            Message = message;
+            Context = context;
+            SlotAcquired = slotAcquired;
+        }
+
+        internal long Sequence { get; }
+
+        internal Message<TPayload> Message { get; }
+
+        internal MessageContext? Context { get; }
+
+        internal bool SlotAcquired { get; }
+    }
+
+    /// <summary>Fluent builder for <see cref="Mailbox{TPayload}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly MessageHandler _handler;
+        private int? _capacity;
+        private MailboxBackpressurePolicy _backpressurePolicy = MailboxBackpressurePolicy.Wait;
+        private MailboxErrorPolicy _errorPolicy = MailboxErrorPolicy.Stop;
+        private ErrorHandler? _errorHandler;
+        private Action<MailboxEvent>? _eventSink;
+
+        internal Builder(MessageHandler handler)
+        {
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        /// <summary>Configures the mailbox as unbounded.</summary>
+        public Builder Unbounded()
+        {
+            _capacity = null;
+            _backpressurePolicy = MailboxBackpressurePolicy.Wait;
+            return this;
+        }
+
+        /// <summary>Configures a bounded mailbox capacity and backpressure policy.</summary>
+        public Builder Bounded(int capacity, MailboxBackpressurePolicy backpressurePolicy = MailboxBackpressurePolicy.Wait)
+        {
+            if (capacity <= 0)
+                throw new ArgumentOutOfRangeException(nameof(capacity), "Mailbox capacity must be greater than zero.");
+
+            _capacity = capacity;
+            _backpressurePolicy = backpressurePolicy;
+            return this;
+        }
+
+        /// <summary>Configures how handler failures affect the mailbox.</summary>
+        public Builder OnError(MailboxErrorPolicy policy, ErrorHandler? handler = null)
+        {
+            _errorPolicy = policy;
+            _errorHandler = handler;
+            return this;
+        }
+
+        /// <summary>Configures a lightweight event sink for metrics or diagnostics adapters.</summary>
+        public Builder OnEvent(Action<MailboxEvent> eventSink)
+        {
+            _eventSink = eventSink ?? throw new ArgumentNullException(nameof(eventSink));
+            return this;
+        }
+
+        /// <summary>Builds an immutable mailbox.</summary>
+        public Mailbox<TPayload> Build() => new(
+            _handler,
+            _capacity,
+            _backpressurePolicy,
+            _errorPolicy,
+            _errorHandler,
+            _eventSink);
+    }
+}

--- a/src/PatternKit.Core/Messaging/Mailboxes/MailboxBackpressurePolicy.cs
+++ b/src/PatternKit.Core/Messaging/Mailboxes/MailboxBackpressurePolicy.cs
@@ -1,0 +1,19 @@
+namespace PatternKit.Messaging.Mailboxes;
+
+/// <summary>
+/// Defines how a bounded mailbox reacts when its queue is full.
+/// </summary>
+public enum MailboxBackpressurePolicy
+{
+    /// <summary>Waits until space is available or the enqueue cancellation token is canceled.</summary>
+    Wait = 0,
+
+    /// <summary>Rejects the incoming message without enqueueing it.</summary>
+    Reject = 1,
+
+    /// <summary>Drops the incoming message without enqueueing it.</summary>
+    DropNewest = 2,
+
+    /// <summary>Drops the oldest queued message and enqueues the incoming message.</summary>
+    DropOldest = 3
+}

--- a/src/PatternKit.Core/Messaging/Mailboxes/MailboxErrorPolicy.cs
+++ b/src/PatternKit.Core/Messaging/Mailboxes/MailboxErrorPolicy.cs
@@ -1,0 +1,13 @@
+namespace PatternKit.Messaging.Mailboxes;
+
+/// <summary>
+/// Defines how a mailbox reacts when the handler throws.
+/// </summary>
+public enum MailboxErrorPolicy
+{
+    /// <summary>Stops accepting new messages after a handler failure.</summary>
+    Stop = 0,
+
+    /// <summary>Continues processing later queued messages after a handler failure.</summary>
+    Continue = 1
+}

--- a/src/PatternKit.Core/Messaging/Mailboxes/MailboxEvent.cs
+++ b/src/PatternKit.Core/Messaging/Mailboxes/MailboxEvent.cs
@@ -1,0 +1,27 @@
+namespace PatternKit.Messaging.Mailboxes;
+
+/// <summary>
+/// Lightweight mailbox event payload for diagnostics and metrics adapters.
+/// </summary>
+public sealed class MailboxEvent
+{
+    internal MailboxEvent(MailboxEventKind kind, long sequence, int queuedCount, Exception? exception = null)
+    {
+        Kind = kind;
+        Sequence = sequence;
+        QueuedCount = queuedCount;
+        Exception = exception;
+    }
+
+    /// <summary>The event kind.</summary>
+    public MailboxEventKind Kind { get; }
+
+    /// <summary>The mailbox sequence number associated with the event, or zero for lifecycle events.</summary>
+    public long Sequence { get; }
+
+    /// <summary>The queued message count observed when the event was raised.</summary>
+    public int QueuedCount { get; }
+
+    /// <summary>The exception associated with a failure event.</summary>
+    public Exception? Exception { get; }
+}

--- a/src/PatternKit.Core/Messaging/Mailboxes/MailboxEventKind.cs
+++ b/src/PatternKit.Core/Messaging/Mailboxes/MailboxEventKind.cs
@@ -1,0 +1,31 @@
+namespace PatternKit.Messaging.Mailboxes;
+
+/// <summary>
+/// Describes mailbox lifecycle and processing events.
+/// </summary>
+public enum MailboxEventKind
+{
+    /// <summary>The mailbox started its single-consumer pump.</summary>
+    Started = 0,
+
+    /// <summary>A message was accepted into the mailbox.</summary>
+    Accepted = 1,
+
+    /// <summary>A message was rejected because the mailbox was stopped or full.</summary>
+    Rejected = 2,
+
+    /// <summary>A message was dropped by a configured backpressure or stop policy.</summary>
+    Dropped = 3,
+
+    /// <summary>A message handler started.</summary>
+    ProcessingStarted = 4,
+
+    /// <summary>A message handler completed successfully.</summary>
+    ProcessingCompleted = 5,
+
+    /// <summary>A message handler failed.</summary>
+    Failed = 6,
+
+    /// <summary>The mailbox stopped its single-consumer pump.</summary>
+    Stopped = 7
+}

--- a/src/PatternKit.Core/Messaging/Mailboxes/MailboxPostResult.cs
+++ b/src/PatternKit.Core/Messaging/Mailboxes/MailboxPostResult.cs
@@ -1,0 +1,35 @@
+namespace PatternKit.Messaging.Mailboxes;
+
+/// <summary>
+/// Result returned when a message is posted to a mailbox.
+/// </summary>
+public sealed class MailboxPostResult
+{
+    internal MailboxPostResult(MailboxPostStatus status, long sequence, string? reason)
+    {
+        Status = status;
+        Sequence = sequence;
+        Reason = reason;
+    }
+
+    /// <summary>The post status.</summary>
+    public MailboxPostStatus Status { get; }
+
+    /// <summary>The mailbox-assigned sequence number, or zero when the message was not accepted.</summary>
+    public long Sequence { get; }
+
+    /// <summary>A short machine-readable reason for rejected or dropped posts.</summary>
+    public string? Reason { get; }
+
+    /// <summary>Gets whether the message was accepted into the mailbox.</summary>
+    public bool Accepted => Status == MailboxPostStatus.Accepted;
+
+    /// <summary>Creates an accepted result.</summary>
+    public static MailboxPostResult AcceptedResult(long sequence) => new(MailboxPostStatus.Accepted, sequence, null);
+
+    /// <summary>Creates a rejected result.</summary>
+    public static MailboxPostResult Rejected(string reason) => new(MailboxPostStatus.Rejected, 0, reason);
+
+    /// <summary>Creates a dropped result.</summary>
+    public static MailboxPostResult Dropped(string reason) => new(MailboxPostStatus.Dropped, 0, reason);
+}

--- a/src/PatternKit.Core/Messaging/Mailboxes/MailboxPostStatus.cs
+++ b/src/PatternKit.Core/Messaging/Mailboxes/MailboxPostStatus.cs
@@ -1,0 +1,16 @@
+namespace PatternKit.Messaging.Mailboxes;
+
+/// <summary>
+/// Describes the outcome of posting a message to a mailbox.
+/// </summary>
+public enum MailboxPostStatus
+{
+    /// <summary>The message was accepted into the mailbox.</summary>
+    Accepted = 0,
+
+    /// <summary>The message was rejected without being enqueued.</summary>
+    Rejected = 1,
+
+    /// <summary>The message was dropped without being processed.</summary>
+    Dropped = 2
+}

--- a/src/PatternKit.Examples/Messaging/MailboxExample.cs
+++ b/src/PatternKit.Examples/Messaging/MailboxExample.cs
@@ -1,0 +1,36 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Mailboxes;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Demonstrates a bounded mailbox that serializes background-style message handling.
+/// </summary>
+public static class MailboxExample
+{
+    /// <summary>Runs a bounded mailbox and returns the processed work item identifiers.</summary>
+    public static async ValueTask<IReadOnlyList<string>> RunAsync()
+    {
+        var processed = new List<string>();
+        using var mailbox = Mailbox<MailboxWorkItem>.Create((message, context, cancellationToken) =>
+            {
+                processed.Add($"{context.Headers.GetString(MessageHeaderNames.CorrelationId)}:{message.Payload.Id}");
+                return default;
+            })
+            .Bounded(8, MailboxBackpressurePolicy.Wait)
+            .OnError(MailboxErrorPolicy.Continue)
+            .Build();
+
+        await mailbox.StartAsync();
+
+        var context = new MessageContext(MessageHeaders.Empty.WithCorrelationId("batch-42"));
+        await mailbox.PostAsync(Message<MailboxWorkItem>.Create(new MailboxWorkItem("prepare")), context);
+        await mailbox.PostAsync(Message<MailboxWorkItem>.Create(new MailboxWorkItem("ship")), context);
+
+        await mailbox.StopAsync();
+        return processed;
+    }
+}
+
+/// <summary>Mailbox example payload.</summary>
+public sealed record MailboxWorkItem(string Id);

--- a/test/PatternKit.Examples.Tests/Messaging/MailboxExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/MailboxExampleTests.cs
@@ -1,0 +1,14 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class MailboxExampleTests
+{
+    [Fact]
+    public async Task RunAsync_ProcessesMessagesInOrder()
+    {
+        var processed = await MailboxExample.RunAsync();
+
+        Assert.Equal(["batch-42:prepare", "batch-42:ship"], processed);
+    }
+}

--- a/test/PatternKit.Tests/Messaging/Mailboxes/MailboxTests.cs
+++ b/test/PatternKit.Tests/Messaging/Mailboxes/MailboxTests.cs
@@ -1,0 +1,457 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Mailboxes;
+
+namespace PatternKit.Tests.Messaging.Mailboxes;
+
+public sealed class MailboxTests
+{
+    [Fact]
+    public async Task PostAsync_ProcessesMessagesInOrder()
+    {
+        var processed = new List<int>();
+        using var mailbox = Mailbox<int>.Create((message, _, _) =>
+            {
+                processed.Add(message.Payload);
+                return default;
+            })
+            .Build();
+
+        await mailbox.StartAsync();
+        var first = await mailbox.PostAsync(Message<int>.Create(1));
+        var second = await mailbox.PostAsync(Message<int>.Create(2));
+        await mailbox.StopAsync();
+
+        Assert.True(first.Accepted);
+        Assert.True(second.Accepted);
+        Assert.Equal([1, 2], processed);
+        Assert.Equal(1, first.Sequence);
+        Assert.Equal(2, second.Sequence);
+    }
+
+    [Fact]
+    public async Task PostAsync_SerializesConcurrentPosts()
+    {
+        var active = 0;
+        var maxActive = 0;
+        var processed = 0;
+        using var mailbox = Mailbox<int>.Create(async (_, _, _) =>
+            {
+                var nowActive = Interlocked.Increment(ref active);
+                maxActive = Math.Max(maxActive, nowActive);
+                await Task.Delay(2);
+                Interlocked.Increment(ref processed);
+                Interlocked.Decrement(ref active);
+            })
+            .Build();
+
+        await mailbox.StartAsync();
+        var posts = Enumerable.Range(0, 50)
+            .Select(value => mailbox.PostAsync(Message<int>.Create(value)).AsTask())
+            .ToArray();
+        var results = await Task.WhenAll(posts);
+        await mailbox.StopAsync();
+
+        Assert.All(results, result => Assert.True(result.Accepted));
+        Assert.Equal(50, processed);
+        Assert.Equal(1, maxActive);
+    }
+
+    [Fact]
+    public async Task BoundedRejectPolicy_RejectsWhenFull()
+    {
+        var started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var mailbox = Mailbox<int>.Create(async (message, _, _) =>
+            {
+                if (message.Payload == 1)
+                {
+                    started.SetResult(null);
+                    await release.Task;
+                }
+            })
+            .Bounded(1, MailboxBackpressurePolicy.Reject)
+            .Build();
+
+        await mailbox.StartAsync();
+        var first = await mailbox.PostAsync(Message<int>.Create(1));
+        await started.Task;
+        var second = await mailbox.PostAsync(Message<int>.Create(2));
+        var third = await mailbox.PostAsync(Message<int>.Create(3));
+        release.SetResult(null);
+        await mailbox.StopAsync();
+
+        Assert.True(first.Accepted);
+        Assert.True(second.Accepted);
+        Assert.Equal(MailboxPostStatus.Rejected, third.Status);
+        Assert.Equal("mailbox-full", third.Reason);
+    }
+
+    [Fact]
+    public async Task BoundedDropNewestPolicy_DropsIncomingWhenFull()
+    {
+        var started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processed = new List<int>();
+        using var mailbox = Mailbox<int>.Create(async (message, _, _) =>
+            {
+                processed.Add(message.Payload);
+                if (message.Payload == 1)
+                {
+                    started.SetResult(null);
+                    await release.Task;
+                }
+            })
+            .Bounded(1, MailboxBackpressurePolicy.DropNewest)
+            .Build();
+
+        await mailbox.StartAsync();
+        var first = await mailbox.PostAsync(Message<int>.Create(1));
+        await started.Task;
+        var second = await mailbox.PostAsync(Message<int>.Create(2));
+        var third = await mailbox.PostAsync(Message<int>.Create(3));
+        release.SetResult(null);
+        await mailbox.StopAsync();
+
+        Assert.True(first.Accepted);
+        Assert.True(second.Accepted);
+        Assert.Equal(MailboxPostStatus.Dropped, third.Status);
+        Assert.Equal([1, 2], processed);
+    }
+
+    [Fact]
+    public async Task BoundedDropOldestPolicy_DropsOldestQueuedMessage()
+    {
+        var started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processed = new List<int>();
+        using var mailbox = Mailbox<int>.Create(async (message, _, _) =>
+            {
+                processed.Add(message.Payload);
+                if (message.Payload == 1)
+                {
+                    started.SetResult(null);
+                    await release.Task;
+                }
+            })
+            .Bounded(1, MailboxBackpressurePolicy.DropOldest)
+            .Build();
+
+        await mailbox.StartAsync();
+        var first = await mailbox.PostAsync(Message<int>.Create(1));
+        await started.Task;
+        var second = await mailbox.PostAsync(Message<int>.Create(2));
+        var third = await mailbox.PostAsync(Message<int>.Create(3));
+        release.SetResult(null);
+        await mailbox.StopAsync();
+
+        Assert.True(first.Accepted);
+        Assert.True(second.Accepted);
+        Assert.True(third.Accepted);
+        Assert.Equal([1, 3], processed);
+    }
+
+    [Fact]
+    public async Task BoundedWaitPolicy_WaitsForQueueSpace()
+    {
+        var started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var mailbox = Mailbox<int>.Create(async (message, _, _) =>
+            {
+                if (message.Payload == 1)
+                {
+                    started.SetResult(null);
+                    await release.Task;
+                }
+            })
+            .Bounded(1)
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1));
+        await started.Task;
+        await mailbox.PostAsync(Message<int>.Create(2));
+        var third = mailbox.PostAsync(Message<int>.Create(3)).AsTask();
+
+        Assert.False(third.IsCompleted);
+
+        release.SetResult(null);
+        var result = await third;
+        await mailbox.StopAsync();
+
+        Assert.True(result.Accepted);
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenDrainFalse_DropsQueuedMessages()
+    {
+        var started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processed = new List<int>();
+        using var mailbox = Mailbox<int>.Create(async (message, _, cancellationToken) =>
+            {
+                processed.Add(message.Payload);
+                if (message.Payload == 1)
+                {
+                    started.SetResult(null);
+                    await Task.Delay(Timeout.Infinite, cancellationToken);
+                }
+            })
+            .Bounded(2, MailboxBackpressurePolicy.Reject)
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1));
+        await started.Task;
+        await mailbox.PostAsync(Message<int>.Create(2));
+        await mailbox.PostAsync(Message<int>.Create(3));
+        await mailbox.StopAsync(drain: false);
+
+        Assert.Equal([1], processed);
+    }
+
+    [Fact]
+    public async Task ErrorPolicyContinue_RoutesFailureAndContinues()
+    {
+        var errors = new List<string>();
+        var processed = new List<int>();
+        using var mailbox = Mailbox<int>.Create((message, _, _) =>
+            {
+                processed.Add(message.Payload);
+                if (message.Payload == 1)
+                    throw new InvalidOperationException("boom");
+
+                return default;
+            })
+            .OnError(
+                MailboxErrorPolicy.Continue,
+                (exception, _, _, _) =>
+                {
+                    errors.Add(exception.Message);
+                    return default;
+                })
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1));
+        await mailbox.PostAsync(Message<int>.Create(2));
+        await mailbox.StopAsync();
+
+        Assert.Equal(["boom"], errors);
+        Assert.Equal([1, 2], processed);
+    }
+
+    [Fact]
+    public async Task ErrorPolicyStop_StopsAcceptingAndDropsQueuedMessages()
+    {
+        using var mailbox = Mailbox<int>.Create((message, _, _) =>
+            {
+                if (message.Payload == 1)
+                    throw new InvalidOperationException("boom");
+
+                return default;
+            })
+            .Bounded(4, MailboxBackpressurePolicy.Reject)
+            .OnError(MailboxErrorPolicy.Stop)
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1));
+        await mailbox.PostAsync(Message<int>.Create(2));
+        await mailbox.StopAsync();
+
+        var afterFailure = await mailbox.PostAsync(Message<int>.Create(3));
+
+        Assert.Equal(MailboxPostStatus.Rejected, afterFailure.Status);
+        Assert.False(mailbox.IsAccepting);
+    }
+
+    [Fact]
+    public async Task PostAsync_PassesMessageContextAndCancellation()
+    {
+        using var source = new CancellationTokenSource();
+        var observed = CancellationToken.None;
+        var context = new MessageContext().WithItem("tenant", "north").WithCancellation(source.Token);
+        var tenant = string.Empty;
+        using var mailbox = Mailbox<int>.Create((_, ctx, cancellationToken) =>
+            {
+                observed = cancellationToken;
+                tenant = ctx.TryGetItem<string>("tenant", out var value) ? value! : string.Empty;
+                return default;
+            })
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1), context);
+        await mailbox.StopAsync();
+
+        Assert.Equal("north", tenant);
+        Assert.True(observed.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task OnEvent_ReceivesLifecycleAndProcessingEvents()
+    {
+        var events = new List<MailboxEvent>();
+        using var mailbox = Mailbox<int>.Create((_, _, _) => default)
+            .OnEvent(events.Add)
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1));
+        await mailbox.StopAsync();
+
+        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.Started);
+        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.Accepted && evt.Sequence == 1);
+        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.ProcessingStarted && evt.QueuedCount >= 0);
+        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.ProcessingCompleted && evt.Exception is null);
+        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.Stopped);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenAlreadyStarted_IsNoOp()
+    {
+        using var mailbox = Mailbox<int>.Create((_, _, _) => default).Build();
+
+        await mailbox.StartAsync();
+        await mailbox.StartAsync();
+        var result = await mailbox.PostAsync(Message<int>.Create(1));
+        await mailbox.StopAsync();
+
+        Assert.True(result.Accepted);
+    }
+
+    [Fact]
+    public async Task OnEvent_WhenSinkThrows_DoesNotAffectProcessing()
+    {
+        var acceptedEvents = 0;
+        using var mailbox = Mailbox<int>.Create((_, _, _) => default)
+            .Bounded(1)
+            .OnEvent(evt =>
+            {
+                if (evt.Kind == MailboxEventKind.Accepted && Interlocked.Increment(ref acceptedEvents) == 1)
+                {
+                    throw new InvalidOperationException("event failed");
+                }
+            })
+            .Build();
+
+        await mailbox.StartAsync();
+        var first = await mailbox.PostAsync(Message<int>.Create(1));
+        var second = await mailbox.PostAsync(Message<int>.Create(2));
+        await mailbox.StopAsync();
+
+        Assert.True(first.Accepted);
+        Assert.True(second.Accepted);
+    }
+
+    [Fact]
+    public async Task BoundedWaitPolicy_RejectsAfterStop()
+    {
+        using var mailbox = Mailbox<int>.Create((_, _, _) => default)
+            .Bounded(1)
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.StopAsync();
+        var result = await mailbox.PostAsync(Message<int>.Create(1));
+
+        Assert.Equal(MailboxPostStatus.Rejected, result.Status);
+        Assert.Equal("mailbox-not-accepting", result.Reason);
+    }
+
+    [Fact]
+    public async Task StopAsync_ObservesStopCancellation()
+    {
+        var started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var source = new CancellationTokenSource();
+        using var mailbox = Mailbox<int>.Create(async (_, _, _) =>
+            {
+                started.SetResult(null);
+                await release.Task;
+            })
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1));
+        await started.Task;
+        source.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await mailbox.StopAsync(cancellationToken: source.Token));
+
+        release.SetResult(null);
+        await mailbox.StopAsync();
+    }
+
+    [Fact]
+    public async Task Properties_ReportCapacityAndQueuedCount()
+    {
+        var started = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var mailbox = Mailbox<int>.Create(async (message, _, _) =>
+            {
+                if (message.Payload == 1)
+                {
+                    started.SetResult(null);
+                    await release.Task;
+                }
+            })
+            .Bounded(2)
+            .Build();
+
+        await mailbox.StartAsync();
+        await mailbox.PostAsync(Message<int>.Create(1));
+        await started.Task;
+        await mailbox.PostAsync(Message<int>.Create(2));
+
+        Assert.Equal(2, mailbox.Capacity);
+        Assert.Equal(1, mailbox.QueuedCount);
+
+        release.SetResult(null);
+        await mailbox.StopAsync();
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotentAndRejectsLaterUse()
+    {
+        var mailbox = Mailbox<int>.Create((_, _, _) => default).Build();
+
+        mailbox.Dispose();
+        mailbox.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => { _ = mailbox.StartAsync(); });
+    }
+
+    [Fact]
+    public async Task PostAsync_ObservesCanceledEnqueueToken()
+    {
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+        using var mailbox = Mailbox<int>.Create((_, _, _) => default).Build();
+
+        await mailbox.StartAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await mailbox.PostAsync(Message<int>.Create(1), cancellationToken: source.Token));
+
+        await mailbox.StopAsync();
+    }
+
+    [Fact]
+    public void Builder_RejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => Mailbox<int>.Create(null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Mailbox<int>.Create((_, _, _) => default).Bounded(0));
+        Assert.Throws<ArgumentNullException>(() => Mailbox<int>.Create((_, _, _) => default).OnEvent(null!));
+
+        var mailbox = Mailbox<int>.Create((_, _, _) => default).Unbounded().Build();
+        Assert.Null(mailbox.Capacity);
+    }
+
+    [Fact]
+    public async Task PostAsync_RejectsNullMessage()
+    {
+        using var mailbox = Mailbox<int>.Create((_, _, _) => default).Build();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await mailbox.PostAsync(null!));
+    }
+}


### PR DESCRIPTION
Closes #176.

## Summary
- add Mailbox<TPayload> with explicit start/stop lifecycle, bounded/unbounded capacity, backpressure policies, error policy, and diagnostics events
- add mailbox runtime tests covering ordering, non-concurrency, backpressure, shutdown, errors, cancellation, events, and validation
- add mailbox example plus docs with DocFX API crosslinks and guidance against observers, mediator/dispatcher, routers, and external queues

## Validation
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Tests\\PatternKit.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Generators.Tests\\PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- docfx metadata docs\\docfx.json
- docfx build docs\\docfx.json
- git diff --check