### PR TITLE
feat: add real-world messaging demos

### DIFF
--- a/docs/examples/enterprise-messaging-workflows.md
+++ b/docs/examples/enterprise-messaging-workflows.md
@@ -23,6 +23,8 @@ Example source:
 | Inbox/outbox | `ReliabilityExample.cs` | Explicit handoff records for durable integration boundaries owned by the application. |
 | Source-generated dispatcher | `DispatcherExample.cs` | Compile-time mediator commands, notifications, streams, and paging. |
 | Source-generated content router | `ContentRouterGeneratorExample.cs` | Attribute-driven content routing without runtime scanning. |
+| Resilient checkout orchestration | `ResilientCheckoutDemo.cs` | Route selection, routing-slip execution, command compensation, and fallback routes. |
+| Collaborating service mailboxes | `ServiceCollaborationMailboxDemo.cs` | Inventory, payment, shipping, and notification mailboxes collaborating over correlated messages. |
 
 ## Workflow Shape
 
@@ -72,6 +74,8 @@ The example tests use behavior-oriented assertions:
 - Mailbox tests assert serialized processing and lifecycle semantics.
 - Reliability tests assert duplicate suppression and outbox record creation.
 - Generator tests assert that generated factories compile and behave like the equivalent runtime builders.
+- Resilient checkout tests assert rollback, fallback route selection, manual review, and side-effect boundaries.
+- Mailbox collaboration tests assert service handoff, compensation, correlation propagation, and final notification outcomes.
 
 ## Related Documentation
 
@@ -83,3 +87,4 @@ The example tests use behavior-oriented assertions:
 - [Mailbox](../patterns/messaging/mailbox.md)
 - [Idempotent Receiver, Inbox, and Outbox](../patterns/messaging/reliability.md)
 - [Messaging Generators](../generators/messaging.md)
+- [Resilient Checkout and Collaborating Mailboxes](resilient-checkout-and-mailboxes.md)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -60,6 +60,9 @@ Welcome! This section collects small, focused demos that show **how to compose b
 * **Enterprise Messaging Workflow Suite**
   End-to-end messaging examples for envelopes, content routing, recipient lists, splitters, aggregators, routing slips, sagas, mailboxes, idempotent receivers, inboxes, outboxes, and generated messaging factories. See [Enterprise Messaging Workflow Suite](enterprise-messaging-workflows.md).
 
+* **Resilient Checkout and Collaborating Mailboxes**
+  Application-shaped messaging demos: checkout route selection, routing-slip execution, command compensation, fallback routes, and service mailboxes collaborating over correlated messages. See [Resilient Checkout and Collaborating Mailboxes](resilient-checkout-and-mailboxes.md).
+
 ## How to run
 
 From the repo root:
@@ -102,6 +105,8 @@ dotnet test PatternKit.slnx -c Release
 * **Source Generator Suite:** `src/PatternKit.Examples/Generators` (+ `PatternKit.Examples.Tests/Generators`) — generated builders, factories, facades, mementos, state machines, strategies, visitors, and host-style composition.
 * **Generator Boundary Demos:** `AdapterGeneratorDemo`, `ObserverGeneratorDemo`, `ProxyGeneratorDemo`, `SingletonGeneratorDemo`, `TemplateMethodGeneratorDemo` (+ matching tests) — generated adapters, observers, proxies, singletons, and template workflows.
 * **Enterprise Messaging:** `src/PatternKit.Examples/Messaging` (+ `PatternKit.Examples.Tests/Messaging`) — runtime and generated messaging workflows.
+* **Resilient Checkout:** `ResilientCheckoutDemo` (+ `ResilientCheckoutDemoTests`) — fallback checkout routes with compensation.
+* **Collaborating Mailboxes:** `ServiceCollaborationMailboxDemo` (+ `ServiceCollaborationMailboxDemoTests`) — inventory, payment, shipping, and notification services collaborating through serialized mailboxes.
 * **Tests:** `PatternKit.Examples.Tests/*` use TinyBDD scenarios that read like specs.
 
 ## Why these demos exist

