### PR TITLE
test: add broker backplane e2e coverage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,11 +17,15 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="TinyBDD" Version="0.19.14" />
     <PackageVersion Include="TinyBDD.Xunit" Version="0.19.14" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/docs/examples/enterprise-messaging-workflows.md
+++ b/docs/examples/enterprise-messaging-workflows.md
@@ -77,7 +77,7 @@ The example tests use behavior-oriented assertions:
 - Generator tests assert that generated factories compile and behave like the equivalent runtime builders.
 - Resilient checkout tests assert rollback, fallback route selection, manual review, and side-effect boundaries.
 - Mailbox collaboration tests assert service handoff, compensation, correlation propagation, and final notification outcomes.
-- Backplane facade tests assert startup-style host configuration, routed request/reply, publish/subscribe fanout, outbox dispatch, idempotent replay, and correlation propagation.
+- Backplane facade tests assert startup-style host configuration, routed request/reply, publish/subscribe fanout, outbox dispatch, idempotent replay, correlation propagation, and RabbitMQ/MQTT Testcontainers E2E delivery.
 
 ## Related Documentation
 

--- a/docs/examples/messaging-backplane-facade.md
+++ b/docs/examples/messaging-backplane-facade.md
@@ -6,6 +6,7 @@ Source:
 
 - `src/PatternKit.Examples/Messaging/BackplaneFacadeDemo.cs`
 - `test/PatternKit.Examples.Tests/Messaging/BackplaneFacadeDemoTests.cs`
+- `test/PatternKit.Examples.Tests/Messaging/BackplaneTestcontainerE2ETests.cs`
 
 ## What PatternKit Provides
 
@@ -122,6 +123,14 @@ The tests assert that:
 - Published events fan out to independent services.
 - Every event is recorded in the outbox before transport dispatch.
 - Correlation IDs flow from the original command through payment, fulfillment, and notification services.
+- RabbitMQ and MQTT Testcontainers run the same host/client workflow through real broker processes.
+
+The container tests live in the examples test project and are compiled for `net8.0` only so the full multi-target suite does not start duplicate broker containers. They use test-owned adapters:
+
+- `RabbitMqBackplaneTransport` maps PatternKit addresses to RabbitMQ fanout exchanges and subscriber queues.
+- `MqttBackplaneTransport` maps PatternKit addresses to MQTT topics over Eclipse Mosquitto.
+
+Those adapters are intentionally in test code. They demonstrate the integration boundary without making PatternKit depend on any broker package.
 
 ## Production Adapter Shape
 

--- a/src/PatternKit.Examples/Messaging/BackplaneFacadeDemo.cs
+++ b/src/PatternKit.Examples/Messaging/BackplaneFacadeDemo.cs
@@ -898,6 +898,7 @@ internal sealed class BackplaneDemoServices
     private readonly ConcurrentQueue<CustomerNotification> _notifications;
     private readonly TaskCompletionSource _completed;
     private BackplaneClient? _client;
