### PR TITLE
test: raise coverage to 95 percent

### DIFF
--- a/src/PatternKit.Examples/Generators/Factories/FactoryGeneratorExamples.cs
+++ b/src/PatternKit.Examples/Generators/Factories/FactoryGeneratorExamples.cs
@@ -97,7 +97,7 @@ public sealed class StartWorkersStep : IOrchestratorStep
 
 public sealed class ApplicationOrchestrator(IServiceProvider services)
 {
-    private readonly OrchestratorStepFactory _factory = new();
+    private readonly OrchestratorStepFactory _factory = new(services);
     private readonly IServiceProvider _services = services;
 
     public async Task RunAsync(IEnumerable<string> steps, CancellationToken cancellationToken = default)

--- a/test/PatternKit.Examples.Tests/Chain/TransactionPipelineDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Chain/TransactionPipelineDemoTests.cs
@@ -163,4 +163,52 @@ public sealed class TransactionPipelineDemoTests(ITestOutputHelper output) : Tin
 
         PaymentPipeline Pipe() => BuildPipeline(discounts: [], rounding: []);
     }
+
+    [Scenario("Config-driven rules cover skipped discounts, bundle application, rounding no-op, and card short-circuit")]
+    [Fact]
+    public async Task ConfigDrivenRules_CoverBranchBehavior()
+    {
+        await Given("standalone config-driven rules and handlers", () =>
+            {
+                var context = Ctx(
+                    items:
+                    [
+                        new LineItem("A", 10m, BundleKey: "B"),
+                        new LineItem("B", 5m, Qty: 1, BundleKey: "B")
+                    ],
+                    tenders: [new Tender(PaymentKind.Card, CardAuthType.Chip, CardVendor.Visa)]);
+                context.RecomputeSubtotal();
+                context.SetTax(0m);
+
+                return new
+                {
+                    Context = context,
+                    CashRule = new Cash2Pct(),
+                    LoyaltyRule = new Loyalty5Pct(),
+                    BundleRule = new Bundle1OffEach(),
+                    Charity = new CharityRoundUp(),
+                    Nickel = new NickelCashOnly(),
+                    Card = new CardTender(new CardProcessors(new() { [CardVendor.Visa] = new GenericProcessor("VisaNet") }))
+                };
+            })
+            .When("applying rules and card handler edge paths", rules =>
+            {
+                rules.CashRule.Apply(rules.Context);
+                rules.LoyaltyRule.Apply(rules.Context);
+                rules.BundleRule.Apply(rules.Context);
+                rules.Charity.Apply(rules.Context);
+                rules.Nickel.Apply(rules.Context);
+                rules.Context.ApplyPayment(rules.Context.RemainderDue, "prepaid");
+                var cardResult = rules.Card.Handle(rules.Context, new Tender(PaymentKind.Card, CardAuthType.Chip, CardVendor.Visa));
+
+                return (rules.Context, cardResult);
+            })
+            .Then("cash and loyalty discounts were skipped", result =>
+                !result.Context.Log.Any(log => log.Contains("cash 2% off", StringComparison.Ordinal))
+                && !result.Context.Log.Any(log => log.Contains("loyalty", StringComparison.Ordinal)))
+            .And("bundle discount was applied", result => result.Context.Log.Any(log => log.Contains("bundle deal", StringComparison.Ordinal)))
+            .And("nickel rounding logged the non-cash skip", result => result.Context.Log.Any(log => log.Contains("not cash-only", StringComparison.Ordinal)))
+            .And("card handler short-circuits when nothing remains due", result => result.cardResult is { Ok: true, Code: "card", Message: "nothing to pay" })
+            .AssertPassed();
+    }
 }

--- a/test/PatternKit.Examples.Tests/ConsoleTestCollection.cs
+++ b/test/PatternKit.Examples.Tests/ConsoleTestCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace PatternKit.Examples.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ConsoleTestCollection
+{
+    public const string Name = "Console output demos";
+}

--- a/test/PatternKit.Examples.Tests/Decorators/StorageDecoratorExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Decorators/StorageDecoratorExampleTests.cs
@@ -1,8 +1,13 @@
 using PatternKit.Examples.Decorators;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Examples.Tests.Decorators;
 
-public sealed class StorageDecoratorExampleTests
+[Feature("Storage decorator example")]
+[Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
+public sealed class StorageDecoratorExampleTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Fact]
     public void InMemoryStorage_ReadWriteExistsAndDelete_WorkAsExpected()
@@ -59,6 +64,91 @@ public sealed class StorageDecoratorExampleTests
 
         Assert.Throws<IOException>(() => storage.WriteFile("data.txt", "payload"));
     }
+
+    [Scenario("Public storage decorator demo runs the composed logging, caching, and retry workflow")]
+    [Fact]
+    public async Task StorageDecoratorDemo_Run_CoversComposedWorkflow()
+    {
+        await Given("a redirected console", CaptureConsole)
+            .When("running the storage decorator demo", string (capture) =>
+            {
+                try
+                {
+                    StorageDecoratorDemo.Run();
+                    return capture.Output();
+                }
+                finally
+                {
+                    capture.Dispose();
+                }
+            })
+            .Then("the write path ran", output => output.Contains("Writing a file", StringComparison.Ordinal))
+            .And("the cache hit path ran", output => output.Contains("[Cache] Hit", StringComparison.Ordinal))
+            .And("the retry failure path was handled", output => output.Contains("Expected error:", StringComparison.Ordinal))
+            .AssertPassed();
+    }
+
+    [Scenario("Logging decorator reports read failures and delete operations")]
+    [Fact]
+    public async Task LoggingDecorator_CoversFailureAndDeleteBranches()
+    {
+        await Given("logging storage with a redirected console", () =>
+            {
+                var capture = CaptureConsole();
+                return new LoggingHarness(new LoggingFileStorage(new InMemoryFileStorage()), capture);
+            })
+            .When("deleting a missing file and reading it", LoggingResult (harness) =>
+            {
+                try
+                {
+                    harness.Storage.DeleteFile("missing.txt");
+                    FileNotFoundException? missing = null;
+                    try
+                    {
+                        harness.Storage.ReadFile("missing.txt");
+                    }
+                    catch (FileNotFoundException ex)
+                    {
+                        missing = ex;
+                    }
+
+                    return new LoggingResult(harness.Capture.Output(), missing);
+                }
+                finally
+                {
+                    harness.Capture.Dispose();
+                }
+            })
+            .Then("delete was logged", result => result.Output.Contains("Deleting file: missing.txt", StringComparison.Ordinal))
+            .And("read failure was logged", result => result.Output.Contains("Error reading missing.txt", StringComparison.Ordinal))
+            .And("the storage error propagated", result => result.Exception is not null)
+            .AssertPassed();
+    }
+
+    private static ConsoleCapture CaptureConsole() => new();
+
+    private sealed class ConsoleCapture : IDisposable
+    {
+        private readonly TextWriter _original = Console.Out;
+        private readonly StringWriter _writer = new();
+
+        public ConsoleCapture()
+        {
+            Console.SetOut(_writer);
+        }
+
+        public string Output() => _writer.ToString();
+
+        public void Dispose()
+        {
+            Console.SetOut(_original);
+            _writer.Dispose();
+        }
+    }
+
+    private sealed record LoggingHarness(LoggingFileStorage Storage, ConsoleCapture Capture);
+
+    private sealed record LoggingResult(string Output, FileNotFoundException? Exception);
 
     private sealed class FlakyStorage : IFileStorage
     {

--- a/test/PatternKit.Examples.Tests/Generators/CorporateApplicationBuilderDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/CorporateApplicationBuilderDemoTests.cs
@@ -52,4 +52,41 @@ public sealed class CorporateApplicationBuilderDemoTests(ITestOutputHelper outpu
                 })
             .AssertPassed();
     }
+
+    [Scenario("BuildProductionAsync returns the fully initialized production application")]
+    [Fact]
+    public async Task BuildProductionAsync_UsesDefaultProductionRecipe()
+    {
+        await Given("the public production build recipe", () => (Func<ValueTask<CorporateApp>>)CorporateApplicationDemo.BuildProductionAsync)
+            .When<CorporateApp>("building the production app", async ValueTask<CorporateApp> (build) => await build())
+            .Then("production configuration is selected", bool (app) =>
+                app.Host.Services.GetRequiredService<IConfiguration>()["ConnectionStrings:Primary"] == "Server=prod;Database=Corporate;")
+            .And("all production modules are enabled", bool (app) =>
+                app.Host.Services.GetService<IMetricsSink>() is not null
+                && app.Host.Services.GetService<INotificationPublisher>() is not null
+                && app.Host.Services.GetService<IBackgroundJobScheduler>() is not null)
+            .And("startup tasks ran", bool (app) =>
+                app.Log.Contains("startup:notifications")
+                && app.Log.Contains("startup:jobs"))
+            .AssertPassed();
+    }
+
+    [Scenario("Notification options expose production-ready defaults and overrides")]
+    [Fact]
+    public Task NotificationOptions_Defaults_And_Overrides_AreExplicit()
+        => Given("default and configured notification options", () => new
+            {
+                Defaults = new NotificationOptions(),
+                Configured = new NotificationOptions { Enabled = false, Provider = "rabbitmq" }
+            })
+            .When("reading options", options => (
+                DefaultEnabled: options.Defaults.Enabled,
+                DefaultProvider: options.Defaults.Provider,
+                ConfiguredEnabled: options.Configured.Enabled,
+                ConfiguredProvider: options.Configured.Provider))
+            .Then("defaults enable queue-backed notifications", values =>
+                values.DefaultEnabled && values.DefaultProvider == "queue")
+            .And("configured values are preserved", values =>
+                values.ConfiguredEnabled == false && values.ConfiguredProvider == "rabbitmq")
+            .AssertPassed();
 }

--- a/test/PatternKit.Examples.Tests/Generators/FacadeSpecsTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/FacadeSpecsTests.cs
@@ -184,6 +184,58 @@ public class FacadeSpecsTests
     }
 
     [Fact]
