### PR TITLE
docs: audit example and generator coverage

### DIFF
--- a/docs/examples/enterprise-messaging-workflows.md
+++ b/docs/examples/enterprise-messaging-workflows.md
@@ -1,0 +1,85 @@
+# Enterprise Messaging Workflow Suite
+
+The messaging examples demonstrate in-process Enterprise Integration Patterns without pretending to be a broker, queue, or durable workflow engine. They show where PatternKit fits: message metadata, deterministic routing, workflow composition, idempotency boundaries, serialized processing, and generated factories for static topologies.
+
+Example source:
+
+- `src/PatternKit.Examples/Messaging`
+- `test/PatternKit.Examples.Tests/Messaging`
+
+## Pattern Map
+
+| Pattern | Example source | What it demonstrates |
+| --- | --- | --- |
+| Message envelope/context | `MessageEnvelopeExample.cs` | Correlation, causation, idempotency, headers, typed payloads, and execution-scoped context. |
+| Content router | `MessageRoutingExample.cs` | First-match routing of orders to named destinations. |
+| Recipient list | `MessageRoutingExample.cs` | Fan-out to multiple interested recipients. |
+| Splitter | `MessageRoutingExample.cs` | Splitting one aggregate message into line-level messages. |
+| Aggregator | `MessageRoutingExample.cs` | Rejoining related messages into a summary. |
+| Routing slip | `RoutingSlipExample.cs` | Ordered fulfillment steps with route progress stored in message headers. |
+| Saga/process manager | `SagaExample.cs` | Typed message transitions over explicit saga state and completion rules. |
+| Mailbox | `MailboxExample.cs` | Serialized async inbox processing with explicit lifecycle and error behavior. |
+| Idempotent receiver | `ReliabilityExample.cs` | Duplicate detection around at-least-once message delivery. |
+| Inbox/outbox | `ReliabilityExample.cs` | Explicit handoff records for durable integration boundaries owned by the application. |
+| Source-generated dispatcher | `DispatcherExample.cs` | Compile-time mediator commands, notifications, streams, and paging. |
+| Source-generated content router | `ContentRouterGeneratorExample.cs` | Attribute-driven content routing without runtime scanning. |
+
+## Workflow Shape
+
+A production application usually combines these primitives in layers:
+
+1. Accept or create a `Message<TPayload>` at the boundary with correlation, causation, and idempotency headers.
+2. Route the message through a content router, recipient list, splitter, or routing slip.
+3. Serialize stateful handlers through a mailbox when concurrency must be constrained.
+4. Use a saga/process manager when multiple messages update long-running state.
+5. Wrap handlers with an idempotent receiver and write outbox records before handing work to external infrastructure.
+
+The examples keep each part small so the ownership boundary stays clear. PatternKit handles in-process composition; persistence, transport, retries across restarts, and exactly-once claims belong to the application and its infrastructure.
+
+## Generated And Runtime Variants
+
+Use runtime builders when the route table, itinerary, or transition set is built from configuration:
+
+```csharp
+var slip = RoutingSlip<FulfillmentOrder>.Create()
+    .Step("reserve", ReserveInventory)
+    .Step("ship", ShipOrder)
+    .Build();
+```
+
+Use source generators when topology is stable and should be compile-time validated:
+
+```csharp
+[GenerateRoutingSlip(typeof(FulfillmentOrder))]
+public static partial class FulfillmentSlip
+{
+    [RoutingSlipStep("reserve", 10)]
+    private static Message<FulfillmentOrder> Reserve(Message<FulfillmentOrder> message, MessageContext context)
+        => message;
+}
+```
+
+The generated factories are AOT-friendly and do not scan assemblies. The runtime builders are better for user- or tenant-defined routing.
+
+## Testing Guidance
+
+The example tests use behavior-oriented assertions:
+
+- Envelope tests assert metadata propagation and immutable message updates.
+- Routing tests assert deterministic first-match and aggregation behavior.
+- Routing-slip tests assert step order and header progress.
+- Saga tests assert transition behavior and completion state.
+- Mailbox tests assert serialized processing and lifecycle semantics.
+- Reliability tests assert duplicate suppression and outbox record creation.
+- Generator tests assert that generated factories compile and behave like the equivalent runtime builders.
+
+## Related Documentation
+
+- [Messaging Patterns](../patterns/messaging/README.md)
+- [Message Envelope and Context](../patterns/messaging/message-envelope.md)
+- [Enterprise Message Routing](../patterns/messaging/message-routing.md)
+- [Routing Slip](../patterns/messaging/routing-slip.md)
+- [Saga / Process Manager](../patterns/messaging/saga.md)
+- [Mailbox](../patterns/messaging/mailbox.md)
+- [Idempotent Receiver, Inbox, and Outbox](../patterns/messaging/reliability.md)
+- [Messaging Generators](../generators/messaging.md)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -13,6 +13,8 @@ Welcome! This section collects small, focused demos that show **how to compose b
 * **Ultra-minimal HTTP routing** to illustrate middleware vs. routes vs. negotiation.
 * **Flyweight identity sharing** to eliminate duplicate immutable objects (glyphs, styles, tokens).
 * **Snapshot history & undo/redo (Memento)** for document/editor style workflows.