--- a/docs/examples/resilient-checkout-and-mailboxes.md
+++ b/docs/examples/resilient-checkout-and-mailboxes.md
@@ -1,0 +1,130 @@
+# Resilient Checkout and Collaborating Mailboxes
+
+This example pair shows PatternKit used in application-shaped messaging workflows, not isolated snippets:
+
+- `ResilientCheckoutDemo` models a multi-step checkout process that chooses a route, executes ordered steps, compensates successful steps when a later step fails, and retries through fallback routes.
+- `ServiceCollaborationMailboxDemo` models service mailboxes collaborating over messages while each service processes its own work serially.
+
+Source:
+
+- `src/PatternKit.Examples/Messaging/ResilientCheckoutDemo.cs`
+- `src/PatternKit.Examples/Messaging/ServiceCollaborationMailboxDemo.cs`
+- `test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs`
+- `test/PatternKit.Examples.Tests/Messaging/ServiceCollaborationMailboxDemoTests.cs`
+
+## Resilient Checkout
+
+The checkout demo combines:
+
+- <xref:PatternKit.Messaging.Routing.ContentRouter`2> to pick an initial or fallback checkout route.
+- <xref:PatternKit.Messaging.Routing.RoutingSlip`1> to execute ordered checkout steps.
+- <xref:PatternKit.Behavioral.Command.Command`1> to model reversible units of work.
+- <xref:PatternKit.Messaging.Message`1> and <xref:PatternKit.Messaging.MessageContext> to carry order/correlation data through the route.
+
+The route selection is explicit:
+
+```csharp
+var router = ContentRouter<CheckoutAttempt, CheckoutRoute>.Create()
+    .When((message, _) => message.Payload.Request.FraudHold)
+    .Then((_, _) => CheckoutRoute.ManualReview)
+    .When((message, _) => message.Payload.PreviousFailure == CheckoutFailureKind.InventoryUnavailable
+                         && message.Payload.Request.AllowDropshipFallback)
+    .Then((_, _) => CheckoutRoute.DropshipCard)
+    .When((message, _) => message.Payload.PreviousFailure == CheckoutFailureKind.PaymentDeclined
+                         && message.Payload.Request.GiftCardBalance >= message.Payload.Request.Total)
+    .Then((_, _) => CheckoutRoute.PrimaryGiftCard)
+    .Default((_, _) => CheckoutRoute.PrimaryCard)
+    .Build();
+```
+
+Each route runs a routing slip:
+
+```csharp
+var slip = RoutingSlip<CheckoutContext>.Create()
+    .Step("validate", Execute(ValidateCommand()))
+    .Step("reserve-inventory", Execute(ReserveInventoryCommand(route.Inventory)))
+    .Step("charge-payment", Execute(ChargePaymentCommand(route.Payment)))
+    .Step("schedule-shipment", Execute(ScheduleShipmentCommand(route.Inventory)))
+    .Build();
+```
+
+The commands are reversible. If inventory reserve succeeds but payment later declines, the checkout context walks the executed command stack in reverse and releases the reservation before trying the gift-card route:
+
+```csharp
+internal void Compensate()
+{
+    while (_executed.Count > 0)
+    {
+        var command = _executed.Pop();
+        if (command.TryUndo(this, out var undo))
+            undo.GetAwaiter().GetResult();
+    }
+}
+```
+
+The tests cover production-relevant paths:
+
+- Primary warehouse + card succeeds.
+- Primary inventory unavailable retries through dropship.
+- Card payment decline releases inventory and retries gift card when balance is available.
+- Fraud hold goes directly to manual review without side effects.
+- Unrecoverable fulfillment failure ends as manual review.
+
+This is still in-process orchestration. A real commerce system would persist checkout state, idempotency keys, and outbox records around the route execution before crossing process boundaries.
+
+## Collaborating Service Mailboxes
+
+The mailbox demo models four services:
+
+- Inventory mailbox reserves or releases reservations.
+- Payment mailbox captures payment or sends a release command when payment is declined.
+- Shipping mailbox schedules fulfillment after payment capture.
+- Notification mailbox emits final customer/application notifications.
+
+Each service owns a `Mailbox<TCommand>` and processes commands serially. Services collaborate by posting messages to each other:
+
+```csharp
+payments = Mailbox<PaymentCommand>.Create(async (message, context, cancellationToken) =>
+{
+    if (message.Payload.Amount > 100m)
+    {
+        await inventory.PostAsync(
+            Message<InventoryCommand>.Create(InventoryCommand.Release(message.Payload.OrderId)),
+            context,
+            cancellationToken);
+
+        await notification.PostAsync(
+            Message<NotificationCommand>.Create(new NotificationCommand(message.Payload.OrderId, "payment-declined")),
+            context,
+            cancellationToken);
+        return;
+    }
+
+    await shipping.PostAsync(
+        Message<ShippingCommand>.Create(new ShippingCommand(message.Payload.OrderId)),
+        context,
+        cancellationToken);
+})
+.Bounded(16, MailboxBackpressurePolicy.Wait)
+.OnError(MailboxErrorPolicy.Continue)
+.Build();
+```
+
+The demo sends two orders:
+
+- `order-ok` reserves inventory, captures payment, schedules shipping, and emits a fulfilled notification.
+- `order-declined` reserves inventory, fails payment, releases inventory, and emits a payment-declined notification.
+
+Correlation IDs flow through the service posts via `MessageContext`, so downstream services can log and publish events under the same checkout correlation.
+
+## Why These Patterns Fit
+
+Use this shape when the application needs deterministic in-process coordination but does not need PatternKit to become infrastructure:
+
+- Content routers choose routes from explicit state and previous failures.
+- Routing slips keep ordered work visible and testable.
+- Commands express compensating actions beside the work they reverse.
+- Mailboxes serialize stateful service handlers and make backpressure explicit.
+- Message headers and context carry correlation without global state.
+
+For durable workflows, persist state before and after route execution, write outbox records for external messages, and use an external queue or broker for cross-process delivery.

