### PR TITLE
feat: add idempotent receiver and outbox helpers

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -157,6 +157,9 @@ If you’re looking for end-to-end, production-shaped demos, check the **Example
 - **[Mailbox](messaging/mailbox.md)**
   Serialized in-process inboxes with bounded backpressure, error policy, and shutdown behavior.
 
+- **[Idempotent Receiver, Inbox, and Outbox](messaging/reliability.md)**
+  Pluggable idempotency stores, inbox boundaries, and outbox records for at-least-once message handling.
+
 - **[TypeDispatcher](behavioral/type-dispatcher/index.md)**
   Type-safe runtime dispatch that routes objects to handlers based on their concrete type.
 

--- a/docs/patterns/messaging/README.md
+++ b/docs/patterns/messaging/README.md
@@ -32,6 +32,12 @@ Bounded or unbounded in-process inboxes serialize async message handling through
 
 [Learn More](mailbox.md)
 
+## Idempotent Receiver, Inbox, and Outbox
+
+Idempotency and handoff helpers compose message handlers with pluggable stores, inbox boundaries, and outbox records without claiming broker durability or exactly-once delivery.
+
+[Learn More](reliability.md)
+
 ## Mediator (Source Generated)
 
 A **zero-dependency**, **source-generated Mediator pattern** implementation for commands, notifications, and streams.
@@ -92,6 +98,7 @@ The Source-Generated Mediator complements other PatternKit patterns:
 - **[Routing Slip](routing-slip.md)** - Ordered message itineraries with fluent runtime and source-generated factories
 - **[Saga / Process Manager](saga.md)** - Typed message transitions over explicit long-running process state
 - **[Mailbox](mailbox.md)** - Serialized in-process inbox with bounded backpressure and shutdown behavior
+- **[Idempotent Receiver, Inbox, and Outbox](reliability.md)** - Pluggable idempotency and handoff helpers for at-least-once processing
 - **[Runtime Mediator](../behavioral/mediator/index.md)** - Pre-built mediator with PatternKit runtime (use for application code)
 - **Observer** - For reactive event handling and pub/sub
 - **Command** - For encapsulating requests as objects

--- a/docs/patterns/messaging/reliability.md
+++ b/docs/patterns/messaging/reliability.md
@@ -1,0 +1,113 @@
+# Idempotent Receiver, Inbox, and Outbox
+
+PatternKit provides small in-process helpers for idempotency and reliable handoff boundaries. They are designed for application composition: you own the storage, broker, transaction boundary, and retry policy.
+
+These APIs do not claim exactly-once delivery. They help make at-least-once message handling safer by checking an idempotency key before running a handler and by modeling outbox records that can be persisted and dispatched by application code.
+
+## Idempotent Receiver
+
+`IdempotentReceiver<TPayload, TResult>` wraps a handler with an idempotency-key claim:
+
+```csharp
+using PatternKit.Messaging;
+using PatternKit.Messaging.Reliability;
+
+var store = new InMemoryIdempotencyStore();
+
+var receiver = IdempotentReceiver<AcceptOrder, string>.Create(
+        store,
+        async (message, context, cancellationToken) =>
+        {
+            await SaveOrderAsync(message.Payload, cancellationToken);
+            return message.Payload.OrderId;
+        })
+    .OnDuplicate(DuplicateMessagePolicy.ReplayCompleted)
+    .Build();
+
+var result = await receiver.HandleAsync(
+    Message<AcceptOrder>
+        .Create(command)
+        .WithIdempotencyKey("accept-order-42"));
+```
+
+The default key selector reads `MessageHeaderNames.IdempotencyKey`. Use `KeyBy` when keys live in a payload or another header.
+
+Duplicate policies are explicit:
+
+- `Suppress` returns `Duplicate` and does not call the handler.
+- `ReplayCompleted` returns a stored completed result when the result is assignable to `TResult`; otherwise it suppresses the duplicate.
+
+Missing key policies are explicit:
+
+- `Reject` returns `MissingKey` and does not call the handler.
+- `Process` calls the handler without idempotency protection.
+
+When the handler succeeds, the receiver calls `IIdempotencyStore.MarkCompletedAsync`. When the handler throws, it calls `MarkFailedAsync` and rethrows.
+
+## Idempotency Store
+
+`IIdempotencyStore` is intentionally small:
+
+```csharp
+ValueTask<IdempotencyClaim> TryClaimAsync(string key, CancellationToken cancellationToken);
+ValueTask MarkCompletedAsync(string key, object? result, CancellationToken cancellationToken);
+ValueTask MarkFailedAsync(string key, string? reason, CancellationToken cancellationToken);
+```
+
+`InMemoryIdempotencyStore` is useful for tests, demos, and single-process tools. Production systems should back the interface with the same durable store that protects the related side effect, usually through a unique key or compare-and-set operation.
+
+## Inbox Processor
+
+`InboxProcessor<TPayload, TResult>` is a small wrapper around an idempotent receiver. It gives application code a named inbox boundary without forcing a storage provider:
+
+```csharp
+var inbox = InboxProcessor<AcceptOrder, string>.Create(receiver);
+var result = await inbox.ProcessAsync(message, context, cancellationToken);
+```
+
+Compose it with [Mailbox](mailbox.md) when work must also be serialized in process, or with [Enterprise Message Routing](message-routing.md) when messages need route selection before handling.
+
+## Outbox
+
+`OutboxMessage<TPayload>` models a pending handoff. `IOutboxDispatcher<TPayload>` sends a record to a broker, queue, HTTP client, or in-process handler. `InMemoryOutbox<TPayload>` provides a deterministic in-process implementation for tests and examples:
+
+```csharp
+var outbox = new InMemoryOutbox<OrderAccepted>();
+
+await outbox.EnqueueAsync(
+    Message<OrderAccepted>.Create(new OrderAccepted(orderId)),
+    id: $"accepted-{orderId}");
+
+await outbox.DispatchPendingAsync(dispatcher, cancellationToken);
+```
+
+The in-memory outbox records attempts and dispatch timestamps, but it is not durable. A production outbox should persist `OutboxMessage<TPayload>` or an equivalent schema in the same transaction as the business state change, then dispatch records after commit.
+
+## Boundaries
+
+- These APIs help with at-least-once processing; they do not provide exactly-once delivery.
+- `InMemoryIdempotencyStore` and `InMemoryOutbox<TPayload>` are not durable across process restarts.
+- A durable implementation should make idempotency claims atomically, usually with a unique key.
+- A durable outbox should persist records before dispatch and mark them dispatched only after the transport accepts them.
+- Handler side effects must still be designed to tolerate retries around process, database, or broker failures.
+
+## API
+
+- <xref:PatternKit.Messaging.Reliability.IdempotentReceiver`2>
+- <xref:PatternKit.Messaging.Reliability.IdempotentReceiverResult`1>
+- <xref:PatternKit.Messaging.Reliability.IdempotentReceiverStatus>
+- <xref:PatternKit.Messaging.Reliability.IIdempotencyStore>
+- <xref:PatternKit.Messaging.Reliability.InMemoryIdempotencyStore>
+- <xref:PatternKit.Messaging.Reliability.IdempotencyClaim>
+- <xref:PatternKit.Messaging.Reliability.IdempotencyEntryStatus>
+- <xref:PatternKit.Messaging.Reliability.DuplicateMessagePolicy>
+- <xref:PatternKit.Messaging.Reliability.MissingIdempotencyKeyPolicy>
+- <xref:PatternKit.Messaging.Reliability.InboxProcessor`2>
+- <xref:PatternKit.Messaging.Reliability.OutboxMessage`1>
+- <xref:PatternKit.Messaging.Reliability.IOutboxDispatcher`1>
+- <xref:PatternKit.Messaging.Reliability.InMemoryOutbox`1>
+
+## Example Source
+
+- `src/PatternKit.Examples/Messaging/ReliabilityExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/ReliabilityExampleTests.cs`

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -305,6 +305,8 @@
           href: messaging/saga.md
         - name: Mailbox
           href: messaging/mailbox.md