+* **Source-generated application wiring** for builders, factories, facades, proxies, observers, visitors, state machines, strategies, mementos, template methods, and messaging factories.
+* **Enterprise messaging workflows** for envelopes, routers, recipient lists, splitters, aggregators, routing slips, sagas, mailboxes, idempotent receivers, inboxes, and outboxes.
 
 ## Demos in this section
 
@@ -37,13 +39,13 @@ Welcome! This section collects small, focused demos that show **how to compose b
 * **Payment Processor — Fluent Decorator Pattern for Point of Sale**
   Demonstrates the **Decorator** pattern for building flexible payment processors. Shows how to layer tax calculation, promotional discounts, loyalty programs, employee benefits, and rounding strategies on a base processor—**no inheritance hierarchies**. Includes five real-world processors (simple, retail, e-commerce, cash register, birthday special) with full test coverage. Perfect for understanding decorator execution order and composition patterns.
 
-* **Flyweight Glyph Cache & Style Sharing**  
+* **Flyweight Glyph Cache & Style Sharing**
   Shows a high-volume text/glyph layout where each distinct glyph (and style) is allocated **once** and reused. Demonstrates intrinsic vs extrinsic state separation, preload of hot keys (spaces), custom key comparers (case-insensitive styles), and thread-safe lazy creation—mirroring classic Flyweight scenarios (rendering, AST token metadata, icon caches).
 
-* **Document Editing History (Memento)**  
+* **Document Editing History (Memento)**
   A simple document buffer with tagged snapshots, undo/redo, jump-to-version, and duplicate suppression illustrating the **Memento** pattern's practical shape in a UI/editor workflow.
 
-* **State Machine — Order Lifecycle**  
+* **State Machine — Order Lifecycle**
   A fluent state machine driving an order lifecycle with entry/exit hooks, transition effects, and default per‑state behavior. Shows determinism (first‑match wins), internal (Stay) vs cross‑state transitions, and log/audit side‑effects.
 
 * **Template Method Data Processor**
@@ -51,6 +53,12 @@ Welcome! This section collects small, focused demos that show **how to compose b
 
 * **Template Method Async Pipeline**
   End-to-end async pipeline (fetch → transform → store) with cancellation, optional synchronization, and error observation. Shows both subclassing (`AsyncTemplateMethod`) and fluent (`AsyncTemplate`) approaches. See [Template Method Async Demo](template-method-async-demo.md).
+
+* **Source Generator Application Suite**
+  A production-shaped generator suite covering DI module wiring, corporate host composition, generated facades, generated proxies, generated observers, generated mementos, generated state machines, generated strategies, generated visitors, generated template methods, and messaging generators. See [Source Generator Application Suite](source-generator-application-suite.md).
+
+* **Enterprise Messaging Workflow Suite**
+  End-to-end messaging examples for envelopes, content routing, recipient lists, splitters, aggregators, routing slips, sagas, mailboxes, idempotent receivers, inboxes, outboxes, and generated messaging factories. See [Enterprise Messaging Workflow Suite](enterprise-messaging-workflows.md).
 
 ## How to run
 
@@ -91,6 +99,9 @@ dotnet test PatternKit.slnx -c Release
 * **Flyweight Structural Tests:** `Structural/Flyweight/FlyweightTests.cs` — preload, concurrency, comparer, guards.
 * **Memento Document Demo:** `MementoDemo` — buffer edits with undo/redo and tags.
 * **State Machine Demo:** `OrderStateDemo` (+ `StateDemoTests`) — order lifecycle with entry/exit hooks and default behaviors.
+* **Source Generator Suite:** `src/PatternKit.Examples/Generators` (+ `PatternKit.Examples.Tests/Generators`) — generated builders, factories, facades, mementos, state machines, strategies, visitors, and host-style composition.
+* **Generator Boundary Demos:** `AdapterGeneratorDemo`, `ObserverGeneratorDemo`, `ProxyGeneratorDemo`, `SingletonGeneratorDemo`, `TemplateMethodGeneratorDemo` (+ matching tests) — generated adapters, observers, proxies, singletons, and template workflows.
+* **Enterprise Messaging:** `src/PatternKit.Examples/Messaging` (+ `PatternKit.Examples.Tests/Messaging`) — runtime and generated messaging workflows.
 * **Tests:** `PatternKit.Examples.Tests/*` use TinyBDD scenarios that read like specs.
 
 ## Why these demos exist