+    public void BillingSubsystems_CoverValidationAndMissingRecordPaths()
+    {
+        var tax = new TaxService();
+        var invoices = new InvoiceService();
+        var payments = new PaymentProcessor();
+
+        Assert.Equal(0m, tax.CalculateTax(100m, "UNKNOWN"));
+        Assert.Equal(0m, tax.GetTaxRate("UNKNOWN"));
+        Assert.Null(invoices.GetInvoice("INV-MISSING"));
+
+        var zeroAmount = payments.ProcessPayment("CUST001", 0m, "CreditCard");
+        var missingMethod = payments.ProcessPayment("CUST001", 10m, "");
+        var missingPaymentRefund = payments.RefundPayment("REC-MISSING", 1m);
+        var paid = payments.ProcessPayment("CUST001", 25m, "CreditCard");
+        var excessiveRefund = payments.RefundPayment(paid.ReceiptNumber!, 30m);
+
+        Assert.False(zeroAmount.Success);
+        Assert.Equal("Amount must be greater than zero", zeroAmount.ErrorMessage);
+        Assert.False(missingMethod.Success);
+        Assert.Equal("Payment method is required", missingMethod.ErrorMessage);
+        Assert.False(missingPaymentRefund.Success);
+        Assert.Equal("Payment not found", missingPaymentRefund.ErrorMessage);
+        Assert.False(excessiveRefund.Success);
+        Assert.Equal("Refund amount exceeds original payment", excessiveRefund.ErrorMessage);
+    }
+
+    [Fact]
+    public void BillingFacade_HandlesPaymentAndRefundFailures()
+    {
+        var facade = new BillingFacade(
+            new InvoiceService(),
+            new NotificationService(),
+            new PaymentProcessor(),
+            new TaxService());
+
+        var failedPayment = facade.ProcessPayment(
+            customerId: "CUST-FAIL",
+            subtotal: -1m,
+            jurisdiction: "US-CA",
+            paymentMethod: "CreditCard");
+        var missingRefund = facade.ProcessRefund(
+            customerId: "CUST-FAIL",
+            receiptNumber: "REC-MISSING",
+            amount: 1m);
+
+        Assert.False(failedPayment.Success);
+        Assert.Equal("Amount must be greater than zero", failedPayment.ErrorMessage);
+        Assert.False(missingRefund.Success);
+        Assert.Equal("Payment not found", missingRefund.ErrorMessage);
+    }
+
+    [Fact]
     public void ShippingDemo_ExecutesSuccessfully()
     {
         // This test validates the demo runs without errors

--- a/test/PatternKit.Examples.Tests/Generators/FactoryGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/FactoryGeneratorExamplesTests.cs
@@ -196,6 +196,36 @@ public sealed class OrchestratorStepFactoryTests
 
         Assert.Throws<ArgumentNullException>(() => factory.CreateFromKey(null!));
     }
+
+    [Fact]
+    public async Task ApplicationOrchestrator_RunsConfiguredStepsAgainstServices()
+    {
+        var seeder = new TestSeeder();
+        var worker = new TestWorker();
+        var services = new ServiceCollection()
+            .AddSingleton<ISeeder>(seeder)
+            .AddSingleton<ICacheProvider, MemoryCacheProvider>()
+            .AddSingleton<IWorker>(worker)
+            .BuildServiceProvider();
+        var orchestrator = new ApplicationOrchestrator(services);
+
+        await orchestrator.RunAsync(["seed", "warm-cache", "start-workers"]);
+
+        Assert.True(seeder.WasSeeded);
+        Assert.True(worker.WasStarted);
+    }
+
+    private sealed class TestSeeder : ISeeder
+    {
+        public bool WasSeeded { get; private set; }
+        public void Seed() => WasSeeded = true;
+    }
+
+    private sealed class TestWorker : IWorker
+    {
+        public bool WasStarted { get; private set; }
+        public void Start() => WasStarted = true;
+    }
 }
 
 public sealed class SeedDataStepTests

--- a/test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs
@@ -93,6 +93,52 @@ public sealed class MementoGeneratorExamplesTests
     }
 
     [Fact]
+    public void GameSession_DoesNotUndoWhenGeneratedHistorySkipsDuplicateMutableState()
+    {
+        var session = new GameStateDemo.GameSession();
+
+        Assert.False(session.UndoToCheckpoint());
+        session.PerformAction(state => state.MovePlayer(2, 3), "move");
+        session.PerformAction(state =>
+        {
+            state.TakeDamage(15);
+            state.IsPaused = true;
+        }, "damage and pause");
+
+        Assert.False(session.UndoToCheckpoint());
+        Assert.Equal(2, session.State.PlayerX);
+        Assert.Equal(3, session.State.PlayerY);
+        Assert.Equal(85, session.State.Health);
+        Assert.True(session.State.IsPaused);
+        Assert.False(session.RedoToCheckpoint());
+    }
+
+    [Fact]
+    public void GameState_HealthIsClampedAndSaveLoadRestoresCapturedValues()
+    {
+        var state = new GameStateDemo.GameState();
+
+        state.TakeDamage(500);
+        Assert.Equal(0, state.Health);
+        state.Heal(500);
+        Assert.Equal(100, state.Health);
+
+        state.MovePlayer(1, 1);
+        state.AddScore(10);
+        var save = GameStateMemento.Capture(in state);
+
+        state.MovePlayer(9, 9);
+        state.TakeDamage(25);
+        state.AddScore(90);
+        save.Restore(state);
+
+        Assert.Equal(1, state.PlayerX);
+        Assert.Equal(1, state.PlayerY);
+        Assert.Equal(100, state.Health);
+        Assert.Equal(10, state.Score);
+    }
+
+    [Fact]
     public void GameStateDemo_RunAndSaveLoad_ReturnExpectedLogEntries()
     {
         var runLog = GameStateDemo.Run();

--- a/test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs
@@ -1,8 +1,13 @@
 using PatternKit.Examples.Generators.State;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Examples.Tests.GeneratorTests;
 
-public sealed class StateGeneratorExamplesTests
+[Feature("State generator examples")]
+[Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
+public sealed class StateGeneratorExamplesTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Fact]
     public void OrderFlow_StartsInDraftAndExposesAvailableTriggers()
@@ -80,5 +85,143 @@ public sealed class StateGeneratorExamplesTests
 
         Assert.Equal(DocumentState.Draft, workflow.State);
         Assert.Empty(workflow.ReviewComments);
+    }
+
+    [Scenario("Order flow demo suite covers happy path, cancellation, guard failure, and state-based logic")]
+    [Fact]
+    public async Task OrderFlowDemo_RunAllDemosAsync_CompletesPublicWorkflowSuite()
+    {
+        await Given("a redirected console", CaptureConsole)
+            .When("running every order flow demo", async Task<string> (capture) =>
+            {
+                try
+                {
+                    await OrderFlowDemo.RunAllDemosAsync();
+                    return capture.Output();
+                }
+                finally
+                {
+                    capture.Dispose();
+                }
+            })
+            .Then("the shipped happy path completed", output => output.Contains("Order processing complete", StringComparison.Ordinal))
+            .And("the cancellation scenario completed", output => output.Contains("Order was cancelled", StringComparison.Ordinal))
+            .And("the guard failure scenario blocked payment", output => output.Contains("Payment blocked by guard", StringComparison.Ordinal))
+            .And("state-based trigger discovery completed", output => output.Contains("State-based logic complete", StringComparison.Ordinal))
+            .AssertPassed();
+    }
+
+    [Scenario("Order flow rejects invalid triggers and honors async cancellation")]
+    [Fact]
+    public async Task OrderFlow_RejectsInvalidTriggersAndAsyncCancellation()
+    {
+        await Given("a submitted order", () =>
+            {
+                var order = new OrderFlow("ORD-BDD", 250m);
+                order.Fire(OrderTrigger.Submit);
+                return order;
+            })
+            .When("shipping before payment and cancelling payment",
+                async Task<(OrderFlow order, InvalidOperationException? invalidShip, OperationCanceledException? cancelledPay)> (order) =>
+            {
+                InvalidOperationException? invalidShip = null;
+                OperationCanceledException? cancelledPay = null;
+
+                try
+                {
+                    order.Fire(OrderTrigger.Ship);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    invalidShip = ex;
+                }
+
+                using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(25));
+                try
+                {
+                    await order.FireAsync(OrderTrigger.Pay, cts.Token);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    cancelledPay = ex;
+                }
+
+                return (order, invalidShip, cancelledPay);
+            })
+            .Then("shipping before payment is rejected", result => result.invalidShip is not null)
+            .And("payment observes cancellation", result => result.cancelledPay is not null)
+            .And("the order remains submitted after failed operations", result => result.order.State == OrderState.Submitted)
+            .AssertPassed();
+    }
+
+    [Scenario("Document workflow covers approval, rejection, publish cancellation, and invalid actions")]
+    [Fact]
+    public async Task DocumentWorkflow_CoversHappyAndSadPaths()
+    {
+        await Given("independent document workflows", () =>
+            (
+                Approval: new DocumentWorkflow("DOC-APPROVE", "Alice"),
+                Rejection: new DocumentWorkflow("DOC-REJECT", "Bob"),
+                Cancellation: new DocumentWorkflow("DOC-CANCEL", "Chris")))
+            .When("driving approval, rejection, and cancelled publish paths",
+                async Task<((DocumentWorkflow Approval, DocumentWorkflow Rejection, DocumentWorkflow Cancellation) workflows, bool canApproveWithoutComment, OperationCanceledException? cancelled)> (workflows) =>
+            {
+                workflows.Approval.Fire(DocumentAction.SubmitForReview);
+                var canApproveWithoutComment = workflows.Approval.CanFire(DocumentAction.Approve);
+                workflows.Approval.ReviewComments.Add("Approved.");
+                workflows.Approval.Fire(DocumentAction.Approve);
+                await workflows.Approval.FireAsync(DocumentAction.Publish, CancellationToken.None);
+
+                workflows.Rejection.Fire(DocumentAction.SubmitForReview);
+                workflows.Rejection.Fire(DocumentAction.Reject);
+                workflows.Rejection.ReviewComments.Add("Revise.");
+                workflows.Rejection.Fire(DocumentAction.Revise);
+
+                workflows.Cancellation.Fire(DocumentAction.SubmitForReview);
+                workflows.Cancellation.ReviewComments.Add("Looks good.");
+                workflows.Cancellation.Fire(DocumentAction.Approve);
+                OperationCanceledException? cancelled = null;
+                using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(25));
+                try
+                {
+                    await workflows.Cancellation.FireAsync(DocumentAction.Publish, cts.Token);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    cancelled = ex;
+                }
+
+                return (workflows, canApproveWithoutComment, cancelled);
+            })
+            .Then("approval requires a review comment", result => !result.canApproveWithoutComment)
+            .And("approved documents can be published", result => result.workflows.Approval.State == DocumentState.Published)
+            .And("rejected documents can return to draft and clear comments", result =>
+                result.workflows.Rejection.State == DocumentState.Draft
+                && result.workflows.Rejection.ReviewComments.Count == 0)
+            .And("publish observes cancellation", result =>
+                result.cancelled is not null
+                && result.workflows.Cancellation.State == DocumentState.Approved)
+            .AssertPassed();
+    }
+
+    private static ConsoleCapture CaptureConsole() => new();
+
+    private sealed class ConsoleCapture : IDisposable
+    {
+        private readonly TextWriter _original = Console.Out;
+        private readonly StringWriter _writer = new();
+
+        public ConsoleCapture()
+        {
+            Console.SetOut(_writer);
+        }
+
+        public string Output() => _writer.ToString();
+
+        public void Dispose()
+        {
+            Console.SetOut(_original);
+            _writer.Dispose();
+        }
     }
 }

--- a/test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs
@@ -1,8 +1,12 @@
 using PatternKit.Examples.Generators.Visitors;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Examples.Tests.GeneratorTests;
 
-public sealed class VisitorGeneratorExamplesTests
+[Feature("Visitor generator examples")]
+public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Fact]
     public void ResultVisitor_DispatchesToConcreteDocumentHandlers()
