### PR TITLE
feat: add enterprise content router generator

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -160,6 +160,9 @@ If you’re looking for end-to-end, production-shaped demos, check the **Example
 - **[Idempotent Receiver, Inbox, and Outbox](messaging/reliability.md)**
   Pluggable idempotency stores, inbox boundaries, and outbox records for at-least-once message handling.
 
+- **[Enterprise Integration Source Generators](messaging/enterprise-generators.md)**
+  Compile-time generated content-router, routing-slip, and saga factories with explicit diagnostics.
+
 - **[TypeDispatcher](behavioral/type-dispatcher/index.md)**
   Type-safe runtime dispatch that routes objects to handlers based on their concrete type.
 

--- a/docs/patterns/messaging/README.md
+++ b/docs/patterns/messaging/README.md
@@ -38,6 +38,12 @@ Idempotency and handoff helpers compose message handlers with pluggable stores, 
 
 [Learn More](reliability.md)
 
+## Enterprise Integration Source Generators
+
+Generated content routers, routing slips, and sagas remove repetitive factory registration while preserving explicit opt-in and compile-time diagnostics.
+
+[Learn More](enterprise-generators.md)
+
 ## Mediator (Source Generated)
 
 A **zero-dependency**, **source-generated Mediator pattern** implementation for commands, notifications, and streams.
@@ -99,6 +105,7 @@ The Source-Generated Mediator complements other PatternKit patterns:
 - **[Saga / Process Manager](saga.md)** - Typed message transitions over explicit long-running process state
 - **[Mailbox](mailbox.md)** - Serialized in-process inbox with bounded backpressure and shutdown behavior
 - **[Idempotent Receiver, Inbox, and Outbox](reliability.md)** - Pluggable idempotency and handoff helpers for at-least-once processing
+- **[Enterprise Integration Source Generators](enterprise-generators.md)** - Generated content-router, routing-slip, and saga factories with diagnostics
 - **[Runtime Mediator](../behavioral/mediator/index.md)** - Pre-built mediator with PatternKit runtime (use for application code)
 - **Observer** - For reactive event handling and pub/sub
 - **Command** - For encapsulating requests as objects