--- a/docs/examples/toc.yml
+++ b/docs/examples/toc.yml
@@ -49,6 +49,9 @@
 - name: Enterprise Messaging Workflow Suite
   href: enterprise-messaging-workflows.md
 
+- name: Resilient Checkout and Collaborating Mailboxes
+  href: resilient-checkout-and-mailboxes.md
+
 - name: Prototype — Game Character Factory with Clone Registry
   href: prototype-demo.md
 

--- a/src/PatternKit.Examples/Messaging/ResilientCheckoutDemo.cs
+++ b/src/PatternKit.Examples/Messaging/ResilientCheckoutDemo.cs
@@ -1,0 +1,415 @@
+using PatternKit.Behavioral.Command;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Production-shaped checkout orchestration demo with route selection, rollback, and fallback routes.
+/// </summary>
+public static class ResilientCheckoutDemo
+{
+    /// <summary>Runs checkout using the supplied request and simulated services.</summary>
+    public static CheckoutResult Run(CheckoutRequest request, CheckoutServices services)
+    {
+        var router = BuildRouteRouter();
+        var attempts = new List<CheckoutAttemptResult>();
+        var context = new CheckoutContext(request, services);
+        var route = router.Route(Message<CheckoutAttempt>.Create(new CheckoutAttempt(request, null)));
+
+        while (true)
+        {
+            context.BeginAttempt(route);
+            var result = ExecuteRoute(context, route);
+            attempts.Add(result);
+
+            if (result.Succeeded || route.Kind == CheckoutRouteKind.ManualReview)
+                return context.ToResult(result.Succeeded, route.Kind == CheckoutRouteKind.ManualReview, attempts);
+
+            var nextRoute = router.Route(Message<CheckoutAttempt>.Create(new CheckoutAttempt(request, result.FailureKind)));
+            if (nextRoute == route || nextRoute.Kind == CheckoutRouteKind.ManualReview)
+            {
+                context.BeginAttempt(CheckoutRoute.ManualReview);
+                attempts.Add(new CheckoutAttemptResult(
+                    CheckoutRoute.ManualReview.Name,
+                    Succeeded: false,
+                    result.FailureKind,
+                    "manual-review"));
+                return context.ToResult(Succeeded: false, ManualReview: true, attempts);
+            }
+
+            route = nextRoute;
+        }
+    }
+
+    private static ContentRouter<CheckoutAttempt, CheckoutRoute> BuildRouteRouter()
+        => ContentRouter<CheckoutAttempt, CheckoutRoute>.Create()
+            .When(static (message, _) => message.Payload.Request.FraudHold)
+            .Then(static (_, _) => CheckoutRoute.ManualReview)
+            .When(static (message, _) => message.Payload.PreviousFailure == CheckoutFailureKind.InventoryUnavailable
+                                         && message.Payload.Request.AllowDropshipFallback)
+            .Then(static (_, _) => CheckoutRoute.DropshipCard)
+            .When(static (message, _) => message.Payload.PreviousFailure == CheckoutFailureKind.PaymentDeclined
+                                         && message.Payload.Request.GiftCardBalance >= message.Payload.Request.Total)
+            .Then(static (_, _) => CheckoutRoute.PrimaryGiftCard)
+            .When(static (message, _) => message.Payload.Request.GiftCardBalance >= message.Payload.Request.Total
+                                         && message.Payload.Request.PreferGiftCard)
+            .Then(static (_, _) => CheckoutRoute.PrimaryGiftCard)
+            .Default(static (_, _) => CheckoutRoute.PrimaryCard)
+            .Build();
+
+    private static CheckoutAttemptResult ExecuteRoute(CheckoutContext context, CheckoutRoute route)
+    {
+        if (route.Kind == CheckoutRouteKind.ManualReview)
+        {
+            context.Audit.Add("manual-review:queued");
+            return new CheckoutAttemptResult(route.Name, Succeeded: false, null, "manual-review");
+        }
+
+        var slip = RoutingSlip<CheckoutContext>.Create()
+            .Step("validate", Execute(ValidateCommand()))
+            .Step("reserve-inventory", Execute(ReserveInventoryCommand(route.Inventory)))
+            .Step("charge-payment", Execute(ChargePaymentCommand(route.Payment)))
+            .Step("schedule-shipment", Execute(ScheduleShipmentCommand(route.Inventory)))
+            .Build();
+
+        try
+        {
+            slip.Execute(Message<CheckoutContext>.Create(context).WithCorrelationId(context.Request.OrderId));
+            return new CheckoutAttemptResult(route.Name, Succeeded: true, null, "completed");
+        }
+        catch (CheckoutStepException ex)
+        {
+            context.Audit.Add($"route:{route.Name}:failed:{ex.FailureKind}");
+            context.Compensate();
+            return new CheckoutAttemptResult(route.Name, Succeeded: false, ex.FailureKind, ex.Message);
+        }
+    }
+
+    private static RoutingSlip<CheckoutContext>.StepHandler Execute(Command<CheckoutContext> command)
+        => (message, _) =>
+        {
+            command.Execute(message.Payload).GetAwaiter().GetResult();
+            message.Payload.Track(command);
+            return message;
+        };
+
+    private static Command<CheckoutContext> ValidateCommand()
+        => Command<CheckoutContext>.Create()
+            .Do(static context =>
+            {
+                if (context.Request.Lines.Count == 0)
+                    throw new CheckoutStepException(CheckoutFailureKind.ValidationFailed, "cart-empty");
+
+                context.Audit.Add("validate:ok");
+            })
+            .Build();
+
+    private static Command<CheckoutContext> ReserveInventoryCommand(InventoryRoute inventory)
+        => Command<CheckoutContext>.Create()
+            .Do(context =>
+            {
+                if (!context.Services.Inventory.TryReserve(context.Request, inventory, out var reservationId))
+                    throw new CheckoutStepException(CheckoutFailureKind.InventoryUnavailable, $"inventory-unavailable:{inventory}");
+
+                context.ReservationId = reservationId;
+                context.Audit.Add($"inventory:reserved:{inventory}:{reservationId}");
+            })
+            .Undo(context =>
+            {
+                if (context.ReservationId is null)
+                    return;
+
+                context.Services.Inventory.Release(context.ReservationId);
+                context.Audit.Add($"inventory:released:{context.ReservationId}");
+                context.ReservationId = null;
+            })
+            .Build();
+
+    private static Command<CheckoutContext> ChargePaymentCommand(PaymentRoute payment)
+        => Command<CheckoutContext>.Create()
+            .Do(context =>
+            {
+                if (!context.Services.Payments.TryCharge(context.Request, payment, out var paymentId))
+                    throw new CheckoutStepException(CheckoutFailureKind.PaymentDeclined, $"payment-declined:{payment}");
+
+                context.PaymentId = paymentId;
+                context.Audit.Add($"payment:charged:{payment}:{paymentId}");
+            })
+            .Undo(context =>
+            {
+                if (context.PaymentId is null)
+                    return;
+
+                context.Services.Payments.Refund(context.PaymentId);
+                context.Audit.Add($"payment:refunded:{context.PaymentId}");
+                context.PaymentId = null;
+            })
+            .Build();
+
+    private static Command<CheckoutContext> ScheduleShipmentCommand(InventoryRoute inventory)
+        => Command<CheckoutContext>.Create()
+            .Do(context =>
+            {
+                var shipmentId = context.Services.Shipping.Schedule(context.Request, inventory);
+                context.ShipmentId = shipmentId;
+                context.Audit.Add($"shipping:scheduled:{shipmentId}");
+            })
+            .Undo(context =>
+            {
+                if (context.ShipmentId is null)
+                    return;
+
+                context.Services.Shipping.Cancel(context.ShipmentId);
+                context.Audit.Add($"shipping:cancelled:{context.ShipmentId}");
+                context.ShipmentId = null;
+            })
+            .Build();
+
+    private sealed class CheckoutContext
+    {
+        private readonly Stack<Command<CheckoutContext>> _executed = new();
+
+        internal CheckoutContext(CheckoutRequest request, CheckoutServices services)
+        {
+            Request = request;
+            Services = services;
+        }
+
+        internal CheckoutRequest Request { get; }
+
+        internal CheckoutServices Services { get; }
+
+        internal List<string> Audit { get; } = new();
+
+        internal string? ReservationId { get; set; }
+
+        internal string? PaymentId { get; set; }
+
+        internal string? ShipmentId { get; set; }
+
+        internal string? FinalRoute { get; private set; }
+
+        internal void BeginAttempt(CheckoutRoute route)
+        {
+            _executed.Clear();
+            FinalRoute = route.Name;
+            Audit.Add($"route:{route.Name}:started");
+        }
+
+        internal void Track(Command<CheckoutContext> command)
+        {
+            if (command.HasUndo)
+                _executed.Push(command);
+        }
+
+        internal void Compensate()
+        {
+            while (_executed.Count > 0)
+            {
+                var command = _executed.Pop();
+                if (command.TryUndo(this, out var undo))
+                    undo.GetAwaiter().GetResult();
+            }
+        }
+
+        internal CheckoutResult ToResult(bool Succeeded, bool ManualReview, IReadOnlyList<CheckoutAttemptResult> attempts)
+            => new(
+                Request.OrderId,
+                Succeeded,
+                ManualReview,
+                FinalRoute ?? "none",
+                ReservationId,
+                PaymentId,
+                ShipmentId,
+                attempts.ToArray(),
+                Audit.ToArray());
+    }
+}
+
+/// <summary>Checkout request used by the resilient checkout demo.</summary>
+public sealed record CheckoutRequest(
+    string OrderId,
+    string CustomerId,
+    IReadOnlyList<CheckoutLine> Lines,
+    bool FraudHold = false,
+    bool PreferGiftCard = false,
+    bool AllowDropshipFallback = true,
+    decimal GiftCardBalance = 0m)
+{
+    /// <summary>Total amount for the request.</summary>
+    public decimal Total => Lines.Sum(static line => line.UnitPrice * line.Quantity);
+}
+
+/// <summary>Checkout line item.</summary>
+public sealed record CheckoutLine(string Sku, int Quantity, decimal UnitPrice);
+
+/// <summary>Simulated service dependencies used by the checkout demo.</summary>
+public sealed class CheckoutServices
+{
+    /// <summary>Inventory service.</summary>
+    public InventoryGateway Inventory { get; init; } = new();
+
+    /// <summary>Payment service.</summary>
+    public PaymentGateway Payments { get; init; } = new();
+
+    /// <summary>Shipping service.</summary>
+    public ShippingGateway Shipping { get; init; } = new();
+}
+
+/// <summary>Simulated inventory adapter.</summary>
+public sealed class InventoryGateway
+{
+    private int _nextReservation = 100;
+
+    /// <summary>Whether primary warehouse reservation should succeed.</summary>
+    public bool PrimaryAvailable { get; set; } = true;
+
+    /// <summary>Whether dropship reservation should succeed.</summary>
+    public bool DropshipAvailable { get; set; } = true;
+
+    /// <summary>Released reservation identifiers.</summary>
+    public List<string> ReleasedReservations { get; } = new();
+
+    internal bool TryReserve(CheckoutRequest request, InventoryRoute route, out string reservationId)
+    {
+        var available = route switch
+        {
+            InventoryRoute.PrimaryWarehouse => PrimaryAvailable,
+            InventoryRoute.Dropship => DropshipAvailable,
+            _ => false
+        };
+
+        if (!available)
+        {
+            reservationId = "";
+            return false;
+        }
+
+        reservationId = $"{route.ToString().ToLowerInvariant()}-{request.OrderId}-{++_nextReservation}";
+        return true;
+    }
+
+    internal void Release(string reservationId) => ReleasedReservations.Add(reservationId);
+}
+
+/// <summary>Simulated payment adapter.</summary>
+public sealed class PaymentGateway
+{
+    private int _nextPayment = 200;
+
+    /// <summary>Whether card authorization should succeed.</summary>
+    public bool CardApproved { get; set; } = true;
+
+    /// <summary>Refunded payment identifiers.</summary>
+    public List<string> RefundedPayments { get; } = new();
+
+    internal bool TryCharge(CheckoutRequest request, PaymentRoute route, out string paymentId)
+    {
+        var approved = route switch
+        {
+            PaymentRoute.Card => CardApproved,
+            PaymentRoute.GiftCard => request.GiftCardBalance >= request.Total,
+            _ => false
+        };
+
+        if (!approved)
+        {
+            paymentId = "";
+            return false;
+        }
+
+        paymentId = $"{route.ToString().ToLowerInvariant()}-{request.OrderId}-{++_nextPayment}";
+        return true;
+    }
+
+    internal void Refund(string paymentId) => RefundedPayments.Add(paymentId);
+}
+
+/// <summary>Simulated shipping adapter.</summary>
+public sealed class ShippingGateway
+{
+    private int _nextShipment = 300;
+
+    /// <summary>Cancelled shipment identifiers.</summary>
+    public List<string> CancelledShipments { get; } = new();
+
+    internal string Schedule(CheckoutRequest request, InventoryRoute route)
+        => $"{route.ToString().ToLowerInvariant()}-ship-{request.OrderId}-{++_nextShipment}";
+
+    internal void Cancel(string shipmentId) => CancelledShipments.Add(shipmentId);
+}
+
+/// <summary>Checkout route attempt input.</summary>
+public sealed record CheckoutAttempt(CheckoutRequest Request, CheckoutFailureKind? PreviousFailure);
+
+/// <summary>Checkout route definition.</summary>
+public sealed record CheckoutRoute(string Name, CheckoutRouteKind Kind, InventoryRoute Inventory, PaymentRoute Payment)
+{
+    /// <summary>Primary warehouse with card payment.</summary>
+    public static CheckoutRoute PrimaryCard { get; } = new(
+        "primary-card",
+        CheckoutRouteKind.Fulfillment,
+        InventoryRoute.PrimaryWarehouse,
+        PaymentRoute.Card);
+
+    /// <summary>Primary warehouse with gift-card payment.</summary>
+    public static CheckoutRoute PrimaryGiftCard { get; } = new(
+        "primary-gift-card",
+        CheckoutRouteKind.Fulfillment,
+        InventoryRoute.PrimaryWarehouse,
+        PaymentRoute.GiftCard);
+
+    /// <summary>Dropship fulfillment with card payment.</summary>
+    public static CheckoutRoute DropshipCard { get; } = new(
+        "dropship-card",
+        CheckoutRouteKind.Fulfillment,
+        InventoryRoute.Dropship,
+        PaymentRoute.Card);
+
+    /// <summary>Manual review route for fraud or unrecoverable failures.</summary>
+    public static CheckoutRoute ManualReview { get; } = new(
+        "manual-review",
+        CheckoutRouteKind.ManualReview,
+        InventoryRoute.None,
+        PaymentRoute.None);
+}
+
+/// <summary>Route kind.</summary>
+public enum CheckoutRouteKind { Fulfillment, ManualReview }
+
+/// <summary>Inventory route.</summary>
+public enum InventoryRoute { None, PrimaryWarehouse, Dropship }
+
+/// <summary>Payment route.</summary>
+public enum PaymentRoute { None, Card, GiftCard }
+
+/// <summary>Checkout failure kind used to choose fallback routes.</summary>
+public enum CheckoutFailureKind { ValidationFailed, InventoryUnavailable, PaymentDeclined }
+
+/// <summary>Single checkout attempt result.</summary>
+public sealed record CheckoutAttemptResult(
+    string Route,
+    bool Succeeded,
+    CheckoutFailureKind? FailureKind,
+    string Message);
+
+/// <summary>Final checkout result.</summary>
+public sealed record CheckoutResult(
+    string OrderId,
+    bool Succeeded,
+    bool ManualReview,
+    string FinalRoute,
+    string? ReservationId,
+    string? PaymentId,
+    string? ShipmentId,
+    IReadOnlyList<CheckoutAttemptResult> Attempts,
+    IReadOnlyList<string> Audit);
+
+internal sealed class CheckoutStepException : Exception
+{
+    internal CheckoutStepException(CheckoutFailureKind failureKind, string message)
+        : base(message) => FailureKind = failureKind;
+
+    internal CheckoutFailureKind FailureKind { get; }
+}