+        - name: Idempotent Receiver, Inbox, and Outbox
+          href: messaging/reliability.md
         - name: Source-Generated Dispatcher
           href: messaging/dispatcher.md
     - name: Type-Dispatcher

--- a/src/PatternKit.Core/Messaging/Reliability/DuplicateMessagePolicy.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/DuplicateMessagePolicy.cs
@@ -1,0 +1,13 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Defines how an idempotent receiver handles a duplicate idempotency key.
+/// </summary>
+public enum DuplicateMessagePolicy
+{
+    /// <summary>Suppresses duplicates and returns no handler result.</summary>
+    Suppress = 0,
+
+    /// <summary>Replays a stored completed result when it is assignable to the receiver result type.</summary>
+    ReplayCompleted = 1
+}

--- a/src/PatternKit.Core/Messaging/Reliability/IIdempotencyStore.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/IIdempotencyStore.cs
@@ -1,0 +1,22 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Pluggable idempotency key store used by idempotent receivers and inbox processors.
+/// </summary>
+public interface IIdempotencyStore
+{
+    /// <summary>
+    /// Attempts to claim <paramref name="key"/> for processing.
+    /// </summary>
+    ValueTask<IdempotencyClaim> TryClaimAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a claimed key as completed and stores an optional replayable result.
+    /// </summary>
+    ValueTask MarkCompletedAsync(string key, object? result = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a claimed key as failed with an optional reason.
+    /// </summary>
+    ValueTask MarkFailedAsync(string key, string? reason = null, CancellationToken cancellationToken = default);
+}

--- a/src/PatternKit.Core/Messaging/Reliability/IOutboxDispatcher.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/IOutboxDispatcher.cs
@@ -1,0 +1,10 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Dispatches outbox records to an application-owned transport, queue, or handler.
+/// </summary>
+public interface IOutboxDispatcher<TPayload>
+{
+    /// <summary>Dispatches a single outbox record.</summary>
+    ValueTask DispatchAsync(OutboxMessage<TPayload> message, CancellationToken cancellationToken = default);
+}

--- a/src/PatternKit.Core/Messaging/Reliability/IdempotencyClaim.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/IdempotencyClaim.cs
@@ -1,0 +1,50 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Result returned when an idempotency key is claimed.
+/// </summary>
+public sealed class IdempotencyClaim
+{
+    internal IdempotencyClaim(bool claimed, string key, IdempotencyEntryStatus status, object? result, string? failureReason)
+    {
+        Claimed = claimed;
+        Key = key;
+        Status = status;
+        Result = result;
+        FailureReason = failureReason;
+    }
+
+    /// <summary>Gets whether the caller owns the key and should process the message.</summary>
+    public bool Claimed { get; }
+
+    /// <summary>The idempotency key.</summary>
+    public string Key { get; }
+
+    /// <summary>The existing or newly-created key status.</summary>
+    public IdempotencyEntryStatus Status { get; }
+
+    /// <summary>The replayable result stored for a completed key, when available.</summary>
+    public object? Result { get; }
+
+    /// <summary>The stored failure reason for a failed key, when available.</summary>
+    public string? FailureReason { get; }
+
+    /// <summary>Creates a claimed key result.</summary>
+    public static IdempotencyClaim ClaimedKey(string key) => new(true, ValidateKey(key), IdempotencyEntryStatus.Processing, null, null);
+
+    /// <summary>Creates an existing key result.</summary>
+    public static IdempotencyClaim Existing(
+        string key,
+        IdempotencyEntryStatus status,
+        object? result = null,
+        string? failureReason = null)
+        => new(false, ValidateKey(key), status, result, failureReason);
+
+    private static string ValidateKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Idempotency key cannot be null, empty, or whitespace.", nameof(key));
+
+        return key;
+    }
+}