@@ -79,5 +83,192 @@ public sealed class VisitorGeneratorExamplesTests
     public async Task DocumentProcessingDemo_RunAsync_Completes()
     {
         await DocumentProcessingDemo.RunAsync();
+    }
+
+    [Scenario("Document validation covers happy and sad paths for every supported document type")]
+    [Fact]
+    public async Task DocumentProcessingDemo_ValidationRules_CoverSupportedDocumentTypes()
+    {
+        await Given("document validation cases", () => new ValidationCase[]
+            {
+                new("valid-pdf", new PdfDocument { FileName = "ok.pdf", PageCount = 1, SizeBytes = 1024 }, true, "PDF is valid"),
+                new("empty-pdf", new PdfDocument { FileName = "empty.pdf", PageCount = 0, SizeBytes = 1024 }, false, "no pages"),
+                new("encrypted-pdf", new PdfDocument { FileName = "secret.pdf", PageCount = 1, IsEncrypted = true, SizeBytes = 1024 }, false, "password"),
+                new("large-pdf", new PdfDocument { FileName = "large.pdf", PageCount = 1, SizeBytes = 100_000_001 }, false, "maximum size"),
+                new("valid-word", new WordDocument { FileName = "ok.docx", WordCount = 1, SizeBytes = 1024 }, true, "Document is valid"),
+                new("empty-word", new WordDocument { FileName = "empty.docx", WordCount = 0, SizeBytes = 1024 }, false, "empty"),
+                new("macro-word", new WordDocument { FileName = "macro.docx", WordCount = 1, HasMacros = true, SizeBytes = 1024 }, false, "macros"),
+                new("large-word", new WordDocument { FileName = "large.docx", WordCount = 1, SizeBytes = 50_000_001 }, false, "maximum size"),
+                new("valid-sheet", new SpreadsheetDocument { FileName = "ok.xlsx", SheetCount = 1, SizeBytes = 1024 }, true, "Spreadsheet is valid"),
+                new("empty-sheet", new SpreadsheetDocument { FileName = "empty.xlsx", SheetCount = 0, SizeBytes = 1024 }, false, "no sheets"),
+                new("wide-sheet", new SpreadsheetDocument { FileName = "wide.xlsx", SheetCount = 101, SizeBytes = 1024 }, false, "Too many sheets"),
+                new("large-sheet", new SpreadsheetDocument { FileName = "large.xlsx", SheetCount = 1, SizeBytes = 75_000_001 }, false, "maximum size"),
+                new("valid-markdown", new MarkdownDocument { FileName = "ok.md", LineCount = 1, SizeBytes = 1024 }, true, "Markdown is valid"),
+                new("empty-markdown", new MarkdownDocument { FileName = "empty.md", LineCount = 0, SizeBytes = 1024 }, false, "empty"),
+                new("large-markdown", new MarkdownDocument { FileName = "large.md", LineCount = 1, SizeBytes = 10_000_001 }, false, "maximum size")
+            })
+            .When("validating each document through the demo rule methods", cases =>
+                cases.Select(c => new
+                {
+                    c.Name,
+                    c.ExpectedValid,
+                    c.ExpectedMessageFragment,
+                    Result = Validate(c.Document)
+                }).ToArray())
+            .Then("each case has the expected validity", results => results.All(r => r.Result.IsValid == r.ExpectedValid))
+            .And("each case reports the expected message", results =>
+                results.All(r => r.Result.Message.Contains(r.ExpectedMessageFragment, StringComparison.OrdinalIgnoreCase)))
+            .AssertPassed();
+    }
+
+    [Scenario("Document async visitors index, scan, default, and cancellation paths")]
+    [Fact]
+    public async Task DocumentProcessingDemo_AsyncVisitors_CoverIndexScanDefaultAndCancellationPaths()
+    {
+        await Given("documents and async visitors", () =>
+            {
+                var scans = new List<string>();
+                var indexer = new DocumentAsyncVisitorBuilder<string>()
+                    .WhenAsync<PdfDocument>((pdf, ct) => new ValueTask<string>(Task.Delay(1, ct).ContinueWith(_ => $"PDF:{pdf.Id}", ct)))
+                    .DefaultAsync((document, ct) => new ValueTask<string>(Task.Delay(1, ct).ContinueWith(_ => $"DEFAULT:{document.Id}", ct)))
+                    .Build();
+                var scanner = new DocumentAsyncActionVisitorBuilder()
+                    .WhenAsync<PdfDocument>((pdf, ct) =>
+                    {
+                        scans.Add(pdf.IsEncrypted ? "encrypted" : "clear");
+                        return ValueTask.CompletedTask;
+                    })
+                    .DefaultAsync((document, ct) =>
+                    {
+                        scans.Add($"default:{document.FileName}");
+                        return ValueTask.CompletedTask;
+                    })
+                    .Build();
+
+                return new { Indexer = indexer, Scanner = scanner, Scans = scans };
+            })
+            .When("running matched, default, and cancelled async visits",
+                async Task<(List<string> scans, string pdfKey, string defaultKey, OperationCanceledException? cancelled)> (harness) =>
+            {
+                var pdf = new PdfDocument { Id = "DOC-PDF", FileName = "file.pdf", IsEncrypted = true };
+                var unknown = new UnknownDocument { Id = "DOC-UNKNOWN", FileName = "file.bin" };
+
+                var pdfKey = await pdf.AcceptAsync(harness.Indexer);
+                var defaultKey = await unknown.AcceptAsync(harness.Indexer);
+                await pdf.AcceptAsync(harness.Scanner);
+                await unknown.AcceptAsync(harness.Scanner);
+
+                OperationCanceledException? cancelled = null;
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+                try
+                {
+                    await pdf.AcceptAsync(harness.Indexer, cts.Token);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    cancelled = ex;
+                }
+
+                return (harness.Scans, pdfKey, defaultKey, cancelled);
+            })
+            .Then("the concrete visitor indexed the PDF", result => result.pdfKey == "PDF:DOC-PDF")
+            .And("the default visitor indexed an unknown document", result => result.defaultKey == "DEFAULT:DOC-UNKNOWN")
+            .And("the scanner recorded concrete and default scan paths", result =>
+                result.scans.SequenceEqual(["encrypted", "default:file.bin"]))
+            .And("async indexing observes cancellation", result => result.cancelled is not null)
+            .AssertPassed();
+    }
+
+    [Scenario("Document processing private helpers cover concrete async indexing and scan branches")]
+    [Fact]
+    public async Task DocumentProcessingDemo_PrivateAsyncHelpers_CoverConcreteBranches()
+    {
+        await Given("documents that exercise every helper branch", () => new
+            {
+                Pdf = new PdfDocument { Id = "PDF-1", FileName = "secure.pdf", PageCount = 4, IsEncrypted = true },
+                Word = new WordDocument { Id = "WORD-1", FileName = "macro.docx", WordCount = 12, HasMacros = true },
+                SheetWithFormulas = new SpreadsheetDocument { Id = "SHEET-1", FileName = "calc.xlsx", SheetCount = 3, HasFormulas = true },
+                SheetWithoutFormulas = new SpreadsheetDocument { Id = "SHEET-2", FileName = "plain.xlsx", SheetCount = 1, HasFormulas = false },
+                MarkdownWithCode = new MarkdownDocument { Id = "MD-1", FileName = "code.md", LineCount = 10, HasCodeBlocks = true },
+                MarkdownWithoutCode = new MarkdownDocument { Id = "MD-2", FileName = "plain.md", LineCount = 5, HasCodeBlocks = false }
+            })
+            .When("invoking the indexing and scanning helpers", async Task<(string[] Keys, List<string> Scans)> (docs) =>
+            {
+                var keys = new[]
+                {
+                    await InvokeIndexAsync("IndexPdfAsync", docs.Pdf),
+                    await InvokeIndexAsync("IndexWordAsync", docs.Word),
+                    await InvokeIndexAsync("IndexSpreadsheetAsync", docs.SheetWithFormulas),
+                    await InvokeIndexAsync("IndexMarkdownAsync", docs.MarkdownWithCode)
+                };
+                var scans = new List<string>();
+
+                await InvokeScanAsync("ScanPdfSecurityAsync", docs.Pdf, scans);
+                await InvokeScanAsync("ScanWordSecurityAsync", docs.Word, scans);
+                await InvokeScanAsync("ScanSpreadsheetSecurityAsync", docs.SheetWithFormulas, scans);
+                await InvokeScanAsync("ScanSpreadsheetSecurityAsync", docs.SheetWithoutFormulas, scans);
+                await InvokeScanAsync("ScanMarkdownSecurityAsync", docs.MarkdownWithCode, scans);
+                await InvokeScanAsync("ScanMarkdownSecurityAsync", docs.MarkdownWithoutCode, scans);
+
+                return (keys, scans);
+            })
+            .Then("all concrete index keys are produced", result =>
+                result.Keys.SequenceEqual(["PDF:PDF-1:P4", "WORD:WORD-1:W12", "SHEET:SHEET-1:S3", "MD:MD-1:L10"]))
+            .And("security scans include positive and negative findings", result =>
+                result.Scans.Any(s => s.Contains("Encrypted content", StringComparison.Ordinal))
+                && result.Scans.Any(s => s.Contains("Contains macros", StringComparison.Ordinal))
+                && result.Scans.Any(s => s.Contains("Contains formulas", StringComparison.Ordinal))
+                && result.Scans.Any(s => s.Contains("No security issues", StringComparison.Ordinal))
+                && result.Scans.Any(s => s.Contains("Contains code blocks", StringComparison.Ordinal)))
+            .AssertPassed();
+    }
+
+    private static DocumentProcessingDemo.ValidationResult Validate(Document document)
+    {
+        var methodName = document switch
+        {
+            PdfDocument => "ValidatePdf",
+            WordDocument => "ValidateWord",
+            SpreadsheetDocument => "ValidateSpreadsheet",
+            MarkdownDocument => "ValidateMarkdown",
+            _ => throw new ArgumentOutOfRangeException(nameof(document), document.GetType().Name, "Unsupported document type.")
+        };
+
+        var method = typeof(DocumentProcessingDemo).GetMethod(
+            methodName,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        return Assert.IsType<DocumentProcessingDemo.ValidationResult>(method.Invoke(null, [document]));
+    }
+
+    private static async Task<string> InvokeIndexAsync(string methodName, Document document)
+    {
+        var method = typeof(DocumentProcessingDemo).GetMethod(
+            methodName,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        var task = Assert.IsAssignableFrom<Task<string>>(method.Invoke(null, [document, CancellationToken.None]));
+        return await task;
+    }
+
+    private static async Task InvokeScanAsync(string methodName, Document document, List<string> scans)
+    {
+        var method = typeof(DocumentProcessingDemo).GetMethod(
+            methodName,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        var task = Assert.IsAssignableFrom<Task>(method.Invoke(null, [document, scans, CancellationToken.None]));
+        await task;
+    }
+
+    private sealed record ValidationCase(
+        string Name,
+        Document Document,
+        bool ExpectedValid,
+        string ExpectedMessageFragment);
+
+    private sealed class UnknownDocument : Document
+    {
     }
 }

--- a/test/PatternKit.Examples.Tests/MementoDemo/MementoDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/MementoDemo/MementoDemoTests.cs
@@ -96,4 +96,95 @@ public sealed class MementoDemoTests(ITestOutputHelper output) : TinyBddXunitBas
                 return true;
             })
             .AssertPassed();