+    private int _submittedAuditCount;
 
     internal BackplaneDemoServices(
         ConcurrentQueue<string> audit,
@@ -958,6 +959,8 @@ internal sealed class BackplaneDemoServices
     {
         _ = cancellationToken;
         _audit.Enqueue($"audit:order-submitted:{message.Payload.OrderId}:{context.Headers.CorrelationId}");
+        Interlocked.Increment(ref _submittedAuditCount);
+        TryComplete();
         return default;
     }
 
@@ -1024,8 +1027,12 @@ internal sealed class BackplaneDemoServices
     {
         _notifications.Enqueue(notification);
         _audit.Enqueue($"notification:{notification.OrderId}:{notification.Kind}");
+        TryComplete();
+    }
 
-        if (_notifications.Count == 3)
+    private void TryComplete()
+    {
+        if (_notifications.Count == 3 && Volatile.Read(ref _submittedAuditCount) == 3)
             _completed.TrySetResult();
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/BackplaneTestcontainerE2ETests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/BackplaneTestcontainerE2ETests.cs
@@ -1,0 +1,428 @@
+#if NET8_0
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using MQTTnet;
+using MQTTnet.Protocol;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Reliability;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Testcontainers.RabbitMq;
+
+namespace PatternKit.Examples.Tests.Messaging;
+
+public sealed class BackplaneTestcontainerE2ETests
+{
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task RabbitMqBackplane_RunsRequestReplyAndPublishSubscribeThroughContainer()
+    {
+#pragma warning disable CS0618 // Testcontainers keeps the parameterless builder for fluent module setup.
+        await using var container = new RabbitMqBuilder()
+            .WithImage("rabbitmq:3.13-alpine")
+            .Build();
+#pragma warning restore CS0618
+
+        await container.StartAsync();
+        await using var transport = await RabbitMqBackplaneTransport.CreateAsync(container.GetConnectionString());
+
+        await AssertBackplaneAsync(transport);
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task MqttBackplane_RunsRequestReplyAndPublishSubscribeThroughContainer()
+    {
+        const int mqttPort = 1883;
+#pragma warning disable CS0618 // Testcontainers keeps the parameterless builder for generic container setup.
+        await using var container = new ContainerBuilder()
+            .WithImage("eclipse-mosquitto:2.0")
+            .WithPortBinding(mqttPort, assignRandomHostPort: true)
+            .WithResourceMapping(
+                Encoding.UTF8.GetBytes("listener 1883 0.0.0.0\nallow_anonymous true\n"),
+                "/mosquitto/config/mosquitto.conf")
+            .Build();
+#pragma warning restore CS0618
+
+        await container.StartAsync();
+        await using var transport = await MqttBackplaneTransport.CreateAsync(
+            container.Hostname,
+            container.GetMappedPublicPort(mqttPort));
+
+        await AssertBackplaneAsync(transport);
+    }
+
+    private static async Task AssertBackplaneAsync(IBackplaneTransport transport)
+    {
+        var outbox = new BackplaneOutbox();
+        var idempotency = new InMemoryIdempotencyStore();
+        var observed = new TaskCompletionSource<CustomerNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        BackplaneClient? client = null;
+
+        await using var host = await BackplaneHost.Create()
+            .UseTransport(() => transport)
+            .UseOutbox(outbox)
+            .UseIdempotencyStore(idempotency)
+            .MapDefaultCommand<SubmitOrder, BackplaneOrderAccepted>("orders.standard")
+            .ReceiveEndpoint("orders.standard", endpoint =>
+                endpoint.HandleCommand<SubmitOrder, BackplaneOrderAccepted>(async (message, context, cancellationToken) =>
+                {
+                    await client!.PublishAsync(
+                        "orders.submitted",
+                        new BackplaneOrderSubmitted(message.Payload.OrderId, message.Payload.Total, message.Payload.CustomerTier),
+                        context.Headers,
+                        cancellationToken);
+
+                    return new BackplaneOrderAccepted(
+                        message.Payload.OrderId,
+                        "orders.standard",
+                        context.Headers.CorrelationId ?? string.Empty);
+                }))
+            .ReceiveEndpoint("notification-service", endpoint =>
+                endpoint.Subscribe<BackplaneOrderSubmitted>("orders.submitted", (message, context, _) =>
+                {
+                    observed.TrySetResult(new CustomerNotification(
+                        message.Payload.OrderId,
+                        "order-submitted",
+                        context.Headers.CorrelationId ?? string.Empty));
+                    return default;
+                }))
+            .BuildAsync();
+
+        client = host.Client;
+
+        var accepted = await host.Client.RequestAsync<SubmitOrder, BackplaneOrderAccepted>(
+            Message<SubmitOrder>
+                .Create(new SubmitOrder("container-order", 42m, CustomerTier.Standard))
+                .WithMessageId("msg-container-order")
+                .WithCorrelationId("corr-container-order")
+                .WithIdempotencyKey("idem-container-order"));
+
+        var notification = await observed.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        Assert.Equal(new BackplaneOrderAccepted("container-order", "orders.standard", "corr-container-order"), accepted);
+        Assert.Equal(new CustomerNotification("container-order", "order-submitted", "corr-container-order"), notification);
+        Assert.Single(outbox.Records);
+        Assert.Equal("orders.submitted", outbox.Records[0].Address);
+        Assert.True(outbox.Records[0].Dispatched);
+        Assert.Equal(1, outbox.Records[0].Delivered);
+        Assert.True(idempotency.TryGet("idem-container-order", out var claim));
+        Assert.Equal(IdempotencyEntryStatus.Completed, claim!.Status);
+    }
+}
+
+internal sealed class RabbitMqBackplaneTransport : IBackplaneTransport
+{
+    private const string ExchangePrefix = "patternkit.backplane.";
+    private readonly IConnection _connection;
+    private readonly IChannel _publisher;
+    private readonly ConcurrentDictionary<string, byte> _subscriptions = new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    private RabbitMqBackplaneTransport(IConnection connection, IChannel publisher)
+    {
+        _connection = connection;
+        _publisher = publisher;
+    }
+
+    internal static async ValueTask<RabbitMqBackplaneTransport> CreateAsync(string connectionString)
+    {
+        var factory = new ConnectionFactory
+        {
+            Uri = new Uri(connectionString),
+            ClientProvidedName = "patternkit-testcontainer-e2e"
+        };
+        var connection = await factory.CreateConnectionAsync();
+        var publisher = await connection.CreateChannelAsync();
+        return new RabbitMqBackplaneTransport(connection, publisher);
+    }
+
+    public async ValueTask<IAsyncDisposable> SubscribeAsync(
+        string address,
+        string subscriberName,
+        BackplaneTransportHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var exchange = ExchangeName(address);
+        var channel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
+        await channel.ExchangeDeclareAsync(exchange, ExchangeType.Fanout, durable: false, autoDelete: true, cancellationToken: cancellationToken);
+
+        var queue = await channel.QueueDeclareAsync(
+            queue: string.Empty,
+            durable: false,
+            exclusive: true,
+            autoDelete: true,
+            cancellationToken: cancellationToken);
+        await channel.QueueBindAsync(queue.QueueName, exchange, routingKey: string.Empty, cancellationToken: cancellationToken);
+
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        consumer.ReceivedAsync += async (_, args) =>
+        {
+            var envelope = BackplaneEnvelopeCodec.Decode(args.Body.ToArray());
+            await handler(envelope, new MessageContext(envelope.Headers, cancellationToken), cancellationToken);
+            await channel.BasicAckAsync(args.DeliveryTag, multiple: false, cancellationToken);
+        };
+
+        var consumerTag = await channel.BasicConsumeAsync(
+            queue.QueueName,
+            autoAck: false,
+            consumerTag: string.Empty,
+            noLocal: false,
+            exclusive: false,
+            arguments: null,
+            consumer,
+            cancellationToken);
+
+        var key = $"{address}\0{subscriberName}\0{consumerTag}";
+        _subscriptions[key] = 0;
+        return new RabbitMqBackplaneSubscription(channel, consumerTag, _subscriptions, key);
+    }
+
+    public async ValueTask<int> SendAsync(
+        string address,
+        BackplaneEnvelope envelope,
+        CancellationToken cancellationToken = default)
+    {
+        var exchange = ExchangeName(address);
+        await _publisher.ExchangeDeclareAsync(exchange, ExchangeType.Fanout, durable: false, autoDelete: true, cancellationToken: cancellationToken);
+        await _publisher.BasicPublishAsync(
+            exchange,
+            routingKey: string.Empty,
+            mandatory: false,
+            basicProperties: new BasicProperties
+            {
+                ContentType = "application/json",
+                MessageId = envelope.Headers.MessageId,
+                CorrelationId = envelope.Headers.CorrelationId,
+                ReplyTo = envelope.Headers.ReplyTo
+            },
+            body: BackplaneEnvelopeCodec.Encode(envelope),
+            cancellationToken);
+
+        return CountSubscriptions(address);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        await _publisher.CloseAsync();
+        await _connection.CloseAsync();
+    }
+
+    private int CountSubscriptions(string address)
+        => _subscriptions.Keys.Count(key => key.StartsWith(address + "\0", StringComparison.Ordinal));
+
+    private static string ExchangeName(string address) => ExchangePrefix + address.Replace('.', '-');
+}
+
+internal sealed class RabbitMqBackplaneSubscription : IAsyncDisposable
+{
+    private readonly IChannel _channel;
+    private readonly string _consumerTag;
+    private readonly ConcurrentDictionary<string, byte> _subscriptions;
+    private readonly string _key;
+
+    internal RabbitMqBackplaneSubscription(
+        IChannel channel,
+        string consumerTag,
+        ConcurrentDictionary<string, byte> subscriptions,
+        string key)
+    {
+        _channel = channel;
+        _consumerTag = consumerTag;
+        _subscriptions = subscriptions;
+        _key = key;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _subscriptions.TryRemove(_key, out _);
+        await _channel.BasicCancelAsync(_consumerTag);
+        await _channel.CloseAsync();
+    }
+}
+
+internal sealed class MqttBackplaneTransport : IBackplaneTransport
+{
+    private readonly MqttClientFactory _factory = new();
+    private readonly string _host;
+    private readonly int _port;
+    private readonly IMqttClient _publisher;
+    private readonly ConcurrentDictionary<string, byte> _subscriptions = new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    private MqttBackplaneTransport(string host, int port, IMqttClient publisher)
+    {
+        _host = host;
+        _port = port;
+        _publisher = publisher;
+    }
+
+    internal static async ValueTask<MqttBackplaneTransport> CreateAsync(string host, int port)
+    {
+        var factory = new MqttClientFactory();
+        var options = new MqttClientOptionsBuilder()
+            .WithClientId("patternkit-publisher-" + Guid.NewGuid().ToString("N"))
+            .WithTcpServer(host, port)
+            .WithCleanSession()
+            .Build();
+        var publisher = factory.CreateMqttClient();
+        await ConnectWithRetryAsync(publisher, options, CancellationToken.None);
+        return new MqttBackplaneTransport(host, port, publisher);
+    }
+
+    public async ValueTask<IAsyncDisposable> SubscribeAsync(
+        string address,
+        string subscriberName,
+        BackplaneTransportHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var client = _factory.CreateMqttClient();
+        var options = new MqttClientOptionsBuilder()
+            .WithClientId($"patternkit-{subscriberName}-{Guid.NewGuid():N}")
+            .WithTcpServer(_host, _port)
+            .WithCleanSession()
+            .Build();
+
+        client.ApplicationMessageReceivedAsync += async args =>
+        {
+            var envelope = BackplaneEnvelopeCodec.Decode(args.ApplicationMessage.Payload.ToArray());
+            await handler(envelope, new MessageContext(envelope.Headers, cancellationToken), cancellationToken);
+        };
+
+        await ConnectWithRetryAsync(client, options, cancellationToken);
+        await client.SubscribeAsync(
+            new MqttClientSubscribeOptionsBuilder()
+                .WithTopicFilter(TopicName(address), MqttQualityOfServiceLevel.AtLeastOnce)
+                .Build(),
+            cancellationToken);
+
+        var key = $"{address}\0{subscriberName}\0{Guid.NewGuid():N}";
+        _subscriptions[key] = 0;
+        return new MqttBackplaneSubscription(client, _subscriptions, key);
+    }
+
+    public async ValueTask<int> SendAsync(
+        string address,
+        BackplaneEnvelope envelope,
+        CancellationToken cancellationToken = default)
+    {
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic(TopicName(address))
+            .WithPayload(BackplaneEnvelopeCodec.Encode(envelope).ToArray())
+            .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
+            .Build();
+
+        await _publisher.PublishAsync(message, cancellationToken);
+        return _subscriptions.Keys.Count(key => key.StartsWith(address + "\0", StringComparison.Ordinal));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        if (_publisher.IsConnected)
+            await _publisher.DisconnectAsync(new MqttClientDisconnectOptions(), CancellationToken.None);
+
+        _publisher.Dispose();
+    }
+
+    private static string TopicName(string address) => "patternkit/backplane/" + address.Replace('.', '/');
+
+    private static async Task ConnectWithRetryAsync(
+        IMqttClient client,
+        MqttClientOptions options,
+        CancellationToken cancellationToken)
+    {
+        Exception? last = null;
+        for (var attempt = 0; attempt < 30; attempt++)
+        {
+            try
+            {
+                await client.ConnectAsync(options, cancellationToken);
+                return;
+            }
+            catch (Exception exception) when (attempt < 29)
+            {
+                last = exception;
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+            }
+        }
+
+        throw new InvalidOperationException("MQTT broker did not become available.", last);
+    }
+}
+
+internal sealed class MqttBackplaneSubscription : IAsyncDisposable
+{
+    private readonly IMqttClient _client;
+    private readonly ConcurrentDictionary<string, byte> _subscriptions;
+    private readonly string _key;
+
+    internal MqttBackplaneSubscription(
+        IMqttClient client,
+        ConcurrentDictionary<string, byte> subscriptions,
+        string key)
+    {
+        _client = client;
+        _subscriptions = subscriptions;
+        _key = key;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _subscriptions.TryRemove(_key, out _);
+        if (_client.IsConnected)
+            await _client.DisconnectAsync(new MqttClientDisconnectOptions(), CancellationToken.None);
+
+        _client.Dispose();
+    }
+}
+
+internal static class BackplaneEnvelopeCodec
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    internal static ReadOnlyMemory<byte> Encode(BackplaneEnvelope envelope)
+    {
+        var dto = new BackplaneEnvelopeDto(
+            envelope.PayloadType.AssemblyQualifiedName!,
+            JsonSerializer.Serialize(envelope.Payload, envelope.PayloadType, Options),
+            envelope.Headers.ToDictionary(
+                static pair => pair.Key,
+                static pair => pair.Value?.ToString() ?? string.Empty,
+                StringComparer.OrdinalIgnoreCase));
+
+        return JsonSerializer.SerializeToUtf8Bytes(dto, Options);
+    }
+
+    internal static BackplaneEnvelope Decode(byte[] payload)
+    {
+        var dto = JsonSerializer.Deserialize<BackplaneEnvelopeDto>(payload, Options)
+            ?? throw new InvalidOperationException("Backplane envelope payload was empty.");
+        var payloadType = Type.GetType(dto.PayloadType, throwOnError: true)!;
+        var message = JsonSerializer.Deserialize(dto.PayloadJson, payloadType, Options)
+            ?? throw new InvalidOperationException($"Backplane payload '{payloadType.FullName}' was empty.");
+
+        return new BackplaneEnvelope(
+            payloadType,
+            message,
+            new MessageHeaders(dto.Headers.Select(static pair => new KeyValuePair<string, object?>(pair.Key, pair.Value))));
+    }
+
+    private sealed record BackplaneEnvelopeDto(
+        string PayloadType,
+        string PayloadJson,
+        IReadOnlyDictionary<string, string> Headers);
+}
+#endif

--- a/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
+++ b/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
@@ -19,7 +19,11 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="MQTTnet" />
+        <PackageReference Include="RabbitMQ.Client" />
         <PackageReference Include="System.Collections.Immutable" />
+        <PackageReference Include="Testcontainers" />
+        <PackageReference Include="Testcontainers.RabbitMq" />
         <PackageReference Include="TinyBDD.Xunit" VersionOverride="0.19.8" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.extensibility.core" />

--- a/test/PatternKit.Examples.Tests/packages.lock.json
+++ b/test/PatternKit.Examples.Tests/packages.lock.json
@@ -56,11 +56,48 @@
           "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
+      "MQTTnet": {
+        "type": "Direct",
+        "requested": "[5.1.0.1559, )",
+        "resolved": "5.1.0.1559",
+        "contentHash": "9mkk0H+76CToIzp9ru5Uj5BuC3P5hQdkhvXM+CLmmTDdZWqajjICCHuUMbDd1yVBt9BWL77Rvzt0A+/PA4WMCA=="
+      },
+      "RabbitMQ.Client": {
+        "type": "Direct",
+        "requested": "[7.2.1, )",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg==",
+        "dependencies": {
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
       "System.Collections.Immutable": {
         "type": "Direct",
         "requested": "[9.0.0, )",
         "resolved": "9.0.0",
         "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w=="
+      },
+      "Testcontainers": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "Testcontainers.RabbitMq": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "+4rDOXdjwwDx11vUpSAAK/gDOPtZ/LC+qj02RiulHtIMEAzC4KjyP5hEactvwSuGfcomFnmtJqYn1Pwyh+pPDw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
       },
       "TinyBDD.Xunit": {
         "type": "Direct",
@@ -98,6 +135,27 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -306,10 +364,29 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "xunit.abstractions": {
         "type": "Transitive",
@@ -514,11 +591,49 @@
           "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
+      "MQTTnet": {
+        "type": "Direct",
+        "requested": "[5.1.0.1559, )",
+        "resolved": "5.1.0.1559",
+        "contentHash": "9mkk0H+76CToIzp9ru5Uj5BuC3P5hQdkhvXM+CLmmTDdZWqajjICCHuUMbDd1yVBt9BWL77Rvzt0A+/PA4WMCA=="
+      },
+      "RabbitMQ.Client": {
+        "type": "Direct",
+        "requested": "[7.2.1, )",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg==",
+        "dependencies": {
+          "System.IO.Pipelines": "8.0.0",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
       "System.Collections.Immutable": {
         "type": "Direct",
         "requested": "[9.0.0, )",
         "resolved": "9.0.0",
         "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w=="
+      },
+      "Testcontainers": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "Testcontainers.RabbitMq": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "+4rDOXdjwwDx11vUpSAAK/gDOPtZ/LC+qj02RiulHtIMEAzC4KjyP5hEactvwSuGfcomFnmtJqYn1Pwyh+pPDw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
       },
       "TinyBDD.Xunit": {
         "type": "Direct",
@@ -556,6 +671,28 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -769,6 +906,20 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -797,6 +948,11 @@
           "System.IO.Pipelines": "10.0.7",
           "System.Text.Encodings.Web": "10.0.7"
         }
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "xunit.abstractions": {
         "type": "Transitive",
@@ -1001,11 +1157,48 @@
           "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
+      "MQTTnet": {
+        "type": "Direct",
+        "requested": "[5.1.0.1559, )",
+        "resolved": "5.1.0.1559",
+        "contentHash": "9mkk0H+76CToIzp9ru5Uj5BuC3P5hQdkhvXM+CLmmTDdZWqajjICCHuUMbDd1yVBt9BWL77Rvzt0A+/PA4WMCA=="
+      },
+      "RabbitMQ.Client": {
+        "type": "Direct",
+        "requested": "[7.2.1, )",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg==",
+        "dependencies": {
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
       "System.Collections.Immutable": {
         "type": "Direct",
         "requested": "[9.0.0, )",
         "resolved": "9.0.0",
         "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w=="
+      },
+      "Testcontainers": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "Testcontainers.RabbitMq": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "+4rDOXdjwwDx11vUpSAAK/gDOPtZ/LC+qj02RiulHtIMEAzC4KjyP5hEactvwSuGfcomFnmtJqYn1Pwyh+pPDw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
       },
       "TinyBDD.Xunit": {
         "type": "Direct",
@@ -1043,6 +1236,27 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -1256,6 +1470,20 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -1284,6 +1512,11 @@
           "System.IO.Pipelines": "10.0.7",
           "System.Text.Encodings.Web": "10.0.7"
         }
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "xunit.abstractions": {
         "type": "Transitive",


### PR DESCRIPTION
Closes #192.

## Summary

- Adds RabbitMQ and MQTT Testcontainers E2E tests for the PatternKit backplane host/client workflow.
- Implements test-owned `RabbitMqBackplaneTransport` and `MqttBackplaneTransport` adapters to prove the pluggable broker boundary without adding broker dependencies to PatternKit runtime projects.
- Verifies request/reply, publish/subscribe event delivery, outbox dispatch, correlation propagation, and idempotency completion through real broker processes.
- Fixes a deterministic completion race in the in-memory backplane demo exposed by coverage-style parallel runs.
- Documents the broker-backed E2E coverage and why adapters remain test/application code.

## Validation

- `dotnet restore test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj`
- `dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --configuration Release --framework net8.0 --no-build --filter "FullyQualifiedName~BackplaneTestcontainerE2ETests" -p:UseSharedCompilation=false`
- `dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false`
- `dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --configuration Release --framework net8.0 --no-restore --filter "FullyQualifiedName~BackplaneTestcontainerE2ETests|FullyQualifiedName~BackplaneFacadeDemoTests.RunAsync_FansOutEventsToIndependentServices" -p:UseSharedCompilation=false`
- `dotnet test PatternKit.slnx --configuration Release --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[PatternKit*]*" DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests]*"`
- `dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true -p:UseSharedCompilation=false`
- `dotnet test test\\PatternKit.Tests\\PatternKit.Tests.csproj --configuration Release --no-build -p:UseSharedCompilation=false`
- `dotnet test test\\PatternKit.Generators.Tests\\PatternKit.Generators.Tests.csproj --configuration Release --no-build -p:UseSharedCompilation=false`
- `docfx metadata docs\\docfx.json`
- `docfx build docs\\docfx.json`
- `git diff --check`