--- a/docs/patterns/messaging/enterprise-generators.md
+++ b/docs/patterns/messaging/enterprise-generators.md
@@ -1,0 +1,90 @@
+# Enterprise Integration Source Generators
+
+PatternKit source generators remove repetitive registration code for explicit enterprise integration patterns. They do not scan assemblies implicitly; each generated factory is opt-in through attributes on a partial type.
+
+Use generators when routes, routing-slip steps, or saga transitions are static enough to validate at compile time and you want AOT-friendly factories without reflection.
+
+## Generated Content Router
+
+`[GenerateContentRouter]` creates a `ContentRouter<TPayload, TResult>` factory from static route predicates and handlers.
+
+```csharp
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+[GenerateContentRouter(typeof(Order), typeof(string))]
+public static partial class OrderRouter
+{
+    private static bool IsWholesale(Message<Order> message, MessageContext context)
+        => message.Payload.Channel == "wholesale";
+
+    [ContentRoute("wholesale", 10, nameof(IsWholesale))]
+    private static string Wholesale(Message<Order> message, MessageContext context)
+        => "wholesale";
+
+    [ContentRouteDefault]
+    private static string Default(Message<Order> message, MessageContext context)
+        => "default";
+}
+
+var route = OrderRouter.Create().Route(Message<Order>.Create(order));
+```
+
+Route handlers must be static and have this shape:
+
+```csharp
+TResult Handler(Message<TPayload> message, MessageContext context)
+```
+
+Predicates referenced by `ContentRouteAttribute.PredicateMethodName` must be static and have this shape:
+
+```csharp
+bool Predicate(Message<TPayload> message, MessageContext context)
+```
+
+The generator orders routes by `ContentRouteAttribute.Order`, then by route name. Route names and orders must be unique so the generated first-match behavior is clear.
+
+## Existing Enterprise Generators
+
+Routing-slip generation is documented in [Routing Slip](routing-slip.md). It discovers `[RoutingSlipStep]` methods and emits sync or async itinerary factories.
+
+Saga/process-manager generation is documented in [Saga / Process Manager](saga.md). It discovers `[SagaStep]` transition methods and optional `[SagaCompleteWhen]` completion checks.
+
+Mailbox and reliability helpers stay runtime-only for now. Their registration is already small and lifecycle-sensitive, so a generator would add indirection without removing meaningful boilerplate.
+
+## Diagnostics
+
+| ID | Meaning |
+| --- | --- |
+| `PKCR001` | `[GenerateContentRouter]` was placed on a non-partial type. |
+| `PKCR002` | The generated content router has no `[ContentRoute]` methods. |
+| `PKCR003` | A route handler or referenced predicate has an invalid signature. |
+| `PKCR004` | The default route handler has an invalid signature or more than one default handler is declared. |
+| `PKCR005` | A route name or route order is duplicated. |
+| `PKRS001`-`PKRS003` | Routing-slip generator validation. |
+| `PKSG001`-`PKSG004` | Saga generator validation. |
+
+## Troubleshooting
+
+- Make the generated host type `partial`.
+- Keep route, step, and saga methods `static`; generated factories reference them directly.
+- Use `nameof(PredicateMethod)` in `[ContentRoute]` so renames remain compile-time safe.
+- Use unique route names and orders. Content routers are first-match, so ambiguous ordering should fail at build time.
+- Ensure generated code builds under nullable enabled; the tests compile generated examples with Release settings.
+
+## API
+
+- <xref:PatternKit.Generators.Messaging.GenerateContentRouterAttribute>
+- <xref:PatternKit.Generators.Messaging.ContentRouteAttribute>
+- <xref:PatternKit.Generators.Messaging.ContentRouteDefaultAttribute>
+- <xref:PatternKit.Generators.Messaging.GenerateRoutingSlipAttribute>
+- <xref:PatternKit.Generators.Messaging.RoutingSlipStepAttribute>
+- <xref:PatternKit.Generators.Messaging.GenerateSagaAttribute>
+- <xref:PatternKit.Generators.Messaging.SagaStepAttribute>
+- <xref:PatternKit.Generators.Messaging.SagaCompleteWhenAttribute>
+- <xref:PatternKit.Messaging.Routing.ContentRouter`2>
+
+## Example Source
+
+- `src/PatternKit.Examples/Messaging/ContentRouterGeneratorExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/ContentRouterGeneratorExampleTests.cs`

--- a/docs/patterns/toc.yml
+++ b/docs/patterns/toc.yml
@@ -307,6 +307,8 @@
           href: messaging/mailbox.md
         - name: Idempotent Receiver, Inbox, and Outbox
           href: messaging/reliability.md
+        - name: Enterprise Integration Source Generators
+          href: messaging/enterprise-generators.md
         - name: Source-Generated Dispatcher
           href: messaging/dispatcher.md
     - name: Type-Dispatcher

--- a/src/PatternKit.Examples/Messaging/ContentRouterGeneratorExample.cs
+++ b/src/PatternKit.Examples/Messaging/ContentRouterGeneratorExample.cs
@@ -1,0 +1,37 @@
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Demonstrates a generated content-router factory for message routing.
+/// </summary>
+public static class ContentRouterGeneratorExample
+{
+    /// <summary>Routes a generated content-router example order.</summary>
+    public static string Run(string channel)
+        => GeneratedOrderRouter.Create().Route(Message<GeneratedOrder>.Create(new GeneratedOrder(channel)));
+}
+
+/// <summary>Generated content-router example payload.</summary>
+public sealed record GeneratedOrder(string Channel);
+
+/// <summary>Generated content-router demo routes.</summary>
+[GenerateContentRouter(typeof(GeneratedOrder), typeof(string))]
+public static partial class GeneratedOrderRouter
+{
+    private static bool IsWholesale(Message<GeneratedOrder> message, MessageContext context)
+        => message.Payload.Channel == "wholesale";
+
+    private static bool IsRetail(Message<GeneratedOrder> message, MessageContext context)
+        => message.Payload.Channel == "retail";
+
+    [ContentRoute("wholesale", 10, nameof(IsWholesale))]
+    private static string Wholesale(Message<GeneratedOrder> message, MessageContext context) => "wholesale";
+
+    [ContentRoute("retail", 20, nameof(IsRetail))]
+    private static string Retail(Message<GeneratedOrder> message, MessageContext context) => "retail";
+
+    [ContentRouteDefault]
+    private static string Default(Message<GeneratedOrder> message, MessageContext context) => "default";
+}

--- a/src/PatternKit.Generators.Abstractions/Messaging/ContentRouterAttributes.cs
+++ b/src/PatternKit.Generators.Abstractions/Messaging/ContentRouterAttributes.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace PatternKit.Generators.Messaging;
+
+/// <summary>
+/// Generates a typed content-router factory for a partial class or struct.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+public sealed class GenerateContentRouterAttribute : Attribute
+{
+    /// <summary>Creates a content-router generator attribute.</summary>
+    public GenerateContentRouterAttribute(Type payloadType, Type resultType)
+    {
+        PayloadType = payloadType ?? throw new ArgumentNullException(nameof(payloadType));
+        ResultType = resultType ?? throw new ArgumentNullException(nameof(resultType));
+    }
+
+    /// <summary>Message payload type routed by the generated content router.</summary>
+    public Type PayloadType { get; }
+
+    /// <summary>Route handler result type returned by the generated content router.</summary>
+    public Type ResultType { get; }
+
+    /// <summary>Name of the generated factory method.</summary>
+    public string FactoryName { get; set; } = "Create";
+}
+
+/// <summary>
+/// Marks a static method as a generated content-router route handler.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class ContentRouteAttribute : Attribute
+{
+    /// <summary>Creates a content-router route attribute.</summary>
+    public ContentRouteAttribute(string name, int order, string predicateMethodName)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Content route name cannot be null, empty, or whitespace.", nameof(name));
+
+        if (string.IsNullOrWhiteSpace(predicateMethodName))
+            throw new ArgumentException("Content route predicate method name cannot be null, empty, or whitespace.", nameof(predicateMethodName));
+
+        Name = name;
+        Order = order;
+        PredicateMethodName = predicateMethodName;
+    }
+
+    /// <summary>Route name used for diagnostics and duplicate validation.</summary>
+    public string Name { get; }
+
+    /// <summary>Route order in the generated content router.</summary>
+    public int Order { get; }
+
+    /// <summary>Name of the static predicate method used by this route.</summary>
+    public string PredicateMethodName { get; }
+}
+
+/// <summary>
+/// Marks a static method as the generated content-router default handler.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class ContentRouteDefaultAttribute : Attribute;

--- a/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/PatternKit.Generators/AnalyzerReleases.Unshipped.md
@@ -165,3 +165,8 @@ PKSG001 | PatternKit.Generators.Messaging | Error | Saga type must be partial
 PKSG002 | PatternKit.Generators.Messaging | Error | Saga has no steps
 PKSG003 | PatternKit.Generators.Messaging | Error | Saga step signature is invalid
 PKSG004 | PatternKit.Generators.Messaging | Error | Saga completion signature is invalid
+PKCR001 | PatternKit.Generators.Messaging | Error | Content router type must be partial.
+PKCR002 | PatternKit.Generators.Messaging | Error | Content router must declare at least one route.
+PKCR003 | PatternKit.Generators.Messaging | Error | Content route handler or predicate signature is invalid.
+PKCR004 | PatternKit.Generators.Messaging | Error | Content router default handler signature is invalid.
+PKCR005 | PatternKit.Generators.Messaging | Error | Content router route name or order is duplicated.

--- a/src/PatternKit.Generators/Messaging/ContentRouterGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/ContentRouterGenerator.cs
@@ -1,0 +1,292 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace PatternKit.Generators.Messaging;
+
+[Generator]
+public sealed class ContentRouterGenerator : IIncrementalGenerator
+{
+    private static readonly DiagnosticDescriptor MustBePartial = new(
+        "PKCR001",
+        "Content router type must be partial",
+        "Type '{0}' is marked with [GenerateContentRouter] but is not declared as partial",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor MissingRoutes = new(
+        "PKCR002",
+        "Content router has no routes",
+        "Type '{0}' is marked with [GenerateContentRouter] but does not declare any [ContentRoute] methods",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor InvalidRoute = new(
+        "PKCR003",
+        "Content router route signature is invalid",
+        "Content route '{0}' must be static, return TResult, and reference a static bool predicate with Message<TPayload> and MessageContext parameters",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor InvalidDefault = new(
+        "PKCR004",
+        "Content router default signature is invalid",
+        "Content router default '{0}' must be static and return TResult with Message<TPayload> and MessageContext parameters",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    private static readonly DiagnosticDescriptor DuplicateRoute = new(
+        "PKCR005",
+        "Content router route name or order is duplicated",
+        "Content route '{0}' duplicates another route name or order in '{1}'",
+        "PatternKit.Generators.Messaging",
+        DiagnosticSeverity.Error,
+        true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var candidates = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "PatternKit.Generators.Messaging.GenerateContentRouterAttribute",
+            static (node, _) => node is TypeDeclarationSyntax,
+            static (ctx, _) => (Type: (INamedTypeSymbol)ctx.TargetSymbol, Node: (TypeDeclarationSyntax)ctx.TargetNode, Attributes: ctx.Attributes));
+
+        context.RegisterSourceOutput(candidates, static (spc, candidate) =>
+        {
+            var attr = candidate.Attributes.FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.GenerateContentRouterAttribute");
+            if (attr is null)
+                return;
+
+            Generate(spc, candidate.Type, candidate.Node, attr);
+        });
+    }
+
+    private static void Generate(
+        SourceProductionContext context,
+        INamedTypeSymbol type,
+        TypeDeclarationSyntax node,
+        AttributeData attribute)
+    {
+        if (!node.Modifiers.Any(static modifier => modifier.Text == "partial"))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustBePartial, node.Identifier.GetLocation(), type.Name));
+            return;
+        }
+
+        var payloadType = attribute.ConstructorArguments.Length >= 1
+            ? attribute.ConstructorArguments[0].Value as INamedTypeSymbol
+            : null;
+        var resultType = attribute.ConstructorArguments.Length >= 2
+            ? attribute.ConstructorArguments[1].Value as INamedTypeSymbol
+            : null;
+        if (payloadType is null || resultType is null)
+            return;
+
+        var hasRouteAttributes = type.GetMembers().OfType<IMethodSymbol>().Any(static method =>
+            method.GetAttributes().Any(static attr =>
+                attr.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.ContentRouteAttribute"));
+        var routes = GetRoutes(type, payloadType, resultType, context);
+        if (routes.Length == 0)
+        {
+            if (!hasRouteAttributes)
+                context.ReportDiagnostic(Diagnostic.Create(MissingRoutes, node.Identifier.GetLocation(), type.Name));
+            return;
+        }
+
+        if (HasDuplicates(routes, out var duplicate))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(DuplicateRoute, duplicate.Location, duplicate.Name, type.Name));
+            return;
+        }
+
+        var defaultHandler = GetDefaultHandler(type, payloadType, resultType, context);
+        var factoryName = GetNamedString(attribute, "FactoryName") ?? "Create";
+        var ordered = routes.OrderBy(static route => route.Order).ThenBy(static route => route.Name).ToArray();
+
+        context.AddSource($"{type.Name}.ContentRouter.g.cs", SourceText.From(
+            GenerateSource(type, payloadType, resultType, ordered, defaultHandler, factoryName),
+            Encoding.UTF8));
+    }
+
+    private static ImmutableArray<Route> GetRoutes(
+        INamedTypeSymbol type,
+        INamedTypeSymbol payloadType,
+        INamedTypeSymbol resultType,
+        SourceProductionContext context)
+    {
+        var builder = ImmutableArray.CreateBuilder<Route>();
+        foreach (var method in type.GetMembers().OfType<IMethodSymbol>())
+        {
+            var attr = method.GetAttributes().FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.ContentRouteAttribute");
+            if (attr is null)
+                continue;
+
+            if (!TryGetRoute(type, method, payloadType, resultType, attr, out var route))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(InvalidRoute, method.Locations.FirstOrDefault(), method.Name));
+                continue;
+            }
+
+            builder.Add(route);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static bool TryGetRoute(
+        INamedTypeSymbol type,
+        IMethodSymbol handler,
+        INamedTypeSymbol payloadType,
+        INamedTypeSymbol resultType,
+        AttributeData attribute,
+        out Route route)
+    {
+        route = default;
+        if (!handler.IsStatic || attribute.ConstructorArguments.Length != 3)
+            return false;
+
+        var name = attribute.ConstructorArguments[0].Value as string;
+        var order = attribute.ConstructorArguments[1].Value as int? ?? 0;
+        var predicateName = attribute.ConstructorArguments[2].Value as string;
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(predicateName))
+            return false;
+
+        var predicate = type.GetMembers(predicateName!).OfType<IMethodSymbol>().FirstOrDefault();
+        if (predicate is null || !IsPredicate(predicate, payloadType) || !IsHandler(handler, payloadType, resultType))
+            return false;
+
+        route = new Route(name!, order, predicate.Name, handler.Name, handler.Locations.FirstOrDefault());
+        return true;
+    }
+
+    private static string? GetDefaultHandler(
+        INamedTypeSymbol type,
+        INamedTypeSymbol payloadType,
+        INamedTypeSymbol resultType,
+        SourceProductionContext context)
+    {
+        string? handler = null;
+        foreach (var method in type.GetMembers().OfType<IMethodSymbol>())
+        {
+            if (!method.GetAttributes().Any(static attr =>
+                    attr.AttributeClass?.ToDisplayString() == "PatternKit.Generators.Messaging.ContentRouteDefaultAttribute"))
+            {
+                continue;
+            }
+
+            if (handler is not null || !IsHandler(method, payloadType, resultType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(InvalidDefault, method.Locations.FirstOrDefault(), method.Name));
+                continue;
+            }
+
+            handler = method.Name;
+        }
+
+        return handler;
+    }
+
+    private static bool IsPredicate(IMethodSymbol method, INamedTypeSymbol payloadType)
+        => method.IsStatic &&
+           method.ReturnType.SpecialType == SpecialType.System_Boolean &&
+           method.Parameters.Length == 2 &&
+           IsMessageOfPayload(method.Parameters[0].Type, payloadType) &&
+           method.Parameters[1].Type.ToDisplayString() == "PatternKit.Messaging.MessageContext";
+
+    private static bool IsHandler(IMethodSymbol method, INamedTypeSymbol payloadType, INamedTypeSymbol resultType)
+        => method.IsStatic &&
+           SymbolEqualityComparer.Default.Equals(method.ReturnType, resultType) &&
+           method.Parameters.Length == 2 &&
+           IsMessageOfPayload(method.Parameters[0].Type, payloadType) &&
+           method.Parameters[1].Type.ToDisplayString() == "PatternKit.Messaging.MessageContext";
+
+    private static bool IsMessageOfPayload(ITypeSymbol type, INamedTypeSymbol payloadType)
+        => type is INamedTypeSymbol named &&
+           named.ConstructedFrom.ToDisplayString() == "PatternKit.Messaging.Message<TPayload>" &&
+           SymbolEqualityComparer.Default.Equals(named.TypeArguments[0], payloadType);
+
+    private static bool HasDuplicates(IReadOnlyList<Route> routes, out Route duplicate)
+    {
+        var names = new HashSet<string>(System.StringComparer.Ordinal);
+        var orders = new HashSet<int>();
+        foreach (var route in routes)
+        {
+            if (!names.Add(route.Name) || !orders.Add(route.Order))
+            {
+                duplicate = route;
+                return true;
+            }
+        }
+
+        duplicate = default;
+        return false;
+    }
+
+    private static string GenerateSource(
+        INamedTypeSymbol type,
+        INamedTypeSymbol payloadType,
+        INamedTypeSymbol resultType,
+        IReadOnlyList<Route> routes,
+        string? defaultHandler,
+        string factoryName)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+
+        var ns = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString();
+        if (ns is not null)
+        {
+            sb.Append("namespace ").Append(ns).AppendLine(";");
+            sb.AppendLine();
+        }
+
+        sb.Append("partial ").Append(GetKind(type)).Append(' ').Append(type.Name).AppendLine();
+        sb.AppendLine("{");
+        sb.Append("    public static global::PatternKit.Messaging.Routing.ContentRouter<")
+            .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+            .Append(", ")
+            .Append(resultType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+            .Append("> ")
+            .Append(factoryName)
+            .AppendLine("()");
+        sb.Append("        => global::PatternKit.Messaging.Routing.ContentRouter<")
+            .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+            .Append(", ")
+            .Append(resultType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+            .AppendLine(">.Create()");
+
+        foreach (var route in routes)
+            sb.Append("            .When(").Append(route.PredicateMethodName).Append(").Then(").Append(route.HandlerMethodName).AppendLine(")");
+
+        if (defaultHandler is not null)
+            sb.Append("            .Default(").Append(defaultHandler).AppendLine(")");
+
+        sb.AppendLine("            .Build();");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string GetKind(INamedTypeSymbol type)
+        => type.TypeKind == TypeKind.Struct ? "struct" : "class";
+
+    private static string? GetNamedString(AttributeData attribute, string name)
+        => attribute.NamedArguments.FirstOrDefault(kv => kv.Key == name).Value.Value as string;
+
+    private readonly record struct Route(
+        string Name,
+        int Order,
+        string PredicateMethodName,
+        string HandlerMethodName,
+        Location? Location);
+}

--- a/test/PatternKit.Examples.Tests/Messaging/ContentRouterGeneratorExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ContentRouterGeneratorExampleTests.cs
@@ -1,0 +1,15 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class ContentRouterGeneratorExampleTests
+{
+    [Theory]
+    [InlineData("wholesale", "wholesale")]
+    [InlineData("retail", "retail")]
+    [InlineData("unknown", "default")]
+    public void Run_RoutesGeneratedContentRouter(string channel, string expected)
+    {
+        Assert.Equal(expected, ContentRouterGeneratorExample.Run(channel));
+    }
+}

--- a/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
@@ -74,6 +74,9 @@ public sealed class AbstractionsAttributeCoverageTests
         { typeof(GenerateSagaAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
         { typeof(SagaStepAttribute), AttributeTargets.Method, false, false },
         { typeof(SagaCompleteWhenAttribute), AttributeTargets.Method, false, false },
+        { typeof(GenerateContentRouterAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
+        { typeof(ContentRouteAttribute), AttributeTargets.Method, false, false },
+        { typeof(ContentRouteDefaultAttribute), AttributeTargets.Method, false, false },
         { typeof(ObserverAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
         { typeof(ObserverHubAttribute), AttributeTargets.Class, false, false },
         { typeof(ObservedEventAttribute), AttributeTargets.Property, false, false },
@@ -315,6 +318,11 @@ public sealed class AbstractionsAttributeCoverageTests
             AsyncFactoryName = "BuildSagaAsync"
         };
         var sagaStep = new SagaStepAttribute(typeof(decimal), 11);
+        var router = new GenerateContentRouterAttribute(typeof(string), typeof(int))
+        {
+            FactoryName = "BuildRouter"
+        };
+        var route = new ContentRouteAttribute("priority", 4, "IsPriority");
 
         Assert.Equal(typeof(string), flyweight.KeyType);
         Assert.Equal("SymbolCache", flyweight.CacheTypeName);
@@ -339,11 +347,22 @@ public sealed class AbstractionsAttributeCoverageTests
         Assert.Equal("BuildSagaAsync", saga.AsyncFactoryName);
         Assert.Equal(typeof(decimal), sagaStep.MessageType);
         Assert.Equal(11, sagaStep.Order);
+        Assert.Equal(typeof(string), router.PayloadType);
+        Assert.Equal(typeof(int), router.ResultType);
+        Assert.Equal("BuildRouter", router.FactoryName);
+        Assert.Equal("priority", route.Name);
+        Assert.Equal(4, route.Order);
+        Assert.Equal("IsPriority", route.PredicateMethodName);
         Assert.Throws<ArgumentNullException>(() => new GenerateRoutingSlipAttribute(null!));
         Assert.Throws<ArgumentException>(() => new RoutingSlipStepAttribute("", 1));
         Assert.Throws<ArgumentNullException>(() => new GenerateSagaAttribute(null!));
         Assert.Throws<ArgumentNullException>(() => new SagaStepAttribute(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => new GenerateContentRouterAttribute(null!, typeof(int)));
+        Assert.Throws<ArgumentNullException>(() => new GenerateContentRouterAttribute(typeof(string), null!));
+        Assert.Throws<ArgumentException>(() => new ContentRouteAttribute("", 1, "Predicate"));
+        Assert.Throws<ArgumentException>(() => new ContentRouteAttribute("name", 1, ""));
         Assert.IsType<SagaCompleteWhenAttribute>(new SagaCompleteWhenAttribute());
+        Assert.IsType<ContentRouteDefaultAttribute>(new ContentRouteDefaultAttribute());
         Assert.IsType<FlyweightFactoryAttribute>(new FlyweightFactoryAttribute());
         Assert.IsType<IteratorStepAttribute>(new IteratorStepAttribute());
         Assert.IsType<TraversalIteratorAttribute>(new TraversalIteratorAttribute());

--- a/test/PatternKit.Generators.Tests/ContentRouterGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ContentRouterGeneratorTests.cs
@@ -1,0 +1,213 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using PatternKit.Generators.Messaging;
+
+namespace PatternKit.Generators.Tests;
+
+public sealed class ContentRouterGeneratorTests
+{
+    [Fact]
+    public void GeneratesContentRouterFactory()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Channel);
+
+            [GenerateContentRouter(typeof(Order), typeof(string), FactoryName = "Build")]
+            public static partial class OrderRouter
+            {
+                private static bool IsWholesale(Message<Order> message, MessageContext context)
+                    => message.Payload.Channel == "wholesale";
+
+                private static bool IsRetail(Message<Order> message, MessageContext context)
+                    => message.Payload.Channel == "retail";
+
+                [ContentRoute("retail", 20, nameof(IsRetail))]
+                private static string Retail(Message<Order> message, MessageContext context) => "retail";
+
+                [ContentRoute("wholesale", 10, nameof(IsWholesale))]
+                private static string Wholesale(Message<Order> message, MessageContext context) => "wholesale";
+
+                [ContentRouteDefault]
+                private static string Default(Message<Order> message, MessageContext context) => "default";
+            }
+
+            public static class Demo
+            {
+                public static string Run()
+                    => OrderRouter.Build().Route(Message<Order>.Create(new Order("wholesale")));
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesContentRouterFactory));
+        var gen = new ContentRouterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
+        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        Assert.Equal("OrderRouter.ContentRouter.g.cs", generated.HintName);
+        var text = generated.SourceText.ToString();
+        Assert.Contains(".When(IsWholesale).Then(Wholesale)", text);
+        Assert.Contains(".When(IsRetail).Then(Retail)", text);
+        Assert.Contains(".Default(Default)", text);
+        Assert.True(text.IndexOf("IsWholesale", StringComparison.Ordinal) < text.IndexOf("IsRetail", StringComparison.Ordinal));
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForNonPartialRouter()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Channel);
+
+            [GenerateContentRouter(typeof(Order), typeof(string))]
+            public static class OrderRouter
+            {
+                private static bool IsRetail(Message<Order> message, MessageContext context) => true;
+
+                [ContentRoute("retail", 10, nameof(IsRetail))]
+                private static string Retail(Message<Order> message, MessageContext context) => "retail";
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForNonPartialRouter));
+        var gen = new ContentRouterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKCR001", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForMissingRoutes()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Channel);
+
+            [GenerateContentRouter(typeof(Order), typeof(string))]
+            public static partial class OrderRouter;
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForMissingRoutes));
+        var gen = new ContentRouterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKCR002", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForInvalidRouteSignature()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Channel);
+
+            [GenerateContentRouter(typeof(Order), typeof(string))]
+            public static partial class OrderRouter
+            {
+                private static bool IsRetail(Message<Order> message, MessageContext context) => true;
+
+                [ContentRoute("retail", 10, nameof(IsRetail))]
+                private static int Retail(Message<Order> message, MessageContext context) => 1;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidRouteSignature));
+        var gen = new ContentRouterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKCR003", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForInvalidDefaultSignature()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Channel);
+
+            [GenerateContentRouter(typeof(Order), typeof(string))]
+            public static partial class OrderRouter
+            {
+                private static bool IsRetail(Message<Order> message, MessageContext context) => true;
+
+                [ContentRoute("retail", 10, nameof(IsRetail))]
+                private static string Retail(Message<Order> message, MessageContext context) => "retail";
+
+                [ContentRouteDefault]
+                private static int Default(Message<Order> message, MessageContext context) => 1;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidDefaultSignature));
+        var gen = new ContentRouterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKCR004", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForDuplicateRouteNameOrOrder()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record Order(string Channel);
+
+            [GenerateContentRouter(typeof(Order), typeof(string))]
+            public static partial class OrderRouter
+            {
+                private static bool IsRetail(Message<Order> message, MessageContext context) => true;
+                private static bool IsWholesale(Message<Order> message, MessageContext context) => true;
+
+                [ContentRoute("retail", 10, nameof(IsRetail))]
+                private static string Retail(Message<Order> message, MessageContext context) => "retail";
+
+                [ContentRoute("wholesale", 10, nameof(IsWholesale))]
+                private static string Wholesale(Message<Order> message, MessageContext context) => "wholesale";
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForDuplicateRouteNameOrOrder));
+        var gen = new ContentRouterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
+        Assert.Equal("PKCR005", diagnostic.Id);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, string assemblyName)
+        => RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName,
+            extra: MetadataReference.CreateFromFile(typeof(PatternKit.Messaging.Message<>).Assembly.Location));
+}


### PR DESCRIPTION
Closes #178.

## Summary
- add GenerateContentRouter, ContentRoute, and ContentRouteDefault attributes
- add ContentRouterGenerator with partial, missing route, invalid signature, invalid default, and duplicate route diagnostics
- add generated content-router example and tests
- add enterprise integration generator docs with attribute reference, diagnostics, troubleshooting, and links to routing slip/saga generators

## Validation
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Tests\\PatternKit.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test\\PatternKit.Generators.Tests\\PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- docfx metadata docs\\docfx.json
- docfx build docs\\docfx.json
- git diff --check