+
+    [Scenario("No-op edits, null input guards, selections, and delete-forward paths are explicit")]
+    [Fact]
+    public Task Editor_EdgeCases_AreStable()
+        => Given("an editor with text and a selection", () =>
+            {
+                var editor = new Editor();
+                editor.Insert("abcdef");
+                editor.Select(1, 3);
+                return editor;
+            })
+            .When("exercise no-op and guarded operations", ed =>
+            {
+                var versionBeforeNoOps = ed.Version;
+                var emptyInsertVersion = ed.Insert("");
+                var sameSelectionVersion = ed.Select(1, 3);
+                var negativeBackspaceVersion = ed.Backspace(0);
+                ArgumentNullException? insertNull = null;
+                ArgumentNullException? replaceNull = null;
+
+                try
+                {
+                    ed.Insert(null!);
+                }
+                catch (ArgumentNullException ex)
+                {
+                    insertNull = ex;
+                }
+
+                try
+                {
+                    ed.ReplaceSelection(null!);
+                }
+                catch (ArgumentNullException ex)
+                {
+                    replaceNull = ex;
+                }
+
+                return (ed, versionBeforeNoOps, emptyInsertVersion, sameSelectionVersion, negativeBackspaceVersion, insertNull, replaceNull);
+            })
+            .Then("no-op edits keep the current version", r =>
+                r.emptyInsertVersion == r.versionBeforeNoOps
+                && r.sameSelectionVersion == r.versionBeforeNoOps
+                && r.negativeBackspaceVersion == r.versionBeforeNoOps)
+            .And("null text is rejected", r => r.insertNull is not null && r.replaceNull is not null)
+            .When("delete the selection and attempt delete at end", r =>
+            {
+                var editor = r.ed;
+                editor.DeleteForward();
+                var textAfterSelectionDelete = editor.State.Text;
+                editor.MoveCaret(editor.State.Text.Length);
+                var versionAtEnd = editor.Version;
+                var endDeleteVersion = editor.DeleteForward();
+                return (editor, textAfterSelectionDelete, versionAtEnd, endDeleteVersion);
+            })
+            .Then("delete-forward removes the selected text", r => r.textAfterSelectionDelete == "aef")
+            .And("delete-forward at end is a no-op", r => r.endDeleteVersion == r.versionAtEnd)
+            .AssertPassed();
+
+    [Scenario("Batch rejects nesting and can decline commits")]
+    [Fact]
+    public Task Editor_Batch_EdgeCases_AreStable()
+        => Given("a new editor", () => new Editor())
+            .When("running non-committing and nested batches", ed =>
+            {
+                var startVersion = ed.Version;
+                var noCommitVersion = ed.Batch("no-commit", e =>
+                {
+                    e.Insert("draft");
+                    return false;
+                });
+
+                InvalidOperationException? nested = null;
+                try
+                {
+                    ed.Batch("outer", e =>
+                    {
+                        e.Batch("inner", _ => true);
+                        return true;
+                    });
+                }
+                catch (InvalidOperationException ex)
+                {
+                    nested = ex;
+                }
+
+                return (ed, startVersion, noCommitVersion, nested);
+            })
+            .Then("declined batch does not commit a new version", r => r.noCommitVersion == r.startVersion)
+            .And("nested batches are rejected", r => r.nested is not null)
+            .AssertPassed();
 }

--- a/test/PatternKit.Examples.Tests/Messaging/DispatcherExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/DispatcherExampleTests.cs
@@ -1,10 +1,15 @@
 using Microsoft.Extensions.DependencyInjection;
 using PatternKit.Examples.Messaging;
 using PatternKit.Examples.Messaging.SourceGenerated;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
-public sealed class DispatcherExampleTests
+[Feature("Source-generated dispatcher examples")]
+[Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
+public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Fact]
     public async Task DispatcherUsageExamples_RunWithoutThrowing()
@@ -121,5 +126,184 @@ public sealed class DispatcherExampleTests
         Assert.NotEmpty(provider.GetServices<INotificationHandler<CustomerCreatedEvent>>());
         Assert.NotNull(provider.GetRequiredService<IStreamHandler<SearchProductsQuery, ProductSearchResult>>());
         Assert.NotNull(provider.GetRequiredService<IPipelineBehavior<CreateCustomerCommand, Customer>>());
+    }
+
+    [Scenario("Comprehensive mediator demo runs a production-style CQRS and notification workflow")]
+    [Fact]
+    public async Task ComprehensiveMediatorDemo_RunAsync_CompletesEndToEnd()
+    {
+        await Given("a redirected console", CaptureConsole)
+            .When("running the comprehensive mediator demo", async Task<string> (capture) =>
+            {
+                try
+                {
+                    await ComprehensiveMediatorDemo.RunAsync();
+                    return capture.Output();
+                }
+                finally
+                {
+                    capture.Dispose();
+                }
+            })
+            .Then("customer creation was dispatched", output => output.Contains("Create Customer", StringComparison.Ordinal))
+            .And("order placement was dispatched", output => output.Contains("Place Order", StringComparison.Ordinal))
+            .And("payment processing was dispatched", output => output.Contains("Process Payment", StringComparison.Ordinal))
+            .And("streaming search returned products", output => output.Contains("Product:", StringComparison.Ordinal))
+            .And("the demo reported logged operations", output => output.Contains("Total operations logged:", StringComparison.Ordinal))
+            .AssertPassed();
+    }
+
+    [Scenario("Pipeline behaviors cover query bypass, validation failure, and rollback")]
+    [Fact]
+    public async Task PipelineBehaviors_CoverSadPaths()
+    {
+        await Given("pipeline behaviors with an in-memory logger", () =>
+            {
+                var logger = new InMemoryLogger();
+                return new
+                {
+                    Logger = logger,
+                    Validation = new ValidationBehavior<CreateCustomerCommand, Customer>(logger),
+                    QueryTransaction = new TransactionBehavior<GetCustomerQuery, Customer?>(logger),
+                    CommandTransaction = new TransactionBehavior<CreateCustomerCommand, Customer>(logger)
+                };
+            })
+            .When("executing bypass, validation failure, and rollback paths",
+                async Task<(InMemoryLogger Logger, Customer? queryResult, bool queryBypassedTransaction, ArgumentNullException? validationFailure, InvalidOperationException? rollbackFailure)> (harness) =>
+            {
+                var customer = new Customer(42, "Ada", "ada@example.com", 1000m);
+                var queryResult = await harness.QueryTransaction.Handle(
+                    new GetCustomerQuery(customer.Id),
+                    default,
+                    () => ValueTask.FromResult<Customer?>(customer));
+                var queryBypassedTransaction = !harness.Logger.GetLogs()
+                    .Any(log => log.Contains("Beginning transaction", StringComparison.Ordinal));
+
+                ArgumentNullException? validationFailure = null;
+                try
+                {
+                    await harness.Validation.Handle(null!, default, () => ValueTask.FromResult(customer));
+                }
+                catch (ArgumentNullException ex)
+                {
+                    validationFailure = ex;
+                }
+
+                InvalidOperationException? rollbackFailure = null;
+                try
+                {
+                    await harness.CommandTransaction.Handle(
+                        new CreateCustomerCommand("Grace", "grace@example.com", 2000m),
+                        default,
+                        () => throw new InvalidOperationException("handler failed"));
+                }
+                catch (InvalidOperationException ex)
+                {
+                    rollbackFailure = ex;
+                }
+
+                return (harness.Logger, queryResult, queryBypassedTransaction, validationFailure, rollbackFailure);
+            })
+            .Then("query requests bypass transaction logging", result =>
+                result.queryResult?.Id == 42
+                && result.queryBypassedTransaction)
+            .And("validation rejects null requests", result => result.validationFailure is not null)
+            .And("command failures are rolled back", result =>
+                result.rollbackFailure is not null
+                && result.Logger.GetLogs().Any(log => log.Contains("Rolling back transaction", StringComparison.Ordinal)))
+            .AssertPassed();
+    }
+
+    [Scenario("Generated dispatcher reports missing commands and streams while empty notification publish is a no-op")]
+    [Fact]
+    public async Task GeneratedDispatcher_CoversMissingHandlersAndStreamLimits()
+    {
+        await Given("an empty dispatcher and a registered stream dispatcher", () =>
+            {
+                var empty = ProductionDispatcher.Create().Build();
+                var products = new InMemoryProductRepository();
+                var stream = ProductionDispatcher.Create()
+                    .Stream<SearchProductsQuery, ProductSearchResult>((query, ct) =>
+                        new SearchProductsHandler(products).Handle(query, ct))
+                    .Build();
+
+                return (empty, stream);
+            })
+            .When("sending unregistered messages and streaming limited search results",
+                async Task<(InvalidOperationException? missingCommand, InvalidOperationException? missingNotification, InvalidOperationException? missingStream, List<ProductSearchResult> streamed)> (dispatchers) =>
+            {
+                InvalidOperationException? missingCommand = null;
+                InvalidOperationException? missingNotification = null;
+                InvalidOperationException? missingStream = null;
+
+                try
+                {
+                    await dispatchers.empty.Send<CreateCustomerCommand, Customer>(
+                        new CreateCustomerCommand("Ada", "ada@example.com", 1000m),
+                        default);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    missingCommand = ex;
+                }
+
+                try
+                {
+                    await dispatchers.empty.Publish(new CustomerCreatedEvent(1, "Ada", "ada@example.com"), default);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    missingNotification = ex;
+                }
+
+                try
+                {
+                    await foreach (var _ in dispatchers.empty.Stream<SearchProductsQuery, ProductSearchResult>(
+                                       new SearchProductsQuery("o", 1),
+                                       default))
+                    {
+                    }
+                }
+                catch (InvalidOperationException ex)
+                {
+                    missingStream = ex;
+                }
+
+                var streamed = new List<ProductSearchResult>();
+                await foreach (var product in dispatchers.stream.Stream<SearchProductsQuery, ProductSearchResult>(
+                                   new SearchProductsQuery("o", 2),
+                                   default))
+                {
+                    streamed.Add(product);
+                }
+
+                return (missingCommand, missingNotification, missingStream, streamed);
+            })
+            .Then("missing command handlers fail clearly", result => result.missingCommand is not null)
+            .And("missing notification handlers are treated as a no-op", result => result.missingNotification is null)
+            .And("missing stream handlers fail clearly", result => result.missingStream is not null)
+            .And("registered stream handlers honor requested limits", result => result.streamed.Count == 2)
+            .AssertPassed();
+    }
+
+    private static ConsoleCapture CaptureConsole() => new();
+
+    private sealed class ConsoleCapture : IDisposable
+    {
+        private readonly TextWriter _original = Console.Out;
+        private readonly StringWriter _writer = new();
+
+        public ConsoleCapture()
+        {
+            Console.SetOut(_writer);
+        }
+
+        public string Output() => _writer.ToString();
+
+        public void Dispose()
+        {
+            Console.SetOut(_original);
+            _writer.Dispose();
+        }
     }
 }

--- a/test/PatternKit.Examples.Tests/ObserverDemo/ReactiveViewModelTests.cs
+++ b/test/PatternKit.Examples.Tests/ObserverDemo/ReactiveViewModelTests.cs
@@ -34,5 +34,68 @@ public sealed class ReactiveViewModelTests(ITestOutputHelper output) : TinyBddXu
             .Then("CanSave is false", c => !c.Vm.CanSave.Value)
             .AssertPassed();
     }