--- a/src/PatternKit.Core/Messaging/Reliability/IdempotencyEntryStatus.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/IdempotencyEntryStatus.cs
@@ -1,0 +1,16 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Describes the stored state of an idempotency key.
+/// </summary>
+public enum IdempotencyEntryStatus
+{
+    /// <summary>The key has been claimed and is currently processing.</summary>
+    Processing = 0,
+
+    /// <summary>The key completed successfully and may have a replayable result.</summary>
+    Completed = 1,
+
+    /// <summary>The key failed. Receivers may choose whether later attempts can retry.</summary>
+    Failed = 2
+}

--- a/src/PatternKit.Core/Messaging/Reliability/IdempotentReceiver.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/IdempotentReceiver.cs
@@ -1,0 +1,154 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Decorates a message handler with idempotency-key claim, completion, and duplicate handling.
+/// </summary>
+/// <typeparam name="TPayload">The message payload type.</typeparam>
+/// <typeparam name="TResult">The handler result type.</typeparam>
+public sealed class IdempotentReceiver<TPayload, TResult>
+{
+    /// <summary>Async handler protected by the idempotent receiver.</summary>
+    public delegate ValueTask<TResult> MessageHandler(
+        Message<TPayload> message,
+        MessageContext context,
+        CancellationToken cancellationToken);
+
+    /// <summary>Extracts an idempotency key from a message and context.</summary>
+    public delegate string? KeySelector(Message<TPayload> message, MessageContext context);
+
+    private readonly IIdempotencyStore _store;
+    private readonly MessageHandler _handler;
+    private readonly KeySelector _keySelector;
+    private readonly DuplicateMessagePolicy _duplicatePolicy;
+    private readonly MissingIdempotencyKeyPolicy _missingKeyPolicy;
+
+    private IdempotentReceiver(
+        IIdempotencyStore store,
+        MessageHandler handler,
+        KeySelector keySelector,
+        DuplicateMessagePolicy duplicatePolicy,
+        MissingIdempotencyKeyPolicy missingKeyPolicy)
+    {
+        _store = store;
+        _handler = handler;
+        _keySelector = keySelector;
+        _duplicatePolicy = duplicatePolicy;
+        _missingKeyPolicy = missingKeyPolicy;
+    }
+
+    /// <summary>Creates an idempotent receiver builder.</summary>
+    public static Builder Create(IIdempotencyStore store, MessageHandler handler) => new(store, handler);
+
+    /// <summary>Handles a message through the idempotent receiver.</summary>
+    public async ValueTask<IdempotentReceiverResult<TResult>> HandleAsync(
+        Message<TPayload> message,
+        MessageContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var effectiveContext = CreateContext(message, context, cancellationToken);
+        var key = _keySelector(message, effectiveContext);
+        if (string.IsNullOrWhiteSpace(key))
+            return await HandleMissingKeyAsync(message, effectiveContext, cancellationToken).ConfigureAwait(false);
+
+        var claim = await _store.TryClaimAsync(key!, cancellationToken).ConfigureAwait(false);
+        if (!claim.Claimed)
+            return HandleDuplicate(claim);
+
+        try
+        {
+            var result = await _handler(message, effectiveContext, effectiveContext.CancellationToken).ConfigureAwait(false);
+            await _store.MarkCompletedAsync(key!, result, cancellationToken).ConfigureAwait(false);
+            return IdempotentReceiverResult<TResult>.ProcessedResult(key, result);
+        }
+        catch (Exception exception)
+        {
+            await _store.MarkFailedAsync(key!, exception.Message, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async ValueTask<IdempotentReceiverResult<TResult>> HandleMissingKeyAsync(
+        Message<TPayload> message,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        if (_missingKeyPolicy == MissingIdempotencyKeyPolicy.Reject)
+            return IdempotentReceiverResult<TResult>.MissingKey();
+
+        var result = await _handler(message, context, context.CancellationToken).ConfigureAwait(false);
+        return IdempotentReceiverResult<TResult>.ProcessedResult(null, result);
+    }
+
+    private IdempotentReceiverResult<TResult> HandleDuplicate(IdempotencyClaim claim)
+    {
+        if (_duplicatePolicy == DuplicateMessagePolicy.ReplayCompleted
+            && claim.Status == IdempotencyEntryStatus.Completed
+            && claim.Result is TResult result)
+        {
+            return IdempotentReceiverResult<TResult>.Replayed(claim.Key, result);
+        }
+
+        return IdempotentReceiverResult<TResult>.Duplicate(claim.Key);
+    }
+
+    private static MessageContext CreateContext(
+        Message<TPayload> message,
+        MessageContext? context,
+        CancellationToken cancellationToken)
+    {
+        if (context is null)
+            return MessageContext.From(message, cancellationToken);
+
+        return cancellationToken.CanBeCanceled
+            ? context.WithCancellation(cancellationToken)
+            : context;
+    }
+
+    /// <summary>Fluent builder for <see cref="IdempotentReceiver{TPayload,TResult}"/>.</summary>
+    public sealed class Builder
+    {
+        private readonly IIdempotencyStore _store;
+        private readonly MessageHandler _handler;
+        private KeySelector _keySelector = static (message, _) => message.Headers.IdempotencyKey;
+        private DuplicateMessagePolicy _duplicatePolicy = DuplicateMessagePolicy.Suppress;
+        private MissingIdempotencyKeyPolicy _missingKeyPolicy = MissingIdempotencyKeyPolicy.Reject;
+
+        internal Builder(IIdempotencyStore store, MessageHandler handler)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        /// <summary>Configures a custom idempotency key selector.</summary>
+        public Builder KeyBy(KeySelector keySelector)
+        {
+            _keySelector = keySelector ?? throw new ArgumentNullException(nameof(keySelector));
+            return this;
+        }
+
+        /// <summary>Configures duplicate handling.</summary>
+        public Builder OnDuplicate(DuplicateMessagePolicy policy)
+        {
+            _duplicatePolicy = policy;
+            return this;
+        }
+
+        /// <summary>Configures missing idempotency key handling.</summary>
+        public Builder OnMissingKey(MissingIdempotencyKeyPolicy policy)
+        {
+            _missingKeyPolicy = policy;
+            return this;
+        }
+
+        /// <summary>Builds an immutable idempotent receiver.</summary>
+        public IdempotentReceiver<TPayload, TResult> Build() => new(
+            _store,
+            _handler,
+            _keySelector,
+            _duplicatePolicy,
+            _missingKeyPolicy);
+    }
+}

--- a/src/PatternKit.Core/Messaging/Reliability/IdempotentReceiverResult.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/IdempotentReceiverResult.cs
@@ -1,0 +1,43 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Result returned by an idempotent receiver.
+/// </summary>
+/// <typeparam name="TResult">The handler result type.</typeparam>
+public sealed class IdempotentReceiverResult<TResult>
+{
+    internal IdempotentReceiverResult(IdempotentReceiverStatus status, string? key, TResult? result)
+    {
+        Status = status;
+        Key = key;
+        Result = result;
+    }
+
+    /// <summary>The receiver outcome.</summary>
+    public IdempotentReceiverStatus Status { get; }
+
+    /// <summary>The idempotency key used for the invocation, when available.</summary>
+    public string? Key { get; }
+
+    /// <summary>The processed or replayed handler result, when available.</summary>
+    public TResult? Result { get; }
+
+    /// <summary>Gets whether the handler ran for this invocation.</summary>
+    public bool Processed => Status == IdempotentReceiverStatus.Processed;
+
+    /// <summary>Creates a processed result.</summary>
+    public static IdempotentReceiverResult<TResult> ProcessedResult(string? key, TResult result)
+        => new(IdempotentReceiverStatus.Processed, key, result);
+
+    /// <summary>Creates a duplicate result.</summary>
+    public static IdempotentReceiverResult<TResult> Duplicate(string key)
+        => new(IdempotentReceiverStatus.Duplicate, key, default);
+
+    /// <summary>Creates a replayed result.</summary>
+    public static IdempotentReceiverResult<TResult> Replayed(string key, TResult result)
+        => new(IdempotentReceiverStatus.Replayed, key, result);
+
+    /// <summary>Creates a missing-key result.</summary>
+    public static IdempotentReceiverResult<TResult> MissingKey()
+        => new(IdempotentReceiverStatus.MissingKey, null, default);
+}

--- a/src/PatternKit.Core/Messaging/Reliability/IdempotentReceiverStatus.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/IdempotentReceiverStatus.cs
@@ -1,0 +1,19 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Describes the outcome of an idempotent receiver invocation.
+/// </summary>
+public enum IdempotentReceiverStatus
+{
+    /// <summary>The message was processed by the handler.</summary>
+    Processed = 0,
+
+    /// <summary>The message was a duplicate and was suppressed.</summary>
+    Duplicate = 1,
+
+    /// <summary>The message was a duplicate and a stored completed result was replayed.</summary>
+    Replayed = 2,
+
+    /// <summary>The message had no idempotency key and was rejected.</summary>
+    MissingKey = 3
+}

--- a/src/PatternKit.Core/Messaging/Reliability/InMemoryIdempotencyStore.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/InMemoryIdempotencyStore.cs
@@ -1,0 +1,100 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Thread-safe in-memory idempotency store for tests, demos, and single-process applications.
+/// </summary>
+public sealed class InMemoryIdempotencyStore : IIdempotencyStore
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+
+    /// <summary>The number of keys stored.</summary>
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+                return _entries.Count;
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IdempotencyClaim> TryClaimAsync(string key, CancellationToken cancellationToken = default)
+    {
+        ValidateKey(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(key, out var entry))
+                return new ValueTask<IdempotencyClaim>(IdempotencyClaim.Existing(key, entry.Status, entry.Result, entry.FailureReason));
+
+            _entries[key] = new Entry(IdempotencyEntryStatus.Processing, null, null);
+            return new ValueTask<IdempotencyClaim>(IdempotencyClaim.ClaimedKey(key));
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask MarkCompletedAsync(string key, object? result = null, CancellationToken cancellationToken = default)
+    {
+        ValidateKey(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+            _entries[key] = new Entry(IdempotencyEntryStatus.Completed, result, null);
+
+        return default;
+    }
+
+    /// <inheritdoc />
+    public ValueTask MarkFailedAsync(string key, string? reason = null, CancellationToken cancellationToken = default)
+    {
+        ValidateKey(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+            _entries[key] = new Entry(IdempotencyEntryStatus.Failed, null, reason);
+
+        return default;
+    }
+
+    /// <summary>Attempts to read the current stored claim for a key.</summary>
+    public bool TryGet(string key, out IdempotencyClaim? claim)
+    {
+        ValidateKey(key);
+
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(key, out var entry))
+            {
+                claim = IdempotencyClaim.Existing(key, entry.Status, entry.Result, entry.FailureReason);
+                return true;
+            }
+        }
+
+        claim = null;
+        return false;
+    }
+
+    private static void ValidateKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Idempotency key cannot be null, empty, or whitespace.", nameof(key));
+    }
+
+    private sealed class Entry
+    {
+        internal Entry(IdempotencyEntryStatus status, object? result, string? failureReason)
+        {
+            Status = status;
+            Result = result;
+            FailureReason = failureReason;
+        }
+
+        internal IdempotencyEntryStatus Status { get; }
+
+        internal object? Result { get; }
+
+        internal string? FailureReason { get; }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Reliability/InMemoryOutbox.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/InMemoryOutbox.cs
@@ -1,0 +1,93 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Thread-safe in-memory outbox for tests, demos, and single-process applications.
+/// </summary>
+public sealed class InMemoryOutbox<TPayload>
+{
+    private readonly object _gate = new();
+    private readonly List<OutboxMessage<TPayload>> _records = new();
+
+    /// <summary>The current outbox records.</summary>
+    public IReadOnlyList<OutboxMessage<TPayload>> Records
+    {
+        get
+        {
+            lock (_gate)
+                return _records.ToArray();
+        }
+    }
+
+    /// <summary>Adds a message to the outbox.</summary>
+    public ValueTask<OutboxMessage<TPayload>> EnqueueAsync(
+        Message<TPayload> message,
+        string? id = null,
+        DateTimeOffset? createdAt = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var record = new OutboxMessage<TPayload>(
+            string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("N") : id!,
+            message,
+            createdAt ?? DateTimeOffset.UtcNow);
+
+        lock (_gate)
+            _records.Add(record);
+
+        return new ValueTask<OutboxMessage<TPayload>>(record);
+    }
+
+    /// <summary>Dispatches pending records through <paramref name="dispatcher"/>.</summary>
+    public async ValueTask<int> DispatchPendingAsync(
+        IOutboxDispatcher<TPayload> dispatcher,
+        CancellationToken cancellationToken = default)
+    {
+        if (dispatcher is null)
+            throw new ArgumentNullException(nameof(dispatcher));
+
+        var dispatched = 0;
+        foreach (var record in SnapshotPending())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await dispatcher.DispatchAsync(record, cancellationToken).ConfigureAwait(false);
+                Replace(record.Id, record.MarkDispatched(DateTimeOffset.UtcNow));
+                dispatched++;
+            }
+            catch (Exception exception)
+            {
+                Replace(record.Id, record.WithAttempt(exception.Message));
+                throw;
+            }
+        }
+
+        return dispatched;
+    }
+
+    private OutboxMessage<TPayload>[] SnapshotPending()
+    {
+        lock (_gate)
+            return _records.Where(record => !record.Dispatched).ToArray();
+    }
+
+    private void Replace(string id, OutboxMessage<TPayload> replacement)
+    {
+        lock (_gate)
+        {
+            for (var i = 0; i < _records.Count; i++)
+            {
+                if (_records[i].Id == id)
+                {
+                    _records[i] = replacement;
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/PatternKit.Core/Messaging/Reliability/InboxProcessor.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/InboxProcessor.cs
@@ -1,0 +1,30 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Inbox processor that applies an idempotent receiver around a message handler.
+/// </summary>
+public sealed class InboxProcessor<TPayload, TResult>
+{
+    private readonly IdempotentReceiver<TPayload, TResult> _receiver;
+
+    private InboxProcessor(IdempotentReceiver<TPayload, TResult> receiver)
+    {
+        _receiver = receiver;
+    }
+
+    /// <summary>Creates an inbox processor from an idempotent receiver.</summary>
+    public static InboxProcessor<TPayload, TResult> Create(IdempotentReceiver<TPayload, TResult> receiver)
+    {
+        if (receiver is null)
+            throw new ArgumentNullException(nameof(receiver));
+
+        return new InboxProcessor<TPayload, TResult>(receiver);
+    }
+
+    /// <summary>Processes an inbox message through the configured idempotent receiver.</summary>
+    public ValueTask<IdempotentReceiverResult<TResult>> ProcessAsync(
+        Message<TPayload> message,
+        MessageContext? context = null,
+        CancellationToken cancellationToken = default)
+        => _receiver.HandleAsync(message, context, cancellationToken);
+}

--- a/src/PatternKit.Core/Messaging/Reliability/MissingIdempotencyKeyPolicy.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/MissingIdempotencyKeyPolicy.cs
@@ -1,0 +1,13 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// Defines how an idempotent receiver handles messages without an idempotency key.
+/// </summary>
+public enum MissingIdempotencyKeyPolicy
+{
+    /// <summary>Rejects messages without an idempotency key.</summary>
+    Reject = 0,
+
+    /// <summary>Processes messages without idempotency protection.</summary>
+    Process = 1
+}

--- a/src/PatternKit.Core/Messaging/Reliability/OutboxMessage.cs
+++ b/src/PatternKit.Core/Messaging/Reliability/OutboxMessage.cs
@@ -1,0 +1,62 @@
+namespace PatternKit.Messaging.Reliability;
+
+/// <summary>
+/// In-process outbox record that can be persisted by application code before dispatch.
+/// </summary>
+/// <typeparam name="TPayload">The payload type stored in the outbox record.</typeparam>
+public sealed class OutboxMessage<TPayload>
+{
+    /// <summary>Creates an outbox record.</summary>
+    public OutboxMessage(string id, Message<TPayload> message, DateTimeOffset createdAt)
+        : this(id, message, createdAt, null, 0, null)
+    {
+    }
+
+    private OutboxMessage(
+        string id,
+        Message<TPayload> message,
+        DateTimeOffset createdAt,
+        DateTimeOffset? dispatchedAt,
+        int attempts,
+        string? lastError)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            throw new ArgumentException("Outbox message id cannot be null, empty, or whitespace.", nameof(id));
+
+        Id = id;
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        CreatedAt = createdAt;
+        DispatchedAt = dispatchedAt;
+        Attempts = attempts;
+        LastError = lastError;
+    }
+
+    /// <summary>The outbox record identifier.</summary>
+    public string Id { get; }
+
+    /// <summary>The message to dispatch.</summary>
+    public Message<TPayload> Message { get; }
+
+    /// <summary>When the outbox record was created.</summary>
+    public DateTimeOffset CreatedAt { get; }
+
+    /// <summary>When the outbox record was dispatched, if it has been dispatched.</summary>
+    public DateTimeOffset? DispatchedAt { get; }
+
+    /// <summary>The number of dispatch attempts.</summary>
+    public int Attempts { get; }
+
+    /// <summary>The last dispatch error, when available.</summary>
+    public string? LastError { get; }
+
+    /// <summary>Gets whether the outbox record has been dispatched.</summary>
+    public bool Dispatched => DispatchedAt is not null;
+
+    /// <summary>Returns a copy with dispatch attempt metadata recorded.</summary>
+    public OutboxMessage<TPayload> WithAttempt(string? error)
+        => new(Id, Message, CreatedAt, DispatchedAt, Attempts + 1, error);
+
+    /// <summary>Returns a copy marked as dispatched.</summary>
+    public OutboxMessage<TPayload> MarkDispatched(DateTimeOffset dispatchedAt)
+        => new(Id, Message, CreatedAt, dispatchedAt, Attempts + 1, null);
+}

--- a/src/PatternKit.Examples/Messaging/ReliabilityExample.cs
+++ b/src/PatternKit.Examples/Messaging/ReliabilityExample.cs
@@ -1,0 +1,76 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Mailboxes;
+using PatternKit.Messaging.Reliability;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Demonstrates idempotent inbox processing with an in-process mailbox and outbox.
+/// </summary>
+public static class ReliabilityExample
+{
+    /// <summary>Runs an idempotent order inbox and returns dispatched outbox payloads.</summary>
+    public static async ValueTask<IReadOnlyList<string>> RunAsync()
+    {
+        var store = new InMemoryIdempotencyStore();
+        var outbox = new InMemoryOutbox<ReliabilityOrderAccepted>();
+        var dispatched = new List<string>();
+
+        var receiver = IdempotentReceiver<AcceptOrder, string>.Create(
+                store,
+                async (message, _, cancellationToken) =>
+                {
+                    await outbox.EnqueueAsync(
+                        Message<ReliabilityOrderAccepted>.Create(new ReliabilityOrderAccepted(message.Payload.OrderId)),
+                        id: $"accepted-{message.Payload.OrderId}",
+                        cancellationToken: cancellationToken);
+                    return message.Payload.OrderId;
+                })
+            .OnDuplicate(DuplicateMessagePolicy.ReplayCompleted)
+            .Build();
+
+        using var mailbox = Mailbox<AcceptOrder>.Create(async (message, context, cancellationToken) =>
+            {
+                await receiver.HandleAsync(message, context, cancellationToken);
+            })
+            .Build();
+
+        await mailbox.StartAsync();
+
+        var command = Message<AcceptOrder>
+            .Create(new AcceptOrder("order-42"))
+            .WithIdempotencyKey("accept-order-42");
+
+        await mailbox.PostAsync(command);
+        await mailbox.PostAsync(command);
+        await mailbox.StopAsync();
+
+        await outbox.DispatchPendingAsync(new DelegateOutboxDispatcher<ReliabilityOrderAccepted>(
+            (record, _) =>
+            {
+                dispatched.Add(record.Message.Payload.OrderId);
+                return default;
+            }));
+
+        return dispatched;
+    }
+}
+
+/// <summary>Reliability example command payload.</summary>
+public sealed record AcceptOrder(string OrderId);
+
+/// <summary>Reliability example event payload.</summary>
+public sealed record ReliabilityOrderAccepted(string OrderId);
+
+internal sealed class DelegateOutboxDispatcher<TPayload> : IOutboxDispatcher<TPayload>
+{
+    private readonly Func<OutboxMessage<TPayload>, CancellationToken, ValueTask> _dispatch;
+
+    internal DelegateOutboxDispatcher(Func<OutboxMessage<TPayload>, CancellationToken, ValueTask> dispatch)
+    {
+        _dispatch = dispatch;
+    }
+
+    public ValueTask DispatchAsync(OutboxMessage<TPayload> message, CancellationToken cancellationToken = default)
+        => _dispatch(message, cancellationToken);
+}

--- a/test/PatternKit.Examples.Tests/Messaging/ReliabilityExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ReliabilityExampleTests.cs
@@ -1,0 +1,14 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class ReliabilityExampleTests
+{
+    [Fact]
+    public async Task RunAsync_DispatchesOneOutboxMessageForDuplicateInput()
+    {
+        var dispatched = await ReliabilityExample.RunAsync();
+
+        Assert.Equal(["order-42"], dispatched);
+    }
+}

--- a/test/PatternKit.Tests/Messaging/Reliability/IdempotentReceiverTests.cs
+++ b/test/PatternKit.Tests/Messaging/Reliability/IdempotentReceiverTests.cs
@@ -1,0 +1,264 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Reliability;
+
+namespace PatternKit.Tests.Messaging.Reliability;
+
+public sealed class IdempotentReceiverTests
+{
+    [Fact]
+    public async Task HandleAsync_ProcessesFirstMessageAndSuppressesDuplicate()
+    {
+        var calls = 0;
+        var store = new InMemoryIdempotencyStore();
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                store,
+                (message, _, _) =>
+                {
+                    calls++;
+                    return new ValueTask<string>($"processed:{message.Payload.Id}");
+                })
+            .Build();
+        var message = Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1");
+
+        var first = await receiver.HandleAsync(message);
+        var duplicate = await receiver.HandleAsync(message);
+
+        Assert.True(first.Processed);
+        Assert.Equal("processed:order-1", first.Result);
+        Assert.Equal(IdempotentReceiverStatus.Duplicate, duplicate.Status);
+        Assert.Equal("idem-1", duplicate.Key);
+        Assert.Equal(1, calls);
+        Assert.True(store.TryGet("idem-1", out var claim));
+        Assert.Equal(IdempotencyEntryStatus.Completed, claim!.Status);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ReplaysCompletedResultWhenConfigured()
+    {
+        var store = new InMemoryIdempotencyStore();
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                store,
+                (message, _, _) => new ValueTask<string>($"processed:{message.Payload.Id}"))
+            .OnDuplicate(DuplicateMessagePolicy.ReplayCompleted)
+            .Build();
+        var message = Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1");
+
+        var first = await receiver.HandleAsync(message);
+        var duplicate = await receiver.HandleAsync(message);
+
+        Assert.Equal(IdempotentReceiverStatus.Processed, first.Status);
+        Assert.Equal(IdempotentReceiverStatus.Replayed, duplicate.Status);
+        Assert.Equal("processed:order-1", duplicate.Result);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SuppressesDuplicateWhenStoredResultHasWrongType()
+    {
+        var store = new InMemoryIdempotencyStore();
+        await store.TryClaimAsync("idem-1");
+        await store.MarkCompletedAsync("idem-1", 42);
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                store,
+                (_, _, _) => new ValueTask<string>("processed"))
+            .OnDuplicate(DuplicateMessagePolicy.ReplayCompleted)
+            .Build();
+
+        var result = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1"));
+
+        Assert.Equal(IdempotentReceiverStatus.Duplicate, result.Status);
+        Assert.Null(result.Result);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RejectsMissingKeyByDefault()
+    {
+        var calls = 0;
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                new InMemoryIdempotencyStore(),
+                (_, _, _) =>
+                {
+                    calls++;
+                    return new ValueTask<string>("processed");
+                })
+            .Build();
+
+        var result = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
+
+        Assert.Equal(IdempotentReceiverStatus.MissingKey, result.Status);
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public async Task HandleAsync_CanProcessMissingKeyWhenConfigured()
+    {
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                new InMemoryIdempotencyStore(),
+                (_, _, _) => new ValueTask<string>("processed"))
+            .OnMissingKey(MissingIdempotencyKeyPolicy.Process)
+            .Build();
+
+        var result = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
+
+        Assert.Equal(IdempotentReceiverStatus.Processed, result.Status);
+        Assert.Null(result.Key);
+        Assert.Equal("processed", result.Result);
+    }
+
+    [Fact]
+    public async Task HandleAsync_UsesCustomKeySelector()
+    {
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                new InMemoryIdempotencyStore(),
+                (message, _, _) => new ValueTask<string>(message.Payload.Id))
+            .KeyBy((message, _) => message.Payload.Id)
+            .Build();
+
+        var first = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
+        var duplicate = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
+
+        Assert.True(first.Processed);
+        Assert.Equal(IdempotentReceiverStatus.Duplicate, duplicate.Status);
+        Assert.Equal("order-1", duplicate.Key);
+    }
+
+    [Fact]
+    public async Task HandleAsync_PreservesSuppliedContextAndAppliesExplicitCancellation()
+    {
+        using var source = new CancellationTokenSource();
+        var observedTenant = string.Empty;
+        var observedCancellation = CancellationToken.None;
+        var context = new MessageContext().WithItem("tenant", "north");
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                new InMemoryIdempotencyStore(),
+                (_, ctx, cancellationToken) =>
+                {
+                    observedTenant = ctx.TryGetItem<string>("tenant", out var tenant) ? tenant! : string.Empty;
+                    observedCancellation = cancellationToken;
+                    return new ValueTask<string>("processed");
+                })
+            .Build();
+
+        var result = await receiver.HandleAsync(
+            Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1"),
+            context,
+            source.Token);
+
+        Assert.Equal(IdempotentReceiverStatus.Processed, result.Status);
+        Assert.Equal("north", observedTenant);
+        Assert.True(observedCancellation.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task HandleAsync_MarksFailedAndRethrowsHandlerFailure()
+    {
+        var store = new InMemoryIdempotencyStore();
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                store,
+                (_, _, _) => throw new InvalidOperationException("handler failed"))
+            .Build();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1")));
+
+        Assert.True(store.TryGet("idem-1", out var claim));
+        Assert.Equal(IdempotencyEntryStatus.Failed, claim!.Status);
+        Assert.Equal("handler failed", claim.FailureReason);
+    }
+
+    [Fact]
+    public async Task HandleAsync_PropagatesStoreFailure()
+    {
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                new FailingStore(),
+                (_, _, _) => new ValueTask<string>("processed"))
+            .Build();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1")));
+    }
+
+    [Fact]
+    public async Task HandleAsync_PropagatesCancellation()
+    {
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                new InMemoryIdempotencyStore(),
+                (_, _, _) => new ValueTask<string>("processed"))
+            .Build();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await receiver.HandleAsync(
+                Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1"),
+                cancellationToken: source.Token));
+    }
+
+    [Fact]
+    public async Task InboxProcessor_DelegatesToIdempotentReceiver()
+    {
+        var receiver = IdempotentReceiver<Order, string>.Create(
+                new InMemoryIdempotencyStore(),
+                (message, _, _) => new ValueTask<string>(message.Payload.Id))
+            .Build();
+        var inbox = InboxProcessor<Order, string>.Create(receiver);
+
+        var result = await inbox.ProcessAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1"));
+
+        Assert.Equal("order-1", result.Result);
+    }
+
+    [Fact]
+    public void Builder_RejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(null!, (_, _, _) => default).Build());
+        Assert.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), null!).Build());
+        Assert.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), (_, _, _) => default).KeyBy(null!));
+        Assert.Throws<ArgumentNullException>(() => InboxProcessor<Order, string>.Create(null!));
+    }
+
+    [Fact]
+    public async Task InMemoryIdempotencyStore_ValidatesKeysAndTracksCount()
+    {
+        var store = new InMemoryIdempotencyStore();
+
+        await Assert.ThrowsAsync<ArgumentException>(async () => await store.TryClaimAsync(""));
+        await store.TryClaimAsync("idem-1");
+        await store.MarkFailedAsync("idem-2", "failed");
+
+        Assert.Equal(2, store.Count);
+        Assert.False(store.TryGet("missing", out var missing));
+        Assert.Null(missing);
+        Assert.True(store.TryGet("idem-2", out var claim));
+        Assert.Equal(IdempotencyEntryStatus.Failed, claim!.Status);
+        Assert.Equal("failed", claim.FailureReason);
+    }
+
+    [Fact]
+    public void IdempotencyClaim_ValidatesFactoryKeys()
+    {
+        Assert.Throws<ArgumentException>(() => IdempotencyClaim.ClaimedKey(""));
+        Assert.Throws<ArgumentException>(() => IdempotencyClaim.Existing(" ", IdempotencyEntryStatus.Completed));
+    }
+
+    [Fact]
+    public async Task HandleAsync_RejectsNullMessage()
+    {
+        var receiver = IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), (_, _, _) => default).Build();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await receiver.HandleAsync(null!));
+    }
+
+    private sealed record Order(string Id);
+
+    private sealed class FailingStore : IIdempotencyStore
+    {
+        public ValueTask<IdempotencyClaim> TryClaimAsync(string key, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("store failed");
+
+        public ValueTask MarkCompletedAsync(string key, object? result = null, CancellationToken cancellationToken = default)
+            => default;
+
+        public ValueTask MarkFailedAsync(string key, string? reason = null, CancellationToken cancellationToken = default)
+            => default;
+    }
+}