--- a/docs/examples/patterns-showcase.md
+++ b/docs/examples/patterns-showcase.md
@@ -42,7 +42,7 @@ var (ok, message, total) = facade.Place(dto);
 - Adapter — `OrderDto` → `Order`: field mapping + validation.
 - Factory — `IPaymentGateway` selection by key: `sandbox`, `stripe`, default.
 - Strategy — Discount rules over `OrderContext` (first match wins).
-- Visitor — Payment fee by runtime type (`Cash`, `Card`).
+- TypeDispatcher — Payment fee by runtime type (`Cash`, `Card`).
 - Template — Algorithm skeleton: compute totals → execute commands → emit events/receipt.
 - Command — Reversible steps: reserve inventory, charge payment, schedule shipment, composed as a macro.
 - Mediator — Generate receipt and emit notifications (decoupled handlers/pre/post behaviors).
@@ -53,9 +53,9 @@ var (ok, message, total) = facade.Place(dto);
 
 ## Similarities And Differences
 
-- Visitor vs Strategy
+- TypeDispatcher vs Strategy
   - Similar: both route to behavior based on a condition.
-  - Different: Visitor dispatches by runtime type; Strategy dispatches by boolean predicates. Use Visitor when the type tells you the behavior; Strategy when rules are data/condition‑driven.
+  - Different: TypeDispatcher dispatches by runtime type; Strategy dispatches by boolean predicates. Use TypeDispatcher when the type tells you the behavior; Strategy when rules are data/condition-driven.
 
 - Adapter vs Facade
   - Similar: both present a friendlier surface area.
@@ -69,15 +69,15 @@ var (ok, message, total) = facade.Place(dto);
   - Similar: decouple senders from receivers.
   - Different: Mediator is request/response + pipeline behaviors; Observer is pub/sub broadcast. Use Mediator for commands/queries, Observer for fan‑out notifications.
 
-- Factory vs Visitor
+- Factory vs TypeDispatcher
   - Similar: both pick a concrete implementation.
-  - Different: Factory chooses a product by key; Visitor chooses a handler by input type at runtime. Use Factory for creation, Visitor for behavior.
+  - Different: Factory chooses a product by key; TypeDispatcher chooses a handler by input type at runtime. Use Factory for creation, TypeDispatcher for behavior.
 
 ---
 
 ## Best‑Fit Guidance
 
-- Type‑based behavior → Visitor (`Payment` handling).
+- Type-based behavior → TypeDispatcher (`Payment` handling).
 - Rule‑based selection → Strategy (`OrderContext` discounts).
 - Boundary transformation → Adapter (`OrderDto` to `Order`).
 - Consistent flow with hooks → Template (compute totals, run commands, report).
@@ -94,7 +94,7 @@ var (ok, message, total) = facade.Place(dto);
 - Adapter: `BuildOrderAdapter` — validates `OrderId` and requires ≥1 item.
 - Factory: `BuildPaymentFactory` — string key to `IPaymentGateway` mapping.
 - Strategy: `BuildDiscountStrategy` — promo category or VIP id.
-- Visitor: `BuildFeeVisitor` — 2.9% card fee with min $0.30, $0 for cash.
+- TypeDispatcher: `BuildFeeDispatcher` — 2.9% card fee with min $0.30, $0 for cash.
 - Template + Commands: `BuildTemplatePipeline` — reserve → charge → schedule; error hook appends to audit.
 - Mediator + Observer: `BuildMediatorAndEvents` — receipt command + AUDIT publish.
 - Facade: `Build()` — wires everything together.