+
+    [Scenario("Reactive primitives suppress duplicate values, publish list changes, and stop after disposal")]
+    [Fact]
+    public async Task ReactivePrimitives_CoverListAndDisposalBranches()
+    {
+        await Given("observable primitives with subscribers", () =>
+            {
+                var propertyHub = new PropertyChangedHub();
+                var count = new ObservableVar<int>(1);
+                var list = new ObservableList<string>();
+                var properties = new List<string>();
+                var values = new List<(int Old, int New)>();
+                var changes = new List<string>();
+                var propertySub = propertyHub.Subscribe(properties.Add);
+                var valueSub = count.Subscribe((oldValue, newValue) => values.Add((oldValue, newValue)));
+                var listSub = list.Subscribe((action, item) => changes.Add($"{action}:{item}"));
+
+                return new ReactiveHarness(propertyHub, count, list, properties, values, changes, propertySub, valueSub, listSub);
+            })
+            .When("raising changes and disposing subscriptions", harness =>
+            {
+                harness.PropertyHub.Raise("Name");
+                harness.Count.Value = 1;
+                harness.Count.Value = 2;
+                harness.List.Add("alpha");
+                var removedMissing = harness.List.Remove("missing");
+                var removedExisting = harness.List.Remove("alpha");
+                var snapshot = harness.List.Snapshot();
+                var enumerated = harness.List.ToArray();
+
+                harness.PropertySubscription.Dispose();
+                harness.ValueSubscription.Dispose();
+                harness.ListSubscription.Dispose();
+
+                harness.PropertyHub.Raise("Ignored");
+                harness.Count.Value = 3;
+                harness.List.Add("beta");
+
+                return (harness, removedMissing, removedExisting, snapshot, enumerated);
+            })
+            .Then("property notifications stop after disposal", result => result.harness.Properties.SequenceEqual(["Name"]))
+            .And("duplicate observable values are suppressed", result => result.harness.Values.SequenceEqual([(1, 2)]))
+            .And("list add/remove notifications are published only for real changes", result =>
+                !result.removedMissing
+                && result.removedExisting
+                && result.harness.Changes.SequenceEqual(["add:alpha", "remove:alpha"]))
+            .And("snapshot and enumeration reflect list state at the time", result =>
+                result.snapshot.Count == 0
+                && result.enumerated.Length == 0
+                && result.harness.List.Count == 1)
+            .AssertPassed();
+    }
+
+    private sealed record ReactiveHarness(
+        PropertyChangedHub PropertyHub,
+        ObservableVar<int> Count,
+        ObservableList<string> List,
+        List<string> Properties,
+        List<(int Old, int New)> Values,
+        List<string> Changes,
+        IDisposable PropertySubscription,
+        IDisposable ValueSubscription,
+        IDisposable ListSubscription);
 }
 

--- a/test/PatternKit.Examples.Tests/ObserverGeneratorDemo/ObserverGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/ObserverGeneratorDemo/ObserverGeneratorDemoTests.cs
@@ -1,8 +1,13 @@
 using PatternKit.Examples.ObserverGeneratorDemo;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Examples.Tests.ObserverGeneratorDemo;
 
-public sealed class ObserverGeneratorDemoTests
+[Feature("Observer generator demos")]
+[Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
+public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Fact]
     public void TemperatureChanged_PublishesToSubscribersInOrder()
@@ -94,5 +99,104 @@ public sealed class ObserverGeneratorDemoTests
         var result = Assert.Single(results);
         Assert.True(result.Success);
         Assert.Equal("Push", result.Channel);
+    }
+
+    [Scenario("Temperature monitor publishes readings, alerts, subscriber failures, and lifecycle disposal")]
+    [Fact]
+    public async Task TemperatureDemos_RunThroughPublicDemoWorkflows()
+    {
+        await Given("a redirected console", CaptureConsole)
+            .When("running the temperature demos", string (capture) =>
+            {
+                try
+                {
+                    TemperatureMonitorDemo.Run();
+                    MultipleSubscribersDemo.Run();
+                    SubscriptionLifecycleDemo.Run();
+                    return capture.Output();
+                }
+                finally
+                {
+                    capture.Dispose();
+                }
+            })
+            .Then("sensor readings were published", output => output.Contains("Simulating sensor readings", StringComparison.Ordinal))
+            .And("subscriber failures were isolated", output => output.Contains("Subscriber 3 threw exceptions", StringComparison.Ordinal))
+            .And("disposed subscriptions stopped receiving readings", output => output.Contains("After 'using' block", StringComparison.Ordinal))
+            .AssertPassed();
+    }
+
+    [Scenario("Async notification demos cover channel fan-out, mixed handlers, and cancellation")]
+    [Fact]
+    public async Task NotificationDemos_RunThroughPublicDemoWorkflows()
+    {
+        await Given("a redirected console", CaptureConsole)
+            .When("running the notification demos", async Task<string> (capture) =>
+            {
+                try
+                {
+                    await AsyncNotificationDemo.RunAsync();
+                    ExceptionHandlingDemo.Run();
+                    await MixedHandlersDemo.RunAsync();
+                    await CancellationDemo.RunAsync();
+                    return capture.Output();
+                }
+                finally
+                {
+                    capture.Dispose();
+                }
+            })
+            .Then("async notification fan-out completed", output => output.Contains("Results:", StringComparison.Ordinal))
+            .And("aggregate policy demo attempted every validator", output => output.Contains("Validator 3: Success", StringComparison.Ordinal))
+            .And("mixed sync and async handlers were awaited", output => output.Contains("PublishAsync waits", StringComparison.Ordinal))
+            .And("cancellation was observed", output => output.Contains("PublishAsync was cancelled", StringComparison.Ordinal))
+            .AssertPassed();
+    }
+
+    [Scenario("Notification system returns channel-specific happy and sad results")]
+    [Fact]
+    public async Task NotificationSystem_ReturnsChannelSpecificResults()
+    {
+        await Given("a notification system", () => new NotificationSystem())
+            .When("sending low and high priority notifications through direct channel APIs",
+                async Task<(NotificationResult lowSms, NotificationResult highSms, NotificationResult push)> (system) =>
+            {
+                var low = new Notification("user-low", "digest", 0);
+                var high = new Notification("user-high", "security alert", 2);
+
+                var lowSms = await system.SendSmsAsync(low);
+                var highSms = await system.SendSmsAsync(high);
+                var push = await system.SendPushAsync(low);
+
+                return (lowSms, highSms, push);
+            })
+            .Then("low priority SMS is rejected", result =>
+                !result.lowSms.Success
+                && result.lowSms.Channel == "SMS"
+                && result.lowSms.Error == "Priority too low for SMS")
+            .And("high priority SMS succeeds", result => result.highSms is { Success: true, Channel: "SMS" })
+            .And("push succeeds for normal notifications", result => result.push is { Success: true, Channel: "Push" })
+            .AssertPassed();
+    }
+
+    private static ConsoleCapture CaptureConsole() => new();
+
+    private sealed class ConsoleCapture : IDisposable
+    {
+        private readonly TextWriter _original = Console.Out;
+        private readonly StringWriter _writer = new();
+
+        public ConsoleCapture()
+        {
+            Console.SetOut(_writer);
+        }
+
+        public string Output() => _writer.ToString();
+
+        public void Dispose()
+        {
+            Console.SetOut(_original);
+            _writer.Dispose();
+        }
     }
 }

--- a/test/PatternKit.Examples.Tests/Pricing/PricingDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Pricing/PricingDemoTests.cs
@@ -56,6 +56,22 @@ public sealed class PricingDemoTests(ITestOutputHelper output) : TinyBddXunitBas
             .AssertPassed();
     }
 
+    [Scenario("Public sample runner builds defaults and executes the documented basket")]
+    [Fact]
+    public async Task RunSampleAsync_ExecutesDefaultBasket()
+    {
+        await Given("the public pricing demo sample", () => (Func<CancellationToken, ValueTask<PricingResult>>)PricingDemo.RunSampleAsync)
+            .When("running the sample", async Task<PricingResult> (run) => await run(CancellationToken.None))
+            .Then("prices were resolved from configured sources", r => r.Log.Any(l => l.StartsWith("price:SKU-APPLE:db:", StringComparison.Ordinal)))
+            .And("discounts and coupons were applied", r =>
+                r.Log.Any(l => l.StartsWith("loyalty:", StringComparison.Ordinal))
+                && r.Log.Any(l => l.StartsWith("coupon:CASHOFF1", StringComparison.Ordinal)))
+            .And("tax and rounding completed", r =>
+                r.Log.Any(l => l.StartsWith("tax:", StringComparison.Ordinal))
+                && r.Log.Any(l => l.StartsWith("round:", StringComparison.Ordinal)))
+            .AssertPassed();
+    }
+
     [Scenario("Source routing: api and file sources resolve when tagged")]
     [Fact]
     public async Task SourceRouting_Api_File()

--- a/test/PatternKit.Examples.Tests/ProxyGeneratorDemo/ProxyGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/ProxyGeneratorDemo/ProxyGeneratorDemoTests.cs
@@ -1,9 +1,14 @@
 using PatternKit.Examples.ProxyGeneratorDemo;
 using PatternKit.Examples.ProxyGeneratorDemo.Interceptors;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Examples.Tests.ProxyGeneratorDemo;
 
-public sealed class ProxyGeneratorDemoTests
+[Feature("Proxy generator demo")]
+[Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
+public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Fact]
     public void RealPaymentService_StoresSuccessfulTransactions()
@@ -100,6 +105,179 @@ public sealed class ProxyGeneratorDemoTests
         Assert.Equal(0, cache.GetStats().Count);
     }
 