--- a/src/PatternKit.Examples/Messaging/ServiceCollaborationMailboxDemo.cs
+++ b/src/PatternKit.Examples/Messaging/ServiceCollaborationMailboxDemo.cs
@@ -1,0 +1,159 @@
+using System.Collections.Concurrent;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Mailboxes;
+
+namespace PatternKit.Examples.Messaging;
+
+/// <summary>
+/// Production-shaped mailbox demo where inventory, payment, shipping, and notification services collaborate.
+/// </summary>
+public static class ServiceCollaborationMailboxDemo
+{
+    /// <summary>Runs two checkout messages through collaborating service mailboxes.</summary>
+    public static async ValueTask<ServiceCollaborationSummary> RunAsync()
+    {
+        var audit = new ConcurrentQueue<string>();
+        var reservations = new ConcurrentDictionary<string, string>();
+        var notifications = new ConcurrentQueue<OrderNotification>();
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Mailbox<InventoryCommand>? inventory = null;
+        Mailbox<PaymentCommand>? payments = null;
+        Mailbox<ShippingCommand>? shipping = null;
+        Mailbox<NotificationCommand>? notification = null;
+
+        notification = Mailbox<NotificationCommand>.Create((message, context, _) =>
+            {
+                audit.Enqueue($"notification:{message.Payload.OrderId}:{message.Payload.Status}");
+                notifications.Enqueue(new OrderNotification(
+                    message.Payload.OrderId,
+                    message.Payload.Status,
+                    context.Headers.GetString(MessageHeaderNames.CorrelationId)!));
+
+                if (notifications.Count == 2)
+                    completed.TrySetResult();
+
+                return default;
+            })
+            .Bounded(16, MailboxBackpressurePolicy.Wait)
+            .OnError(MailboxErrorPolicy.Continue)
+            .Build();
+
+        shipping = Mailbox<ShippingCommand>.Create(async (message, context, cancellationToken) =>
+            {
+                audit.Enqueue($"shipping:scheduled:{message.Payload.OrderId}");
+                await notification!.PostAsync(
+                    Message<NotificationCommand>.Create(new NotificationCommand(message.Payload.OrderId, "fulfilled")),
+                    context,
+                    cancellationToken);
+            })
+            .Bounded(16, MailboxBackpressurePolicy.Wait)
+            .OnError(MailboxErrorPolicy.Continue)
+            .Build();
+
+        payments = Mailbox<PaymentCommand>.Create(async (message, context, cancellationToken) =>
+            {
+                if (message.Payload.Amount > 100m)
+                {
+                    audit.Enqueue($"payment:declined:{message.Payload.OrderId}");
+                    await inventory!.PostAsync(
+                        Message<InventoryCommand>.Create(InventoryCommand.Release(message.Payload.OrderId)),
+                        context,
+                        cancellationToken);
+                    await notification!.PostAsync(
+                        Message<NotificationCommand>.Create(new NotificationCommand(message.Payload.OrderId, "payment-declined")),
+                        context,
+                        cancellationToken);
+                    return;
+                }
+
+                audit.Enqueue($"payment:captured:{message.Payload.OrderId}");
+                await shipping!.PostAsync(
+                    Message<ShippingCommand>.Create(new ShippingCommand(message.Payload.OrderId)),
+                    context,
+                    cancellationToken);
+            })
+            .Bounded(16, MailboxBackpressurePolicy.Wait)
+            .OnError(MailboxErrorPolicy.Continue)
+            .Build();
+
+        inventory = Mailbox<InventoryCommand>.Create(async (message, context, cancellationToken) =>
+            {
+                if (message.Payload.Kind == InventoryCommandKind.Release)
+                {
+                    if (reservations.TryRemove(message.Payload.OrderId, out var reservationId))
+                        audit.Enqueue($"inventory:released:{message.Payload.OrderId}:{reservationId}");
+                    return;
+                }
+
+                var reserved = $"res-{message.Payload.OrderId}";
+                reservations[message.Payload.OrderId] = reserved;
+                audit.Enqueue($"inventory:reserved:{message.Payload.OrderId}:{reserved}");
+                await payments!.PostAsync(
+                    Message<PaymentCommand>.Create(new PaymentCommand(message.Payload.OrderId, message.Payload.Amount)),
+                    context,
+                    cancellationToken);
+            })
+            .Bounded(16, MailboxBackpressurePolicy.Wait)
+            .OnError(MailboxErrorPolicy.Continue)
+            .Build();
+
+        await notification.StartAsync();
+        await shipping.StartAsync();
+        await payments.StartAsync();
+        await inventory.StartAsync();
+
+        var approvedContext = new MessageContext(MessageHeaders.Empty.WithCorrelationId("checkout-ok"));
+        var declinedContext = new MessageContext(MessageHeaders.Empty.WithCorrelationId("checkout-declined"));
+
+        await inventory.PostAsync(
+            Message<InventoryCommand>.Create(InventoryCommand.Reserve("order-ok", 75m)),
+            approvedContext);
+        await inventory.PostAsync(
+            Message<InventoryCommand>.Create(InventoryCommand.Reserve("order-declined", 125m)),
+            declinedContext);
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await inventory.StopAsync();
+        await payments.StopAsync();
+        await shipping.StopAsync();
+        await notification.StopAsync();
+
+        return new ServiceCollaborationSummary(
+            audit.ToArray(),
+            notifications.ToArray(),
+            reservations.Keys.Order(StringComparer.Ordinal).ToArray());
+    }
+}
+
+/// <summary>Inventory service command for the mailbox collaboration demo.</summary>
+public sealed record InventoryCommand(string OrderId, decimal Amount, InventoryCommandKind Kind)
+{
+    /// <summary>Creates a reserve command.</summary>
+    public static InventoryCommand Reserve(string orderId, decimal amount) => new(orderId, amount, InventoryCommandKind.Reserve);
+
+    /// <summary>Creates a release command.</summary>
+    public static InventoryCommand Release(string orderId) => new(orderId, 0m, InventoryCommandKind.Release);
+}
+
+/// <summary>Inventory command kind.</summary>
+public enum InventoryCommandKind { Reserve, Release }
+
+/// <summary>Payment service command for the mailbox collaboration demo.</summary>
+public sealed record PaymentCommand(string OrderId, decimal Amount);
+
+/// <summary>Shipping service command for the mailbox collaboration demo.</summary>
+public sealed record ShippingCommand(string OrderId);
+
+/// <summary>Notification service command for the mailbox collaboration demo.</summary>
+public sealed record NotificationCommand(string OrderId, string Status);
+
+/// <summary>Notification emitted by the collaboration demo.</summary>
+public sealed record OrderNotification(string OrderId, string Status, string CorrelationId);
+
+/// <summary>Summary returned by the collaboration demo.</summary>
+public sealed record ServiceCollaborationSummary(
+    IReadOnlyList<string> Audit,
+    IReadOnlyList<OrderNotification> Notifications,
+    IReadOnlyList<string> OpenReservations);