--- a/test/PatternKit.Tests/Messaging/Reliability/OutboxTests.cs
+++ b/test/PatternKit.Tests/Messaging/Reliability/OutboxTests.cs
@@ -1,0 +1,108 @@
+using PatternKit.Messaging;
+using PatternKit.Messaging.Reliability;
+
+namespace PatternKit.Tests.Messaging.Reliability;
+
+public sealed class OutboxTests
+{
+    [Fact]
+    public async Task EnqueueAsync_AddsOutboxRecord()
+    {
+        var outbox = new InMemoryOutbox<Order>();
+        var createdAt = new DateTimeOffset(2026, 5, 13, 12, 0, 0, TimeSpan.Zero);
+
+        var record = await outbox.EnqueueAsync(
+            Message<Order>.Create(new Order("order-1")),
+            "outbox-1",
+            createdAt);
+
+        Assert.Equal("outbox-1", record.Id);
+        Assert.Equal(createdAt, record.CreatedAt);
+        Assert.False(record.Dispatched);
+        Assert.Single(outbox.Records);
+    }
+
+    [Fact]
+    public async Task DispatchPendingAsync_DispatchesPendingRecordsAndMarksThemDispatched()
+    {
+        var outbox = new InMemoryOutbox<Order>();
+        var dispatcher = new RecordingDispatcher();
+        await outbox.EnqueueAsync(Message<Order>.Create(new Order("order-1")), "outbox-1");
+        await outbox.EnqueueAsync(Message<Order>.Create(new Order("order-2")), "outbox-2");
+
+        var dispatched = await outbox.DispatchPendingAsync(dispatcher);
+        var secondPass = await outbox.DispatchPendingAsync(dispatcher);
+
+        Assert.Equal(2, dispatched);
+        Assert.Equal(0, secondPass);
+        Assert.Equal(["order-1", "order-2"], dispatcher.Dispatched);
+        Assert.All(outbox.Records, record =>
+        {
+            Assert.True(record.Dispatched);
+            Assert.Equal(1, record.Attempts);
+            Assert.Null(record.LastError);
+        });
+    }
+
+    [Fact]
+    public async Task DispatchPendingAsync_RecordsFailedAttemptAndRethrows()
+    {
+        var outbox = new InMemoryOutbox<Order>();
+        await outbox.EnqueueAsync(Message<Order>.Create(new Order("order-1")), "outbox-1");
+        var dispatcher = new FailingDispatcher();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outbox.DispatchPendingAsync(dispatcher));
+
+        var record = Assert.Single(outbox.Records);
+        Assert.False(record.Dispatched);
+        Assert.Equal(1, record.Attempts);
+        Assert.Equal("dispatch failed", record.LastError);
+    }
+
+    [Fact]
+    public async Task DispatchPendingAsync_ObservesCancellation()
+    {
+        var outbox = new InMemoryOutbox<Order>();
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+        await outbox.EnqueueAsync(Message<Order>.Create(new Order("order-1")), "outbox-1");
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await outbox.DispatchPendingAsync(new RecordingDispatcher(), source.Token));
+    }
+
+    [Fact]
+    public void OutboxMessage_ValidatesArguments()
+    {
+        Assert.Throws<ArgumentException>(() => new OutboxMessage<Order>("", Message<Order>.Create(new Order("order-1")), DateTimeOffset.UtcNow));
+        Assert.Throws<ArgumentNullException>(() => new OutboxMessage<Order>("outbox-1", null!, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_ValidatesArguments()
+    {
+        var outbox = new InMemoryOutbox<Order>();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await outbox.EnqueueAsync(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await outbox.DispatchPendingAsync(null!));
+    }
+
+    private sealed record Order(string Id);
+
+    private sealed class RecordingDispatcher : IOutboxDispatcher<Order>
+    {
+        internal List<string> Dispatched { get; } = new();
+
+        public ValueTask DispatchAsync(OutboxMessage<Order> message, CancellationToken cancellationToken = default)
+        {
+            Dispatched.Add(message.Message.Payload.Id);
+            return default;
+        }
+    }
+
+    private sealed class FailingDispatcher : IOutboxDispatcher<Order>
+    {
+        public ValueTask DispatchAsync(OutboxMessage<Order> message, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("dispatch failed");
+    }
+}


### PR DESCRIPTION
Closes #177.

## Summary
- add pluggable idempotency store contracts plus in-memory implementation
- add IdempotentReceiver and InboxProcessor with duplicate, replay, missing-key, failure, and cancellation behavior
- add OutboxMessage, IOutboxDispatcher, and InMemoryOutbox for explicit handoff records
- add mailbox/outbox composition example and docs explaining at-least-once, idempotency, and durability boundaries

## Validation
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Tests\\PatternKit.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Generators.Tests\\PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- docfx metadata docs\\docfx.json
- docfx build docs\\docfx.json
- git diff --check