+    [Scenario("Comprehensive proxy demo runs the generated proxy pipeline")]
+    [Fact]
+    public async Task ProxyGeneratorDemo_Run_ExercisesAllDemoScenarios()
+    {
+        await Given("a redirected console", CaptureConsole)
+            .When("running the complete proxy demo", string (capture) =>
+            {
+                try
+                {
+                    PatternKit.Examples.ProxyGeneratorDemo.ProxyGeneratorDemo.Run();
+                    return capture.Output();
+                }
+                finally
+                {
+                    capture.Dispose();
+                }
+            })
+            .Then("the basic proxy scenario completed", output => output.Contains("Basic Proxy", StringComparison.Ordinal))
+            .And("the interceptor pipeline scenario completed", output => output.Contains("Pipeline Mode", StringComparison.Ordinal))
+            .And("the invalid authentication scenario was caught", output => output.Contains("Invalid authentication token", StringComparison.Ordinal))
+            .And("the caching scenario reported cache statistics", output => output.Contains("Cache stats:", StringComparison.Ordinal))
+            .AssertPassed();
+    }
+
+    [Scenario("Proxy interceptors cover happy and sad paths")]
+    [Fact]
+    public async Task ProxyInterceptors_RecordSuccessAndFailurePaths()
+    {
+        await Given("authenticated and cache-enabled proxies", () =>
+            {
+                var timing = new TimingInterceptor();
+                var cache = new CachingInterceptor();
+                var authProxy = new PaymentServiceProxy(
+                    new RealPaymentService(),
+                    [new AuthenticationInterceptor(), new RetryInterceptor(maxRetries: 2), new LoggingInterceptor("Spec"), timing]);
+                var cacheProxy = new PaymentServiceProxy(
+                    new RealPaymentService(),
+                    [cache, timing, new LoggingInterceptor("History")]);
+
+                return new ProxyHarness(authProxy, cacheProxy, timing, cache);
+            })
+            .When("processing valid and invalid requests", ProxyResult (harness) =>
+            {
+                var accepted = harness.AuthenticatedProxy.ProcessPayment(CreateRequest("cust-bdd", 125m));
+                harness.HistoryProxy.ProcessPayment(CreateRequest("cust-bdd", 75m));
+                var history = harness.HistoryProxy.GetTransactionHistory("cust-bdd");
+                UnauthorizedAccessException? rejected = null;
+
+                try
+                {
+                    harness.AuthenticatedProxy.ProcessPayment(new PaymentRequest
+                    {
+                        CustomerId = "cust-bdd",
+                        Amount = 10m,
+                        Currency = "USD",
+                        Description = "missing token",
+                        AuthToken = null
+                    });
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    rejected = ex;
+                }
+
+                return new ProxyResult(harness, accepted, history, rejected);
+            })
+            .Then("the valid request reached the real service", result => result.Accepted.Success && result.History.Count == 1)
+            .And("the cache captured the history result", result => result.Harness.Cache.GetStats().Count == 1)
+            .And("timing recorded successful methods", result =>
+                result.Harness.Timing.GetTimings().ContainsKey(nameof(IPaymentService.ProcessPayment))
+                && result.Harness.Timing.GetTimings().ContainsKey(nameof(IPaymentService.GetTransactionHistory)))
+            .And("the missing token request was rejected", result =>
+                result.Rejected is not null
+                && result.Rejected.Message.Contains("required", StringComparison.OrdinalIgnoreCase))
+            .AssertPassed();
+    }
+
+    [Scenario("Proxy interceptors observe retriable sync and async inner failures")]
+    [Fact]
+    public async Task ProxyInterceptors_RecordRetriableInnerFailures()
+    {
+        await Given("throwing sync and async payment proxies", () =>
+            {
+                var syncTiming = new TimingInterceptor();
+                var asyncTiming = new TimingInterceptor();
+                var syncProxy = new PaymentServiceProxy(
+                    new ThrowingPaymentService(syncException: new IOException("gateway down")),
+                    [new RetryInterceptor(maxRetries: 4), syncTiming, new LoggingInterceptor("SyncFailure")]);
+                var asyncProxy = new PaymentServiceProxy(
+                    new ThrowingPaymentService(asyncException: new IOException("async gateway down")),
+                    [new CachingInterceptor(), new RetryInterceptor(maxRetries: 5), asyncTiming, new LoggingInterceptor("AsyncFailure")]);
+
+                return (syncProxy, asyncProxy, syncTiming, asyncTiming);
+            })
+            .When("processing payments that fail inside the service", async Task<(IOException? syncFailure, IOException? asyncFailure, TimingInterceptor syncTiming, TimingInterceptor asyncTiming)> (proxies) =>
+            {
+                IOException? syncFailure = null;
+                IOException? asyncFailure = null;
+
+                try
+                {
+                    proxies.syncProxy.ProcessPayment(CreateRequest("sync-fail", 10m));
+                }
+                catch (IOException ex)
+                {
+                    syncFailure = ex;
+                }
+
+                try
+                {
+                    await proxies.asyncProxy.ProcessPaymentAsync(CreateRequest("async-fail", 10m));
+                }
+                catch (IOException ex)
+                {
+                    asyncFailure = ex;
+                }
+
+                return (syncFailure, asyncFailure, proxies.syncTiming, proxies.asyncTiming);
+            })
+            .Then("the sync retriable failure propagates after interceptors observe it", result => result.syncFailure is not null)
+            .And("the async retriable failure propagates after interceptors observe it", result => result.asyncFailure is not null)
+            .And("timing removes failed operations from active timers", result =>
+                result.syncTiming.GetTimings().Count == 0
+                && result.asyncTiming.GetTimings().Count == 0)
+            .AssertPassed();
+    }
+
+    [Scenario("Proxy interceptors expose async no-op, invalid auth, and non-retriable exception branches")]
+    [Fact]
+    public async Task ProxyInterceptors_CoverAsyncNoOpAndNonRetriableBranches()
+    {
+        await Given("standalone interceptors and method contexts", () => new
+            {
+                Retry = new RetryInterceptor(maxRetries: 1),
+                Cache = new CachingInterceptor(),
+                Auth = new AuthenticationInterceptor(),
+                Context = new GetTransactionHistoryMethodContext("cust-standalone"),
+                MissingToken = new ProcessPaymentAsyncMethodContext(
+                    new PaymentRequest
+                    {
+                        CustomerId = "cust-standalone",
+                        Amount = 1m,
+                        Currency = "USD",
+                        Description = "missing token",
+                        AuthToken = null
+                    },
+                    CancellationToken.None)
+            })
+            .When("invoking direct async interceptor paths", async Task<UnauthorizedAccessException?> (harness) =>
+            {
+                await harness.Retry.BeforeAsync(harness.Context);
+                await harness.Retry.AfterAsync(harness.Context);
+                await harness.Retry.OnExceptionAsync(harness.Context, new ArgumentException("bad input"));
+                await harness.Cache.BeforeAsync(harness.Context);
+                await harness.Cache.AfterAsync(harness.Context);
+                await harness.Cache.OnExceptionAsync(harness.Context, new IOException("ignored"));
+
+                try
+                {
+                    await harness.Auth.BeforeAsync(harness.MissingToken);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    return ex;
+                }
+
+                return null;
+            })
+            .Then("authentication rejects missing tokens on async contexts", ex =>
+                ex is not null && ex.Message.Contains("required", StringComparison.OrdinalIgnoreCase))
+            .AssertPassed();
+    }
+
     private static PaymentRequest CreateRequest(string customerId, decimal amount) =>
         new()
         {
@@ -109,4 +287,51 @@ public sealed class ProxyGeneratorDemoTests
             Description = "test payment",
             AuthToken = "valid-token-123"
         };
+
+    private static ConsoleCapture CaptureConsole() => new();
+
+    private sealed class ConsoleCapture : IDisposable
+    {
+        private readonly TextWriter _original = Console.Out;
+        private readonly StringWriter _writer = new();
+
+        public ConsoleCapture()
+        {
+            Console.SetOut(_writer);
+        }
+
+        public string Output() => _writer.ToString();
+
+        public void Dispose()
+        {
+            Console.SetOut(_original);
+            _writer.Dispose();
+        }
+    }
+
+    private sealed record ProxyHarness(
+        PaymentServiceProxy AuthenticatedProxy,
+        PaymentServiceProxy HistoryProxy,
+        TimingInterceptor Timing,
+        CachingInterceptor Cache);
+
+    private sealed record ProxyResult(
+        ProxyHarness Harness,
+        PaymentResult Accepted,
+        IReadOnlyList<Transaction> History,
+        UnauthorizedAccessException? Rejected);
+
+    private sealed class ThrowingPaymentService(
+        Exception? syncException = null,
+        Exception? asyncException = null) : IPaymentService
+    {
+        public PaymentResult ProcessPayment(PaymentRequest request)
+            => throw syncException ?? new IOException("sync failure");
+
+        public Task<PaymentResult> ProcessPaymentAsync(PaymentRequest request, CancellationToken cancellationToken = default)
+            => Task.FromException<PaymentResult>(asyncException ?? new IOException("async failure"));
+
+        public IReadOnlyList<Transaction> GetTransactionHistory(string customerId)
+            => throw syncException ?? new IOException("history failure");
+    }
 }

--- a/test/PatternKit.Examples.Tests/SingletonGeneratorDemo/SingletonGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/SingletonGeneratorDemo/SingletonGeneratorDemoTests.cs
@@ -43,6 +43,18 @@ public class SingletonGeneratorDemoTests
     }
 
     [Fact]
+    public void AppClock_ProvidesLocalTimeAndCurrentDate()
+    {
+        var before = DateTimeOffset.Now.AddSeconds(-1);
+        var now = AppClock.Instance.Now;
+        var after = DateTimeOffset.Now.AddSeconds(1);
+        var today = AppClock.Instance.Today;
+
+        Assert.InRange(now, before, after);
+        Assert.InRange(today.DayNumber, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)).DayNumber, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).DayNumber);
+    }
+
+    [Fact]
     public void ConfigManager_ReturnsSameInstance()
     {
         // Act
@@ -63,6 +75,8 @@ public class SingletonGeneratorDemoTests
         Assert.NotNull(config.AppName);
         Assert.NotNull(config.Environment);
         Assert.NotNull(config.ConnectionString);
+        Assert.False(config.DebugLogging);
+        Assert.Contains($"App={config.AppName}", config.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/PatternKit.Examples.Tests/Strategies/Coercion/CoercerTests.cs
+++ b/test/PatternKit.Examples.Tests/Strategies/Coercion/CoercerTests.cs
@@ -175,6 +175,34 @@ public class CoercerTests(ITestOutputHelper output) : TinyBddXunitBase(output)
             .AssertPassed();
     }
 
+    [Scenario("Static convenience coercer covers direct casts, misses, and conversion failures")]
+    [Fact]
+    public async Task StaticConvenience_CoversDirectMissAndFailurePaths()
+    {
+        await Given("mixed source values", () => new object?[]
+            {
+                123,
+                new object(),
+                Json("true"),
+                Json("\"not-a-number\""),
+                "not-a-number"
+            })
+            .When("coercing with static convenience APIs", values => new
+            {
+                Direct = Coercer<int>.Coerce<int>(values[0]),
+                UnsupportedString = Coercer<string>.From(values[1]),
+                BoolFromWrongShape = Coercer<bool>.From(values[3]),
+                BoolFromJson = Coercer<bool>.Coerce<bool>(values[2]),
+                FailedInt = Coercer<int>.From(values[4])
+            })
+            .Then("direct casts succeed", result => result.Direct == 123)
+            .And("unsupported sources return defaults", result => result.UnsupportedString is null)
+            .And("json handlers reject wrong shapes", result => result.BoolFromWrongShape == default)
+            .And("json bools still coerce", result => result.BoolFromJson)
+            .And("convertible failures are swallowed", result => result.FailedInt == default)
+            .AssertPassed();
+    }
+
     // ---------- Ordering correctness ----------
     [Scenario("Ordering: FromJsonNumberInt runs before ConvertibleFallback for ints")]
     [Fact]

--- a/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
@@ -15,6 +15,7 @@ using PatternKit.Generators.Proxy;
 using PatternKit.Generators.Singleton;
 using PatternKit.Generators.State;
 using PatternKit.Generators.Template;
+using PatternKit.Generators.Visitors;
 using PatternKit.Generators;
 
 namespace PatternKit.Generators.Tests;
@@ -95,7 +96,8 @@ public sealed class AbstractionsAttributeCoverageTests
         { typeof(StateExitAttribute), AttributeTargets.Method, true, false },
         { typeof(TemplateAttribute), AttributeTargets.Class | AttributeTargets.Struct, false, false },
         { typeof(TemplateStepAttribute), AttributeTargets.Method, false, false },
-        { typeof(TemplateHookAttribute), AttributeTargets.Method, false, false }
+        { typeof(TemplateHookAttribute), AttributeTargets.Method, false, false },
+        { typeof(GenerateVisitorAttribute), AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, false, false }
     };
 
     [Theory]
@@ -533,6 +535,28 @@ public sealed class AbstractionsAttributeCoverageTests
         AssertEnumValues(StateMachineGuardFailurePolicy.Throw, StateMachineGuardFailurePolicy.Ignore, StateMachineGuardFailurePolicy.ReturnFalse);
         AssertEnumValues(HookPoint.BeforeAll, HookPoint.AfterAll, HookPoint.OnError);
         AssertEnumValues(TemplateErrorPolicy.Rethrow, TemplateErrorPolicy.HandleAndContinue);