--- a/docs/examples/source-generator-application-suite.md
+++ b/docs/examples/source-generator-application-suite.md
@@ -1,0 +1,82 @@
+# Source Generator Application Suite
+
+This example suite shows how PatternKit generators remove boilerplate while preserving explicit application architecture. The examples live under `src/PatternKit.Examples/Generators` and are validated by `test/PatternKit.Examples.Tests/Generators`.
+
+The examples are intentionally application-shaped: DI module setup, orchestrated startup steps, generated facades, builder-driven host composition, source-generated strategies, generated mementos, generated state machines, and generated visitors.
+
+## Pattern Map
+
+| Generator | Example source | Test source | Production shape |
+| --- | --- | --- | --- |
+| Builder | `src/PatternKit.Examples/Generators/Builders/CorporateApplicationBuilderDemo` | `test/PatternKit.Examples.Tests/Generators/CorporateApplicationBuilderDemoTests.cs` | Host/application composition similar to ASP.NET Core extension methods. |
+| Factory Method | `src/PatternKit.Examples/Generators/Factories/FactoryGeneratorExamples.cs` | `test/PatternKit.Examples.Tests/Generators/FactoryGeneratorExamplesTests.cs` | Configuration keys map to `IServiceCollection` module wiring. |
+| Factory Class | `src/PatternKit.Examples/Generators/Factories/FactoryGeneratorExamples.cs` | `test/PatternKit.Examples.Tests/Generators/FactoryGeneratorExamplesTests.cs` | Startup orchestration steps are selected by stable string keys. |
+| Facade | `src/PatternKit.Examples/Generators/Facade` | `test/PatternKit.Examples.Tests/Generators/FacadeSpecsTests.cs` | Billing and shipping subsystem operations are exposed through focused facades. |
+| Memento | `src/PatternKit.Examples/Generators/Memento` | `test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs` | Editor and game state snapshots support undo, restore, and state checkpointing. |
+| State Machine | `src/PatternKit.Examples/Generators/State/OrderFlowDemo.cs` | `test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs` | Order lifecycle transitions are generated from explicit state metadata. |
+| Strategy | `src/PatternKit.Examples/Generators/Strategies/StrategySpecs.cs` | `test/PatternKit.Examples.Tests/Generators/StrategySpecsTests.cs` | Generated action, result, and try strategies replace repetitive routing scaffolding. |
+| Visitor | `src/PatternKit.Examples/Generators/Visitors/DocumentProcessingDemo.cs` | `test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs` | Document processing uses generated visitor interfaces, accept methods, and builders. |
+| Adapter | `src/PatternKit.Examples/AdapterGeneratorDemo` | `test/PatternKit.Examples.Tests/AdapterGeneratorDemo/AdapterGeneratorDemoTests.cs` | External payment, logging, and clock contracts are adapted into internal abstractions. |
+| Observer | `src/PatternKit.Examples/ObserverGeneratorDemo` | `test/PatternKit.Examples.Tests/ObserverGeneratorDemo/ObserverGeneratorDemoTests.cs` | Notification and telemetry systems use generated event hubs and typed subscriptions. |
+| Proxy | `src/PatternKit.Examples/ProxyGeneratorDemo` | `test/PatternKit.Examples.Tests/ProxyGeneratorDemo/ProxyGeneratorDemoTests.cs` | Payment service calls are wrapped by generated authentication, caching, logging, retry, and timing interceptors. |
+| Singleton | `src/PatternKit.Examples/SingletonGeneratorDemo` | `test/PatternKit.Examples.Tests/SingletonGeneratorDemo/SingletonGeneratorDemoTests.cs` | Configuration, clocks, and service registries expose generated singleton accessors. |
+| Template Method | `src/PatternKit.Examples/TemplateMethodGeneratorDemo` | `test/PatternKit.Examples.Tests/TemplateMethodGeneratorDemo` | Import and order-processing workflows are generated from ordered steps and hook points. |
+| Messaging | `src/PatternKit.Examples/Messaging` | `test/PatternKit.Examples.Tests/Messaging` | Dispatchers, content routers, routing slips, and sagas are generated for in-process enterprise integration flows. |
+
+## Corporate Application Builder
+
+`CorporateApplicationBuilderDemo` is the most complete host-style generator example. It models a production startup surface where teams compose a host with environment selection, observability, messaging, background jobs, secrets, startup tasks, and module validation.
+
+```csharp
+var app = await CorporateApplicationDemo.CreateBuilder()
+    .ForEnvironment(CorporateEnvironment.Production)
+    .EnableMessaging()
+    .EnableJobs()
+    .LoadSecrets()
+    .AddStartupTasks()
+    .RequireModules()
+    .BuildAndInitializeAsync();
+```
+
+The generated builder keeps fluent application composition explicit. Extension methods such as `EnableMessaging()` and `EnableJobs()` remain handwritten application policy, while `[GenerateBuilder]` owns the repetitive builder plumbing.
+
+## DI Module And Orchestrator Factories
+
+`FactoryGeneratorExamples.cs` demonstrates two factory styles:
+
+- `[FactoryMethod]` maps module names to `IServiceCollection` setup functions.
+- `[FactoryClass]` maps orchestration keys to concrete startup steps.
+
+```csharp
+var provider = ServiceModuleBootstrap.Build(["metrics", "caching", "workers"]);
+var orchestrator = new ApplicationOrchestrator(provider);
+await orchestrator.RunAsync(["warm-cache", "start-workers"]);
+```
+
+This shape fits systems where module and startup order are configuration-owned, but object creation should still be compile-time generated and testable.
+
+## Generated Cross-Cutting Examples
+
+The generator examples cover common enterprise seams:
+
+- Generated facades simplify billing and shipping subsystem APIs.
+- Generated proxies wrap service calls with authentication, caching, retry, logging, and timing.
+- Generated observers centralize notification and telemetry dispatch.
+- Generated mementos snapshot mutable editor/game state.
+- Generated template methods enforce workflow order while preserving hook points.
+- Generated state machines keep lifecycle transitions deterministic.
+
+## Messaging Generator Examples
+
+Messaging examples live under `src/PatternKit.Examples/Messaging`:
+
+- `DispatcherExample.cs` demonstrates source-generated mediator commands, notifications, streams, and paging.
+- `ContentRouterGeneratorExample.cs` demonstrates generated content-based routing.
+- `RoutingSlipExample.cs` demonstrates generated routing-slip factories for fulfillment workflows.
+- `SagaExample.cs` demonstrates generated process-manager transitions over explicit state.
+
+See [Messaging Generators](../generators/messaging.md) and [Enterprise Messaging Workflow Suite](enterprise-messaging-workflows.md) for deeper routing and workflow guidance.
+
+## Validation
+
+These examples are compiled with `PatternKit.Generators` as an analyzer reference, so generated code is exercised during normal builds. The examples test project verifies behavior across the supported target frameworks, and DocFX validates the crosslinks in this page.