--- a/test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs
@@ -1,0 +1,110 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class ResilientCheckoutDemoTests
+{
+    [Fact]
+    public void Run_CompletesPrimaryCardRoute()
+    {
+        var services = new CheckoutServices();
+        var request = CreateRequest("order-primary", total: 75m);
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.ManualReview);
+        Assert.Equal("primary-card", result.FinalRoute);
+        Assert.Single(result.Attempts);
+        Assert.StartsWith("primarywarehouse-order-primary-", result.ReservationId, StringComparison.Ordinal);
+        Assert.StartsWith("card-order-primary-", result.PaymentId, StringComparison.Ordinal);
+        Assert.StartsWith("primarywarehouse-ship-order-primary-", result.ShipmentId, StringComparison.Ordinal);
+        Assert.Contains("validate:ok", result.Audit);
+        Assert.Empty(services.Inventory.ReleasedReservations);
+        Assert.Empty(services.Payments.RefundedPayments);
+    }
+
+    [Fact]
+    public void Run_RollsBackPrimaryReservationAndRetriesDropshipWhenInventoryUnavailable()
+    {
+        var services = new CheckoutServices
+        {
+            Inventory = new InventoryGateway { PrimaryAvailable = false, DropshipAvailable = true }
+        };
+        var request = CreateRequest("order-dropship", total: 75m);
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("dropship-card", result.FinalRoute);
+        Assert.Equal(["primary-card", "dropship-card"], result.Attempts.Select(static attempt => attempt.Route));
+        Assert.Equal(CheckoutFailureKind.InventoryUnavailable, result.Attempts[0].FailureKind);
+        Assert.StartsWith("dropship-order-dropship-", result.ReservationId, StringComparison.Ordinal);
+        Assert.Empty(services.Inventory.ReleasedReservations);
+        Assert.Contains("route:primary-card:failed:InventoryUnavailable", result.Audit);
+    }
+
+    [Fact]
+    public void Run_RefundsCardAndRetriesGiftCardWhenPaymentDeclines()
+    {
+        var services = new CheckoutServices
+        {
+            Payments = new PaymentGateway { CardApproved = false }
+        };
+        var request = CreateRequest("order-gift", total: 80m, giftCardBalance: 100m);
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("primary-gift-card", result.FinalRoute);
+        Assert.Equal(["primary-card", "primary-gift-card"], result.Attempts.Select(static attempt => attempt.Route));
+        Assert.Equal(CheckoutFailureKind.PaymentDeclined, result.Attempts[0].FailureKind);
+        Assert.Single(services.Inventory.ReleasedReservations);
+        Assert.Empty(services.Payments.RefundedPayments);
+        Assert.StartsWith("giftcard-order-gift-", result.PaymentId, StringComparison.Ordinal);
+        Assert.Contains(result.Audit, static entry => entry.StartsWith("inventory:released:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Run_SendsFraudHoldToManualReviewWithoutSideEffects()
+    {
+        var services = new CheckoutServices();
+        var request = CreateRequest("order-review", total: 60m) with { FraudHold = true };
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.ManualReview);
+        Assert.Equal("manual-review", result.FinalRoute);
+        Assert.Null(result.ReservationId);
+        Assert.Null(result.PaymentId);
+        Assert.Null(result.ShipmentId);
+        Assert.Contains("manual-review:queued", result.Audit);
+        Assert.Empty(services.Inventory.ReleasedReservations);
+        Assert.Empty(services.Payments.RefundedPayments);
+    }
+
+    [Fact]
+    public void Run_SendsUnrecoverableFailureToManualReview()
+    {
+        var services = new CheckoutServices
+        {
+            Inventory = new InventoryGateway { PrimaryAvailable = false, DropshipAvailable = false }
+        };
+        var request = CreateRequest("order-unrecoverable", total: 75m);
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.ManualReview);
+        Assert.Equal("manual-review", result.FinalRoute);
+        Assert.Equal(["primary-card", "dropship-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
+    }
+
+    private static CheckoutRequest CreateRequest(string orderId, decimal total, decimal giftCardBalance = 0m)
+        => new(
+            orderId,
+            "customer-42",
+            [new CheckoutLine("SKU-1", Quantity: 1, UnitPrice: total)],
+            GiftCardBalance: giftCardBalance);
+}

--- a/test/PatternKit.Examples.Tests/Messaging/ServiceCollaborationMailboxDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ServiceCollaborationMailboxDemoTests.cs
@@ -1,0 +1,28 @@
+using PatternKit.Examples.Messaging;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class ServiceCollaborationMailboxDemoTests
+{
+    [Fact]
+    public async Task RunAsync_CoordinatesServicesAndCompensatesDeclinedPayment()
+    {
+        var summary = await ServiceCollaborationMailboxDemo.RunAsync();
+
+        Assert.Contains(summary.Audit, static entry => entry == "inventory:reserved:order-ok:res-order-ok");
+        Assert.Contains(summary.Audit, static entry => entry == "payment:captured:order-ok");
+        Assert.Contains(summary.Audit, static entry => entry == "shipping:scheduled:order-ok");
+        Assert.Contains(summary.Audit, static entry => entry == "notification:order-ok:fulfilled");
+
+        Assert.Contains(summary.Audit, static entry => entry == "inventory:reserved:order-declined:res-order-declined");
+        Assert.Contains(summary.Audit, static entry => entry == "payment:declined:order-declined");
+        Assert.Contains(summary.Audit, static entry => entry == "inventory:released:order-declined:res-order-declined");
+        Assert.Contains(summary.Audit, static entry => entry == "notification:order-declined:payment-declined");
+
+        Assert.Equal(["order-ok"], summary.OpenReservations);
+        Assert.Contains(summary.Notifications, static notification =>
+            notification is { OrderId: "order-ok", Status: "fulfilled", CorrelationId: "checkout-ok" });
+        Assert.Contains(summary.Notifications, static notification =>
+            notification is { OrderId: "order-declined", Status: "payment-declined", CorrelationId: "checkout-declined" });
+    }
+}


### PR DESCRIPTION
## Summary
- add a resilient checkout demo using content routing, routing slips, and command compensation
- add a collaborating service mailbox demo for inventory, payment, shipping, and notifications
- document the real-world flows and link them from the examples and enterprise messaging docs
- add tests covering primary success, fallback routes, compensation, manual review, service handoff, and correlation propagation

## Validation
- dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false
- dotnet test test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false
- dotnet test test/PatternKit.Tests/PatternKit.Tests.csproj --configuration Release --no-build -p:UseSharedCompilation=false
- dotnet test test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj --configuration Release --no-build -p:UseSharedCompilation=false
- docfx metadata docs/docfx.json
- docfx build docs/docfx.json
- git diff --check