+    }
+
+    [Fact]
+    public void Visitor_Attribute_Exposes_Defaults_And_Configuration()
+    {
+        var defaults = new GenerateVisitorAttribute();
+        var configured = new GenerateVisitorAttribute
+        {
+            VisitorInterfaceName = "IWorkflowNodeVisitor",
+            GenerateAsync = false,
+            GenerateActions = false,
+            AutoDiscoverDerivedTypes = false
+        };
+
+        Assert.Null(defaults.VisitorInterfaceName);
+        Assert.True(defaults.GenerateAsync);
+        Assert.True(defaults.GenerateActions);
+        Assert.True(defaults.AutoDiscoverDerivedTypes);
+        Assert.Equal("IWorkflowNodeVisitor", configured.VisitorInterfaceName);
+        Assert.False(configured.GenerateAsync);
+        Assert.False(configured.GenerateActions);
+        Assert.False(configured.AutoDiscoverDerivedTypes);
     }
 
     private static void AssertEnumValues<TEnum>(params TEnum[] values)

--- a/test/PatternKit.Generators.Tests/BridgeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/BridgeGeneratorTests.cs
@@ -99,4 +99,93 @@ public class BridgeGeneratorTests
         var diags = result.Results.SelectMany(r => r.Diagnostics);
         Assert.Contains(diags, d => d.Id == "PKBRG002");
     }
+
+    [Fact]
+    public void GeneratesGenericBridgeWithForwardedPropertiesRefParametersAndDefaults()
+    {
+        const string source = """
+            using PatternKit.Generators.Bridge;
+
+            [BridgeImplementor]
+            public abstract class Repository<T>
+            {
+                public abstract string Name { get; }
+                public abstract void Copy(ref int source, out int destination, in bool enabled);
+                public abstract string Format(string value = "quoted", bool enabled = true, int count = 3, object? state = null);
+                [BridgeIgnore] public abstract void Ignored();
+                public static void StaticUtility() { }
+            }
+
+            [BridgeAbstraction(typeof(Repository<string>), ImplementorPropertyName = "Backend")]
+            public partial record Store<T>
+            {
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GeneratesGenericBridgeWithForwardedPropertiesRefParametersAndDefaults));
+        var gen = new BridgeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Store.Bridge.g.cs").SourceText.ToString();
+        Assert.Contains("public abstract partial record class Store<T>", generated);
+        Assert.Contains("protected string Name => Backend.Name;", generated);
+        Assert.Contains("ref int source, out int destination, in bool enabled", generated);
+        Assert.Contains("Backend.Copy(ref source, out destination, in enabled)", generated);
+        Assert.Contains(@"string value = @""quoted""", generated);
+        Assert.Contains("bool enabled = true", generated);
+        Assert.Contains("int count = 3", generated);
+        Assert.Contains("object? state = default", generated);
+        Assert.DoesNotContain("Ignored", generated);
+        Assert.True(updated.Emit(Stream.Null).Success, string.Join("\n", updated.GetDiagnostics()));
+    }
+
+    [Fact]
+    public void ReportsDiagnosticForEventMembersAndDefaultNameConflicts()
+    {
+        const string unsupportedEvent = """
+            using PatternKit.Generators.Bridge;
+
+            namespace TestNamespace;
+
+            public interface IRenderer
+            {
+                event System.Action? Rendered;
+            }
+
+            [BridgeAbstraction(typeof(IRenderer))]
+            public partial class Shape
+            {
+            }
+            """;
+        const string conflictingDefault = """
+            using PatternKit.Generators.Bridge;
+
+            namespace TestNamespace;
+
+            public interface IRenderer
+            {
+                void Draw();
+            }
+
+            public sealed class ExistingShape
+            {
+            }
+
+            [BridgeAbstraction(typeof(IRenderer), GenerateDefault = true, DefaultTypeName = "ExistingShape")]
+            public partial class Shape
+            {
+            }
+            """;
+
+        var eventComp = RoslynTestHelpers.CreateCompilation(unsupportedEvent, nameof(ReportsDiagnosticForEventMembersAndDefaultNameConflicts) + "Event");
+        var conflictComp = RoslynTestHelpers.CreateCompilation(conflictingDefault, nameof(ReportsDiagnosticForEventMembersAndDefaultNameConflicts) + "Conflict");
+        var gen = new BridgeGenerator();
+
+        _ = RoslynTestHelpers.Run(eventComp, gen, out var eventResult, out _);
+        _ = RoslynTestHelpers.Run(conflictComp, gen, out var conflictResult, out _);
+
+        Assert.Contains(eventResult.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKBRG003");
+        Assert.Contains(conflictResult.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKBRG004");
+    }
 }

--- a/test/PatternKit.Generators.Tests/ChainGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ChainGeneratorTests.cs
@@ -68,4 +68,122 @@ public class ChainGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
         Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKCH003");
     }
+
+    [Theory]
+    [InlineData("""
+        [Chain]
+        public class Router
+        {
+            [ChainHandler(Order = 0)] private bool A(in Request request, out Response response) { response = default; return false; }
+            [ChainDefault] private Response NotFound(in Request request) => new(404);
+        }
+        """, "PKCH001")]
+    [InlineData("""
+        [Chain]
+        public partial class Router
+        {
+            [ChainDefault] private Response NotFound(in Request request) => new(404);
+        }
+        """, "PKCH002")]
+    [InlineData("""
+        [Chain]
+        public partial class Router
+        {
+            [ChainHandler(Order = 0)] private Response A(in Request request) => new(200);
+            [ChainDefault] private Response NotFound(in Request request) => new(404);
+        }
+        """, "PKCH004")]
+    [InlineData("""
+        [Chain]
+        public partial class Router
+        {
+            [ChainHandler(Order = 0)] private bool A(in Request request, out Response response) { response = default; return false; }
+        }
+        """, "PKCH007")]
+    [InlineData("""
+        [Chain]
+        public partial class Router
+        {
+            [ChainHandler(Order = 0)] private bool A(in Request request, out Response response) { response = default; return false; }
+            [ChainDefault] private string NotFound(in Request request) => "missing";
+        }
+        """, "PKCH004")]
+    public void ReportsResponsibilityChainDiagnostics(string routerSource, string diagnosticId)
+    {
+        var source = $$"""
+            using PatternKit.Generators.Chain;
+
+            namespace TestNamespace;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            {{routerSource}}
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsResponsibilityChainDiagnostics) + diagnosticId);
+        var gen = new ChainGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
+    }
+
+    [Theory]
+    [InlineData("", "PKCH005")]
+    [InlineData("""
+        [ChainTerminal] private Response Finish(in Request request) => new(200);
+        [ChainTerminal] private Response FinishAgain(in Request request) => new(201);
+        """, "PKCH006")]
+    public void ReportsPipelineTerminalDiagnostics(string terminals, string diagnosticId)
+    {
+        var source = $$"""
+            using PatternKit.Generators.Chain;
+
+            namespace TestNamespace;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Chain(Model = ChainModel.Pipeline)]
+            public partial class Router
+            {
+                {{terminals}}
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsPipelineTerminalDiagnostics) + diagnosticId);
+        var gen = new ChainGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
+    }
+
+    [Fact]
+    public void GeneratesResponsibilityChainWithCustomMethodNamesInGlobalNamespace()
+    {
+        const string source = """
+            using PatternKit.Generators.Chain;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Chain(HandleMethodName = "Route", TryHandleMethodName = "TryRoute")]
+            public partial class Router
+            {
+                [ChainHandler(Order = 0)] private bool A(in Request request, out Response response) { response = new Response(200); return true; }
+                [ChainDefault] private Response NotFound(in Request request) => new(404);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GeneratesResponsibilityChainWithCustomMethodNamesInGlobalNamespace));
+        var gen = new ChainGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Router.Chain.g.cs").SourceText.ToString();
+        Assert.Contains("public bool TryRoute", generated);
+        Assert.Contains("public global::Response Route", generated);
+        Assert.DoesNotContain("namespace ", generated);
+        Assert.True(updated.Emit(Stream.Null).Success);
+    }
 }

--- a/test/PatternKit.Generators.Tests/CommandGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/CommandGeneratorTests.cs
@@ -53,4 +53,70 @@ public class CommandGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
         Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKCMD002");
     }
+
+    [Fact]
+    public void GeneratesAsyncCommandExecutorWithCancellationToken()
+    {
+        const string source = """
+            using PatternKit.Generators.Command;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestNamespace;
+
+            [Command(CommandTypeName = "RefreshProjection")]
+            public readonly partial record struct RefreshUser(string UserId);
+
+            public sealed class ProjectionService
+            {
+                [CommandHandler]
+                public ValueTask Handle(RefreshUser command, CancellationToken ct) => ValueTask.CompletedTask;
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GeneratesAsyncCommandExecutorWithCancellationToken));
+        var gen = new CommandGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "RefreshUser.Command.g.cs").SourceText.ToString();
+        Assert.Contains("public static global::System.Threading.Tasks.ValueTask ExecuteAsync", generated);
+        Assert.Contains("handler.Handle(command, ct)", generated);
+        Assert.True(updated.Emit(Stream.Null).Success);
+    }
+
+    [Theory]
+    [InlineData("public readonly record struct RenameUser(string NewName);", "PKCMD001")]
+    [InlineData("""
+        public readonly partial record struct RenameUser(string NewName);
+        public sealed class UserService
+        {
+            [CommandHandler] public void Handle(RenameUser command) { }
+            [CommandHandler] public void HandleAgain(RenameUser command) { }
+        }
+        """, "PKCMD003")]
+    [InlineData("""
+        public readonly partial record struct RenameUser(string NewName);
+        public sealed class UserService
+        {
+            [CommandHandler] public string Handle(RenameUser command) => command.NewName;
+        }
+        """, "PKCMD004")]
+    public void ReportsCommandShapeDiagnostics(string commandSource, string diagnosticId)
+    {
+        var source = $$"""
+            using PatternKit.Generators.Command;
+
+            namespace TestNamespace;
+
+            [Command]
+            {{commandSource}}
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsCommandShapeDiagnostics) + diagnosticId);
+        var gen = new CommandGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
+    }
 }

--- a/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
@@ -916,5 +916,78 @@ public class TemplateGeneratorTests
         Assert.DoesNotContain("public void Execute(", generatedSource);
     }
 
+    [Fact]
+    public void Generates_Async_Template_With_Mixed_Sync_Async_Hooks_And_Error_Rethrow()
+    {
+        var source = """
+            using PatternKit.Generators.Template;
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace PatternKit.Examples;
+
+            public sealed class ImportContext
+            {
+                public string Data { get; set; } = "";
+            }
+
+            [Template(ExecuteAsyncMethodName = "RunAsync", ErrorPolicy = TemplateErrorPolicy.Rethrow)]
+            public partial class ImportWorkflow
+            {
+                [TemplateHook(HookPoint.BeforeAll)]
+                private ValueTask OpenAsync(ImportContext ctx, CancellationToken ct) => ValueTask.CompletedTask;
+
+                [TemplateHook(HookPoint.BeforeAll)]
+                private void TraceOpen(ImportContext ctx) { }
+
+                [TemplateStep(0, Name = "Validate")]
+                private ValueTask ValidateAsync(ImportContext ctx, CancellationToken ct) => ValueTask.CompletedTask;
+
+                [TemplateStep(1, Name = "Transform")]
+                private void Transform(ImportContext ctx) { }
+
+                [TemplateHook(HookPoint.AfterAll)]
+                private ValueTask CloseAsync(ImportContext ctx, CancellationToken ct) => ValueTask.CompletedTask;
+
+                [TemplateHook(HookPoint.AfterAll)]
+                private void TraceClose(ImportContext ctx) { }
+
+                [TemplateHook(HookPoint.OnError)]
+                private ValueTask CaptureErrorAsync(ImportContext ctx, Exception ex, CancellationToken ct) => ValueTask.CompletedTask;
+
+                [TemplateHook(HookPoint.OnError)]
+                private void TraceError(ImportContext ctx, Exception ex) { }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(Generates_Async_Template_With_Mixed_Sync_Async_Hooks_And_Error_Rethrow));
+
+        var gen = new TemplateGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        var generated = run.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Single(gs => gs.HintName == "ImportWorkflow.Template.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("public async System.Threading.Tasks.ValueTask RunAsync", generated);
+        Assert.Contains("await OpenAsync(ctx, ct).ConfigureAwait(false);", generated);
+        Assert.Contains("TraceOpen(ctx);", generated);
+        Assert.Contains("await ValidateAsync(ctx, ct).ConfigureAwait(false);", generated);
+        Assert.Contains("Transform(ctx);", generated);
+        Assert.Contains("await CloseAsync(ctx, ct).ConfigureAwait(false);", generated);
+        Assert.Contains("TraceClose(ctx);", generated);
+        Assert.Contains("await CaptureErrorAsync(ctx, ex, ct).ConfigureAwait(false);", generated);
+        Assert.Contains("TraceError(ctx, ex);", generated);
+        Assert.Contains("throw;", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
     #endregion
 }

--- a/test/PatternKit.Tests/Behavioral/ActionVisitorExtraTests.cs
+++ b/test/PatternKit.Tests/Behavioral/ActionVisitorExtraTests.cs
@@ -44,6 +44,15 @@ public sealed class ActionVisitorExtraTests(ITestOutputHelper output) : TinyBddX
            .Then("ok == true", ok => ok)
            .AssertPassed();
 
+    [Scenario("TryVisit returns false when no action or default matches")]
+    [Fact]
+    public Task ActionVisitor_TryVisit_NoDefault_ReturnsFalse()
+        => Given("visitor with one concrete action and no default", () =>
+            ActionVisitor<Node>.Create().On<Number>(_ => { }).Build())
+           .When("TryVisit Neg", v => v.TryVisit(new Neg(new Number(2))))
+           .Then("ok == false", ok => ok == false)
+           .AssertPassed();
+
     [Scenario("Registration order matters: base before derived")]
     [Fact]
     public Task ActionVisitor_Order_Matters()

--- a/test/PatternKit.Tests/Behavioral/AsyncVisitorTests.cs
+++ b/test/PatternKit.Tests/Behavioral/AsyncVisitorTests.cs
@@ -115,4 +115,20 @@ public sealed class AsyncVisitorTests(ITestOutputHelper output) : TinyBddXunitBa
 
     private static async Task<int> VisitNegDefaultSync(AsyncVisitor<Node, int> v)
         => await v.VisitAsync(new Neg(new Number(1)));
+
+    [Scenario("TryVisitAsync returns true when default handler handles unmatched node")]
+    [Fact]
+    public Task AsyncVisitor_TryVisit_Default_ReturnsTrue()
+        => Given("visitor with async default", () =>
+            AsyncVisitor<Node, int>.Create()
+                .On<Number>((_, _) => new ValueTask<int>(1))
+                .Default((node, _) => new ValueTask<int>(node is Neg ? -9 : -1))
+                .Build())
+           .When("trying Neg", TryNegDefault)
+           .Then("ok == true", r => r.ok)
+           .And("default result returned", r => r.result == -9)
+           .AssertPassed();
+
+    private static async Task<(bool ok, int result)> TryNegDefault(AsyncVisitor<Node, int> v)
+        => await v.TryVisitAsync(new Neg(new Number(1)));
 }

--- a/test/PatternKit.Tests/Behavioral/VisitorAdditionalTests.cs
+++ b/test/PatternKit.Tests/Behavioral/VisitorAdditionalTests.cs
@@ -45,6 +45,16 @@ public sealed class VisitorAdditionalTests(ITestOutputHelper output) : TinyBddXu
            .And("result == ?", x => x.res == "?")
            .AssertPassed();
 
+    [Scenario("TryVisit returns false and default result when no handler matches")]
+    [Fact]
+    public Task ResultVisitor_TryVisit_NoDefault_ReturnsFalse()
+        => Given("a visitor with one concrete handler and no default", () =>
+            Visitor<Node, string>.Create().On<Number>(_ => "number").Build())
+           .When("TryVisit Neg", v => { var ok = v.TryVisit(new Neg(new Number(0)), out var res); return (ok, res); })
+           .Then("ok == false", x => x.ok == false)
+           .And("result == null", x => x.res is null)
+           .AssertPassed();
+
     [Scenario("Registration order matters: base before derived (result)")]
     [Fact]
     public Task ResultVisitor_Order_Matters()

--- a/test/PatternKit.Tests/Structural/Facade/TypedFacadeTests.cs
+++ b/test/PatternKit.Tests/Structural/Facade/TypedFacadeTests.cs
@@ -1,4 +1,6 @@
 using PatternKit.Structural.Facade;
+using System.Linq.Expressions;
+using System.Reflection;
 using TinyBDD;
 using TinyBDD.Xunit;
 using Xunit.Abstractions;
@@ -253,4 +255,79 @@ public sealed class TypedFacadeTests(ITestOutputHelper output) : TinyBddXunitBas
             })
             .Then("method call is type-safe", result => result == 30)
             .AssertPassed();