--- a/docs/examples/toc.yml
+++ b/docs/examples/toc.yml
@@ -9,22 +9,22 @@
 
 - name: Composed, Preference-Aware Notification Strategy (Email/SMS/Push/IM)
   href: composed-notification-strategy.md
-  
-- name: Mediated Transaction Pipeline 
+
+- name: Mediated Transaction Pipeline
   href: mediated-transaction-pipeline.md
-  
+
 - name: Configuration-Driven Transaction Pipeline
   href: config-driven-transaction-pipeline.md
 
 - name: Minimal Web Request Router
   href: mini-router.md
-  
+
 - name: Payment Processor — Fluent Decorator Pattern for Point of Sale
   href: payment-processor-decorator.md
 
 - name: POS App State Singleton
   href: pos-app-state-singleton.md
-  
+
 - name: Pricing Calculator (Async Sources, Loyalty, Rounding)
   href: pricing-calculator.md
 
@@ -43,12 +43,18 @@
 - name: Patterns Showcase — Integrated Order Processing
   href: patterns-showcase.md
 
+- name: Source Generator Application Suite
+  href: source-generator-application-suite.md
+
+- name: Enterprise Messaging Workflow Suite
+  href: enterprise-messaging-workflows.md
+
 - name: Prototype — Game Character Factory with Clone Registry
   href: prototype-demo.md
-  
+
 - name: Proxy Pattern Demonstrations — Virtual, Protection, Caching, Logging, Mocking, Remote
   href: proxy-demo.md
-  
+
 - name: Flyweight Glyph Cache & Style Sharing
   href: flyweight-glyph-cache.md
 

--- a/docs/generators/examples.md
+++ b/docs/generators/examples.md
@@ -1,6 +1,8 @@
-# Generator Examples (DI + Orchestration)
+# Generator Examples
 
-Three production-flavored samples live in `src/PatternKit.Examples/Generators` to show the factory and builder generators in action with `IServiceCollection` and `Host`.
+Production-flavored samples live in `src/PatternKit.Examples` to show generator output in realistic application shapes: DI module registration, application builders, subsystem facades, service proxies, observers, mementos, state machines, strategies, visitors, template workflows, singletons, adapters, and messaging factories.
+
+See [Source Generator Application Suite](../examples/source-generator-application-suite.md) for the full source/test map.
 
 ## 1) ServiceModules with FactoryMethod
 
@@ -99,8 +101,25 @@ var app = await CorporateApplicationDemo.CreateBuilder()
 
 The demo wires observability, messaging, background jobs, async secret loading, and startup tasks before emitting a ready-to-run `CorporateApp` instance.
 
-## Where to find the code
+## Additional Generator Examples
+
+| Generator | Example source | Tests |
+| --- | --- | --- |
+| Adapter | `src/PatternKit.Examples/AdapterGeneratorDemo` | `test/PatternKit.Examples.Tests/AdapterGeneratorDemo` |
+| Facade | `src/PatternKit.Examples/Generators/Facade` | `test/PatternKit.Examples.Tests/Generators/FacadeSpecsTests.cs` |
+| Memento | `src/PatternKit.Examples/Generators/Memento` | `test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs` |
+| Observer | `src/PatternKit.Examples/ObserverGeneratorDemo` | `test/PatternKit.Examples.Tests/ObserverGeneratorDemo` |
+| Proxy | `src/PatternKit.Examples/ProxyGeneratorDemo` | `test/PatternKit.Examples.Tests/ProxyGeneratorDemo` |
+| Singleton | `src/PatternKit.Examples/SingletonGeneratorDemo` | `test/PatternKit.Examples.Tests/SingletonGeneratorDemo` |
+| State Machine | `src/PatternKit.Examples/Generators/State` | `test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs` |
+| Strategy | `src/PatternKit.Examples/Generators/Strategies` | `test/PatternKit.Examples.Tests/Generators/StrategySpecsTests.cs` |
+| Template Method | `src/PatternKit.Examples/TemplateMethodGeneratorDemo` | `test/PatternKit.Examples.Tests/TemplateMethodGeneratorDemo` |
+| Visitor | `src/PatternKit.Examples/Generators/Visitors` | `test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs` |
+| Messaging | `src/PatternKit.Examples/Messaging` | `test/PatternKit.Examples.Tests/Messaging` |
+
+## Where to Find the Code
 
 - `src/PatternKit.Examples/Generators/FactoryGeneratorExamples.cs`