+
+    [Scenario("TypedFacade reports duplicate mappings for every supported arity")]
+    [Fact]
+    public Task TypedFacade_DuplicateMappings_Cover_All_Arities()
+        => Given("duplicate mapping operations", () => new Func<Exception?>[]
+            {
+                () => Record.Exception(() => TypedFacade<ISimpleService>.Create()
+                    .Map(x => x.GetStatus, () => "ok")
+                    .Map(x => x.GetStatus, () => "duplicate")),
+                () => Record.Exception(() => TypedFacade<IComplexService>.Create()
+                    .Map(x => x.Operation1, (string value) => value)
+                    .Map(x => x.Operation1, (string value) => value)),
+                () => Record.Exception(() => TypedFacade<ICalculator>.Create()
+                    .Map(x => x.Add, (int a, int b) => a + b)
+                    .Map(x => x.Add, (int a, int b) => a - b)),
+                () => Record.Exception(() => TypedFacade<IComplexService>.Create()
+                    .Map(x => x.Operation3, (string value, int length, bool flag) => flag && value.Length > length)
+                    .Map(x => x.Operation3, (string value, int length, bool flag) => !flag && value.Length <= length)),
+                () => Record.Exception(() => TypedFacade<IComplexService>.Create()
+                    .Map(x => x.Operation4, (decimal a, decimal b, decimal c, decimal d) => a + b + c + d)
+                    .Map(x => x.Operation4, (decimal a, decimal b, decimal c, decimal d) => a * b * c * d))
+            })
+            .When("running each duplicate mapper", operations => operations.Select(operation => operation()).ToArray())
+            .Then("each duplicate is rejected", exceptions => exceptions.All(ex => ex is ArgumentException))
+            .And("each error names the mapped method", exceptions => exceptions.All(ex => ex!.Message.Contains("already mapped", StringComparison.Ordinal)))
+            .AssertPassed();
+
+    [Scenario("TypedFacade validates method selector expressions and signatures")]
+    [Fact]
+    public Task TypedFacade_PrivateValidation_Covers_Invalid_Selectors_And_Signatures()
+        => Given("private validation helpers", () => new
+            {
+                Extract = typeof(TypedFacade<ISimpleService>.Builder).GetMethod(
+                    "ExtractMethodInfo",
+                    BindingFlags.NonPublic | BindingFlags.Static)!,
+                Validate = typeof(TypedFacade<ISimpleService>.Builder).GetMethod(
+                    "ValidateMethodSignature",
+                    BindingFlags.NonPublic | BindingFlags.Static)!,
+                GetStatus = typeof(ISimpleService).GetMethod(nameof(ISimpleService.GetStatus))!,
+                Operation1 = typeof(IComplexService).GetMethod(nameof(IComplexService.Operation1))!
+            })
+            .When("invoking invalid selectors and signature checks", helpers =>
+            {
+                Expression<Func<ISimpleService, int>> notMethodSelector = _ => 1;
+                Expression<Func<ISimpleService, Func<string>>> notMethodGroup = _ => (Func<string>)(() => "inline");
+
+                return new[]
+                {
+                    InvokePrivateArgumentException(() => helpers.Extract
+                        .MakeGenericMethod(typeof(Func<ISimpleService, int>))
+                        .Invoke(null, [notMethodSelector])),
+                    InvokePrivateArgumentException(() => helpers.Extract
+                        .MakeGenericMethod(typeof(Func<ISimpleService, Func<string>>))
+                        .Invoke(null, [notMethodGroup])),
+                    InvokePrivateArgumentException(() => helpers.Validate
+                        .Invoke(null, [helpers.GetStatus, typeof(int), Array.Empty<Type>()])),
+                    InvokePrivateArgumentException(() => helpers.Validate
+                        .Invoke(null, [helpers.Operation1, typeof(string), Array.Empty<Type>()])),
+                    InvokePrivateArgumentException(() => helpers.Validate
+                        .Invoke(null, [helpers.Operation1, typeof(string), new[] { typeof(int) }]))
+                };
+            })
+            .Then("all invalid inputs are rejected", exceptions => exceptions.All(ex => ex is not null))
+            .And("messages identify selector or signature failures", exceptions =>
+                exceptions.Any(ex => ex!.Message.Contains("method selector", StringComparison.Ordinal))
+                && exceptions.Any(ex => ex!.Message.Contains("return type mismatch", StringComparison.Ordinal))
+                && exceptions.Any(ex => ex!.Message.Contains("parameter count mismatch", StringComparison.Ordinal))
+                && exceptions.Any(ex => ex!.Message.Contains("parameter 0 type mismatch", StringComparison.Ordinal)))
+            .AssertPassed();
+
+    private static ArgumentException? InvokePrivateArgumentException(Action action)
+    {
+        var exception = Record.Exception(action);
+        return Assert.IsType<ArgumentException>(Assert.IsType<TargetInvocationException>(exception).InnerException);
+    }
 }


### PR DESCRIPTION
## Summary
- add focused TinyBDD-based happy and sad path coverage across examples, core visitors/facades, and source generator edge cases
- cover generator abstraction visitor attributes and additional proxy, memento, state, facade, dispatcher, observer, and chain demo paths
- fix the factory orchestrator example to pass its service provider into the generated factory

## Validation
- dotnet test PatternKit.slnx --configuration Release --no-restore -p:UseSharedCompilation=false
- local merged coverage estimate: 21,421 / 22,549 source lines = 95.00%