-- `src/PatternKit.Examples/Generators/CorporateApplicationBuilderDemo.cs`
-- Project references `PatternKit.Generators` as an analyzer so the factories/builders are generated at build time.
+- `src/PatternKit.Examples/Generators/Builders/CorporateApplicationBuilderDemo`
+- `src/PatternKit.Examples/Messaging`
+- Project references `PatternKit.Generators` as an analyzer so generated APIs are emitted at build time.

--- a/docs/generators/index.md
+++ b/docs/generators/index.md
@@ -64,6 +64,9 @@ PatternKit includes a Roslyn incremental generator package (`PatternKit.Generato
 | Generator | Description | Attribute |
 |---|---|---|
 | [**Dispatcher**](dispatcher.md) | Mediator pattern with commands, notifications, and streams | `[GenerateDispatcher]` |
+| [**Content Router**](messaging.md#generated-content-router) | Content-based message routing factories | `[GenerateContentRouter]` |
+| [**Routing Slip**](messaging.md#generated-routing-slip) | Ordered message itinerary factories | `[GenerateRoutingSlip]` |
+| [**Saga**](messaging.md#generated-saga) | Typed process-manager transition factories | `[GenerateSaga]` |
 
 ## Quick Reference
 
@@ -132,14 +135,27 @@ public interface IDocumentVisitor { }
 ```csharp
 // Dispatcher - mediator pattern
 [assembly: GenerateDispatcher(Namespace = "MyApp", Name = "Dispatcher")]
+
+// Content router - generated first-match route factory
+[GenerateContentRouter(typeof(Order), typeof(string))]
+public static partial class OrderRouter { }
+
+// Routing slip - generated ordered itinerary factory
+[GenerateRoutingSlip(typeof(Order))]
+public static partial class OrderSlip { }
+
+// Saga - generated process-manager factory
+[GenerateSaga(typeof(OrderSagaState))]
+public static partial class OrderSaga { }
 ```
 
 ## Examples
 
-See the samples in `PatternKit.Examples/Generators` for:
-- DI module wiring
-- Orchestrated application steps
-- Real-world usage patterns
+See [Generator Examples](examples.md) and [Source Generator Application Suite](../examples/source-generator-application-suite.md) for:
+- DI module wiring and generated host builders
+- Orchestrated application startup steps
+- Generated facades, proxies, observers, mementos, state machines, strategies, visitors, and messaging factories
+- Real-world usage patterns validated by `PatternKit.Examples.Tests`
 
 ## Troubleshooting
 

--- a/docs/generators/messaging.md
+++ b/docs/generators/messaging.md
@@ -1,0 +1,135 @@
+# Messaging Generators
+
+PatternKit includes four messaging-oriented source generators:
+
+- <xref:PatternKit.Generators.Messaging.GenerateDispatcherAttribute> for source-generated mediator dispatchers.
+- <xref:PatternKit.Generators.Messaging.GenerateContentRouterAttribute> for content-based message routers.
+- <xref:PatternKit.Generators.Messaging.GenerateRoutingSlipAttribute> for ordered routing-slip factories.
+- <xref:PatternKit.Generators.Messaging.GenerateSagaAttribute> for typed saga/process-manager factories.
+
+Use these generators when the message topology is known at compile time and should remain explicit, AOT-friendly, and validated by the compiler. They generate factories and fluent builders; they do not discover handlers from assemblies at runtime and they do not replace brokers, durable queues, or workflow engines.
+
+## Generated Dispatcher
+
+The dispatcher generator emits a mediator-style dispatcher from an assembly-level attribute:
+
+```csharp
+using PatternKit.Generators.Messaging;
+
+[assembly: GenerateDispatcher(
+    Namespace = "MyApp.Messaging",
+    Name = "AppDispatcher")]
+```
+
+The generated dispatcher supports commands, notifications, streams, and pipeline behaviors without a runtime dependency on PatternKit. See [Dispatcher Generator](dispatcher.md) for the complete API, diagnostics, and examples.
+
+Example source:
+
+- `src/PatternKit.Examples/Messaging/DispatcherExample.cs`
+- `src/PatternKit.Examples/MediatorComprehensiveDemo/ComprehensiveDemo.cs`
+- `test/PatternKit.Examples.Tests/Messaging/DispatcherExampleTests.cs`
+
+## Generated Content Router
+
+`[GenerateContentRouter]` creates a `ContentRouter<TPayload, TResult>` factory from static route methods:
+
+```csharp
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+[GenerateContentRouter(typeof(Order), typeof(string))]
+public static partial class OrderRouter
+{
+    private static bool IsWholesale(Message<Order> message, MessageContext context)
+        => message.Payload.Channel == "wholesale";
+
+    [ContentRoute("wholesale", 10, nameof(IsWholesale))]
+    private static string Wholesale(Message<Order> message, MessageContext context)
+        => "wholesale";
+
+    [ContentRouteDefault]
+    private static string Default(Message<Order> message, MessageContext context)
+        => "default";
+}
+```
+
+Routes are ordered by `ContentRouteAttribute.Order`, then by name. Duplicate route names or duplicate route orders are diagnostics because a content router must remain deterministic.
+
+Example source:
+
+- `src/PatternKit.Examples/Messaging/ContentRouterGeneratorExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/ContentRouterGeneratorExampleTests.cs`
+
+## Generated Routing Slip
+
+`[GenerateRoutingSlip]` emits a factory for a named itinerary over `Message<TPayload>`:
+
+```csharp
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+[GenerateRoutingSlip(typeof(FulfillmentOrder))]
+public static partial class FulfillmentSlip
+{
+    [RoutingSlipStep("reserve", 10)]
+    private static Message<FulfillmentOrder> Reserve(Message<FulfillmentOrder> message, MessageContext context)
+        => message.WithPayload(message.Payload with { Status = "reserved" });
+
+    [RoutingSlipStep("ship", 20)]
+    private static Message<FulfillmentOrder> Ship(Message<FulfillmentOrder> message, MessageContext context)
+        => message.WithPayload(message.Payload with { Status = "shipped" });
+}
+```
+
+Generated routing slips are useful when the steps are static and route order should be validated at compile time. Runtime routing slips remain better when tenant configuration or user input defines the itinerary.
+
+Example source:
+
+- `src/PatternKit.Examples/Messaging/RoutingSlipExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/RoutingSlipExampleTests.cs`
+
+## Generated Saga
+
+`[GenerateSaga]` emits a process-manager factory from typed transition methods:
+
+```csharp
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+[GenerateSaga(typeof(OrderSagaState))]
+public static partial class OrderSaga
+{
+    [SagaStep(typeof(OrderSubmitted), 10)]
+    private static OrderSagaState Submitted(OrderSagaState state, Message<OrderSubmitted> message, MessageContext context)
+        => state with { OrderId = message.Payload.OrderId, Submitted = true };
+
+    [SagaCompleteWhen]
+    private static bool IsComplete(OrderSagaState state)
+        => state.Submitted && state.Paid;
+}
+```
+
+Use generated sagas for in-process orchestration where transitions are explicit and state is owned by the caller. Persist saga state and outbox records outside PatternKit when the workflow must survive process restarts.
+
+Example source:
+
+- `src/PatternKit.Examples/Messaging/SagaExample.cs`
+- `test/PatternKit.Examples.Tests/Messaging/SagaExampleTests.cs`
+
+## Diagnostics
+
+| ID | Generator | Meaning |
+| --- | --- | --- |
+| `PKDSP001`-`PKDSP004` | Dispatcher | Invalid dispatcher configuration or handler registration. |
+| `PKCR001`-`PKCR005` | Content Router | Non-partial host, missing routes, invalid signatures, duplicate defaults, or duplicate route identity. |
+| `PKRS001`-`PKRS003` | Routing Slip | Non-partial host, missing steps, or invalid step signatures. |
+| `PKSG001`-`PKSG004` | Saga | Non-partial host, missing transitions, invalid transition signatures, or invalid completion checks. |
+
+## Related Runtime Patterns
+
+- [Message Envelope and Context](../patterns/messaging/message-envelope.md)
+- [Enterprise Message Routing](../patterns/messaging/message-routing.md)
+- [Routing Slip](../patterns/messaging/routing-slip.md)
+- [Saga / Process Manager](../patterns/messaging/saga.md)
+- [Mailbox](../patterns/messaging/mailbox.md)
+- [Idempotent Receiver, Inbox, and Outbox](../patterns/messaging/reliability.md)

--- a/docs/generators/toc.yml
+++ b/docs/generators/toc.yml
@@ -1,6 +1,9 @@
 - name: Generators Overview
   href: index.md
 
+- name: Adapter
+  href: adapter.md
+
 - name: Builder
   href: builder.md
 
@@ -13,8 +16,17 @@
 - name: Command
   href: command.md
 
+- name: Composer
+  href: composer.md
+
 - name: Composite
   href: composite.md
+
+- name: Decorator
+  href: decorator.md
+
+- name: Dispatcher
+  href: dispatcher.md
 
 - name: Facade
   href: facade.md
@@ -31,14 +43,26 @@
 - name: Iterator
   href: iterator.md
 
+- name: Memento
+  href: memento.md
+
+- name: Messaging Generators
+  href: messaging.md
+
 - name: Prototype
   href: prototype.md
 
 - name: Proxy
   href: proxy.md
 
+- name: Singleton
+  href: singleton.md
+
 - name: State Machine
   href: state-machine.md
+
+- name: Strategy
+  href: strategy.md
 
 - name: Template Method
   href: template-method-generator.md

--- a/test/PatternKit.Examples.Tests/Documentation/DocumentationCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/Documentation/DocumentationCoverageTests.cs
@@ -1,0 +1,140 @@
+using System.Text.RegularExpressions;
+
+namespace PatternKit.Examples.Tests.Documentation;
+
+public sealed class DocumentationCoverageTests
+{
+    private static readonly Regex TocHrefRegex = new(@"href:\s*(?<href>[^\s#]+)", RegexOptions.Compiled);
+
+    [Theory]
+    [InlineData("docs/generators/toc.yml")]
+    [InlineData("docs/examples/toc.yml")]
+    [InlineData("docs/patterns/toc.yml")]
+    public void Toc_Hrefs_Point_To_Existing_Files(string relativeTocPath)
+    {
+        var root = FindRepoRoot();
+        var tocPath = Path.Combine(root, Normalize(relativeTocPath));
+        var tocDirectory = Path.GetDirectoryName(tocPath)!;
+
+        foreach (Match match in TocHrefRegex.Matches(File.ReadAllText(tocPath)))
+        {
+            var href = match.Groups["href"].Value;
+            if (href.EndsWith("/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var target = Path.GetFullPath(Path.Combine(tocDirectory, Normalize(href)));
+
+            Assert.True(File.Exists(target), $"{relativeTocPath} references missing file: {href}");
+        }
+    }
+
+    [Fact]
+    public void Generator_Toc_Includes_All_Generator_Pages()
+    {
+        var root = FindRepoRoot();
+        var generatorDocs = Path.Combine(root, "docs", "generators");
+        var toc = File.ReadAllText(Path.Combine(generatorDocs, "toc.yml"));
+        var expectedPages = Directory
+            .EnumerateFiles(generatorDocs, "*.md")
+            .Select(Path.GetFileName)
+            .Where(name => !string.Equals(name, "index.md", StringComparison.OrdinalIgnoreCase))
+            .Order(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var page in expectedPages)
+        {
+            Assert.Contains($"href: {page}", toc, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Example_Toc_Exposes_Generator_And_Messaging_Suites()
+    {
+        var root = FindRepoRoot();
+        var toc = File.ReadAllText(Path.Combine(root, "docs", "examples", "toc.yml"));
+
+        Assert.Contains("href: source-generator-application-suite.md", toc, StringComparison.Ordinal);
+        Assert.Contains("href: enterprise-messaging-workflows.md", toc, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Source_Generator_Application_Suite_Maps_Example_Families_To_Tests()
+    {
+        var root = FindRepoRoot();
+        var doc = File.ReadAllText(Path.Combine(root, "docs", "examples", "source-generator-application-suite.md"));
+
+        var expectedGeneratorFamilies = new[]
+        {
+            "Builder",
+            "Factory Method",
+            "Factory Class",
+            "Facade",
+            "Memento",
+            "State Machine",
+            "Strategy",
+            "Visitor",
+            "Adapter",
+            "Observer",
+            "Proxy",
+            "Singleton",
+            "Template Method",
+            "Messaging"
+        };
+
+        foreach (var family in expectedGeneratorFamilies)
+        {
+            Assert.Contains($"| {family} |", doc, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("test/PatternKit.Examples.Tests/Generators", doc, StringComparison.Ordinal);
+        Assert.Contains("test/PatternKit.Examples.Tests/Messaging", doc, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Enterprise_Messaging_Workflow_Suite_Maps_Runtime_And_Generated_Patterns()
+    {
+        var root = FindRepoRoot();
+        var doc = File.ReadAllText(Path.Combine(root, "docs", "examples", "enterprise-messaging-workflows.md"));
+
+        var expectedPatterns = new[]
+        {
+            "Message envelope/context",
+            "Content router",
+            "Recipient list",
+            "Splitter",
+            "Aggregator",
+            "Routing slip",
+            "Saga/process manager",
+            "Mailbox",
+            "Idempotent receiver",
+            "Inbox/outbox",
+            "Source-generated dispatcher",
+            "Source-generated content router"
+        };
+
+        foreach (var pattern in expectedPatterns)
+        {
+            Assert.Contains($"| {pattern} |", doc, StringComparison.Ordinal);
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PatternKit.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find PatternKit repository root.");
+    }
+
+    private static string Normalize(string path)
+        => path.Replace('/', Path.DirectorySeparatorChar);
+}


### PR DESCRIPTION
## Summary
- add source-generator and enterprise-messaging example suite docs with source/test mappings
- expose missing generator docs in DocFX ToC and add messaging generator docs
- add docs coverage tests for ToC targets and generator/example suite discoverability
- correct the integrated showcase docs to reference TypeDispatcher instead of Visitor for payment-fee dispatch

## Validation
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- dotnet test test/PatternKit.Tests/PatternKit.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- docfx metadata docs/docfx.json
- docfx build docs/docfx.json
- git diff --check