### PR TITLE
fix: harden proxy generation and raise coverage

### DIFF
--- a/src/PatternKit.Generators/ProxyGenerator.cs
+++ b/src/PatternKit.Generators/ProxyGenerator.cs
@@ -877,6 +877,7 @@ public sealed class ProxyGenerator : IIncrementalGenerator
     private void GenerateProxyMethod(StringBuilder sb, MemberInfo member, ContractInfo contractInfo, ProxyConfig config)
     {
         var accessibility = GetAccessibilityKeyword(member.Accessibility);
+        var overrideModifier = contractInfo.IsAbstractClass ? "override " : "";
 
         // Determine if this method needs async modifier (uses interceptors with async support)
         // Note: ref-returning methods cannot be async
@@ -888,7 +889,7 @@ public sealed class ProxyGenerator : IIncrementalGenerator
         var asyncModifier = useAsync ? "async " : "";
 
         sb.AppendLine($"    /// <summary>Proxies {member.Name}.</summary>");
-        sb.Append($"    {accessibility} {asyncModifier}{member.ReturnType} {member.Name}(");
+        sb.Append($"    {accessibility} {overrideModifier}{asyncModifier}{member.ReturnType} {member.Name}(");
 
         // Generate parameters
         var paramList = string.Join(", ", member.Parameters.Select(p =>
@@ -995,8 +996,15 @@ public sealed class ProxyGenerator : IIncrementalGenerator
         else
         {
             var refModifier = member.ReturnsByRef || member.ReturnsByRefReadonly ? "ref " : "";
-            var awaitModifier = member.IsAsync ? "await " : "";
-            sb.Append($"            return {awaitModifier}{refModifier}_inner.{member.Name}(");
+            if (member.IsAsync && !member.IsGenericAsyncReturnType)
+            {
+                sb.Append($"            await _inner.{member.Name}(");
+            }
+            else
+            {
+                var awaitModifier = member.IsAsync ? "await " : "";
+                sb.Append($"            return {awaitModifier}{refModifier}_inner.{member.Name}(");
+            }
             sb.Append(string.Join(", ", member.Parameters.Select(p =>
             {
                 var refKind = p.RefKind switch
@@ -1009,6 +1017,10 @@ public sealed class ProxyGenerator : IIncrementalGenerator
                 return $"{refKind}{p.Name}";
             })));
             sb.AppendLine(");");
+            if (member.IsAsync && !member.IsGenericAsyncReturnType)
+            {
+                sb.AppendLine("            return;");
+            }
         }
 
         sb.AppendLine("        }");
@@ -1132,6 +1144,7 @@ public sealed class ProxyGenerator : IIncrementalGenerator
         }
         else // Swallow
         {
+            EmitOutParameterDefaults(sb, member, "            ");
             if (!member.IsVoid)
             {
                 sb.AppendLine("            return default!;");
@@ -1269,21 +1282,34 @@ public sealed class ProxyGenerator : IIncrementalGenerator
         }
         else // Swallow
         {
-            if (!member.IsVoid)
+            if (!member.IsVoid && (!member.IsAsync || member.IsGenericAsyncReturnType))
             {
                 sb.AppendLine("            return default!;");
+            }
+            else
+            {
+                sb.AppendLine("            return;");
             }
         }
 
         sb.AppendLine("        }");
     }
 
+    private static void EmitOutParameterDefaults(StringBuilder sb, MemberInfo member, string indent)
+    {
+        foreach (var parameter in member.Parameters.Where(p => p.RefKind == RefKind.Out))
+        {
+            sb.Append(indent).Append(parameter.Name).AppendLine(" = default!;");
+        }
+    }
+
     private void GenerateProxyProperty(StringBuilder sb, MemberInfo member, ContractInfo contractInfo, ProxyConfig config)
     {
         var accessibility = GetAccessibilityKeyword(member.Accessibility);
+        var overrideModifier = contractInfo.IsAbstractClass ? "override " : "";
 
         sb.AppendLine($"    /// <summary>Proxies {member.Name}.</summary>");
-        sb.Append($"    {accessibility} {member.ReturnType} {member.Name}");
+        sb.Append($"    {accessibility} {overrideModifier}{member.ReturnType} {member.Name}");
 
         if (member.HasGetter && member.HasSetter)
         {

--- a/test/PatternKit.Generators.Tests/AdapterGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/AdapterGeneratorTests.cs
@@ -1277,4 +1277,121 @@ public class AdapterGeneratorTests
         var diags = result.Results.SelectMany(r => r.Diagnostics);
         Assert.Contains(diags, d => d.Id == "PKADP006");
     }
+
+    [Fact]
+    public void GenerateAdapter_ThrowingStubWithDefaultsRefsAndCustomNamespace()
+    {
+        const string source = """
+            using PatternKit.Generators.Adapter;
+
+            namespace TestNamespace;
+
+            public enum Mode { Slow = 0, Fast = 1 }
+
+            public interface IService
+            {
+                string Name { get; }
+                void Copy(ref int source, out int destination, in bool enabled, string? label = null, Mode mode = Mode.Fast);
+                int Retry(int count = 3);
+            }
+
+            public class LegacyService { }
+
+            [GenerateAdapter(
+                Target = typeof(IService),
+                Adaptee = typeof(LegacyService),
+                AdapterTypeName = "ServiceAdapter",
+                MissingMap = AdapterMissingMapPolicy.ThrowingStub,
+                Sealed = false,
+                Namespace = "Generated")]
+            public static partial class ServiceAdapters
+            {
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateAdapter_ThrowingStubWithDefaultsRefsAndCustomNamespace));
+        var gen = new AdapterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generatedSource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Single(gs => gs.HintName == "Generated.ServiceAdapter.Adapter.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("namespace Generated;", generatedSource);
+        Assert.Contains("public partial class ServiceAdapter : global::TestNamespace.IService", generatedSource);
+        Assert.Contains("Name", generatedSource);
+        Assert.Contains("get => throw new global::System.NotImplementedException", generatedSource);
+        Assert.Contains("ref int source", generatedSource);
+        Assert.Contains("out int destination", generatedSource);
+        Assert.Contains("in bool enabled", generatedSource);
+        Assert.Contains("string? label = null", generatedSource);
+        Assert.Contains("global::TestNamespace.Mode mode = global::TestNamespace.Mode.Fast", generatedSource);
+        Assert.Contains("int count = 3", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void AdapterDiagnostics_OpenGenericAbstractCtorAndBadMapSignatures()
+    {
+        const string source = """
+            using PatternKit.Generators.Adapter;
+
+            namespace TestNamespace;
+
+            public interface IGeneric<T> { T Get(); }
+            public abstract class AbstractAdaptee { }
+            public abstract class TargetWithoutDefaultCtor
+            {
+                protected TargetWithoutDefaultCtor(string value) { }
+                public abstract string Value { get; }
+            }
+
+            public interface IService
+            {
+                string Name { get; }
+                int Get(int value);
+                void Copy(ref int value);
+            }
+
+            public class LegacyService { }
+
+            [GenerateAdapter(Target = typeof(IGeneric<>), Adaptee = typeof(LegacyService))]
+            public static partial class OpenTargetHost { }
+
+            [GenerateAdapter(Target = typeof(IService), Adaptee = typeof(AbstractAdaptee))]
+            public static partial class AbstractAdapteeHost { }
+
+            [GenerateAdapter(Target = typeof(TargetWithoutDefaultCtor), Adaptee = typeof(LegacyService))]
+            public static partial class MissingCtorHost { }
+
+            [GenerateAdapter(Target = typeof(IService), Adaptee = typeof(LegacyService))]
+            public static partial class BadMapHost
+            {
+                [AdapterMap(TargetMember = nameof(IService.Name))]
+                public static int BadProperty(LegacyService adaptee) => 0;
+
+                [AdapterMap(TargetMember = nameof(IService.Get))]
+                public static string BadReturn(LegacyService adaptee, string value) => "";
+
+                [AdapterMap(TargetMember = nameof(IService.Copy))]
+                public static void BadRef(LegacyService adaptee, int value) { }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(AdapterDiagnostics_OpenGenericAbstractCtorAndBadMapSignatures));
+        var gen = new AdapterGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Contains(diagnostics, d => d.Id == "PKADP002" && d.GetMessage().Contains("IGeneric"));
+        Assert.Contains(diagnostics, d => d.Id == "PKADP007" && d.GetMessage().Contains("AbstractAdaptee"));
+        Assert.Contains(diagnostics, d => d.Id == "PKADP012" && d.GetMessage().Contains("TargetWithoutDefaultCtor"));
+        Assert.Contains(diagnostics, d => d.Id == "PKADP005" && d.GetMessage().Contains("Return type"));
+        Assert.Contains(diagnostics, d => d.Id == "PKADP005" && d.GetMessage().Contains("ref kind mismatch"));
+    }
 }

--- a/test/PatternKit.Generators.Tests/ComposerGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ComposerGeneratorTests.cs
@@ -822,4 +822,90 @@ public class ComposerGeneratorTests
         var emit = updated.Emit(Stream.Null);
         Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
+
+    [Fact]
+    public void StructComposer_ForceAsync_CustomNames_InnerFirst_CoversStructAsyncPipeline()
+    {
+        var source = """
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Composer;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Composer(
+                InvokeMethodName = "Run",
+                InvokeAsyncMethodName = "RunAsync",
+                ForceAsync = true,
+                WrapOrder = ComposerWrapOrder.InnerFirst)]
+            public partial struct RequestPipeline
+            {
+                [ComposeStep(2, Name = "Audit")]
+                private Response Audit(in Request req, Func<Request, Response> next) => next(req);
+
+                [ComposeStep(1)]
+                private ValueTask<Response> AuthAsync(Request req, Func<Request, ValueTask<Response>> next)
+                    => next(req);
+
+                [ComposeTerminal]
+                private Response Terminal(in Request req) => new(200);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(StructComposer_ForceAsync_CustomNames_InnerFirst_CoversStructAsyncPipeline));
+        var gen = new ComposerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
+        Assert.Contains("RunAsync", generatedSource);
+        Assert.Contains("var self = this;", generatedSource);
+        Assert.Contains("terminalFunc", generatedSource);
+        Assert.Contains("self.AuthAsync(arg, pipeline)", generatedSource);
+        Assert.Contains("self.Audit(in arg, inp => pipeline(inp).GetAwaiter().GetResult())", generatedSource);
+        Assert.DoesNotContain("public Response Run(", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void AsyncSignatureWarnings_WhenCancellationTokenIsWrongType()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Composer;
+
+            namespace PatternKit.Examples;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Composer]
+            public partial class RequestPipeline
+            {
+                [ComposeStep(0)]
+                private ValueTask<Response> StepAsync(Request req, Func<Request, ValueTask<Response>> next, string notCancellationToken)
+                    => next(req);
+
+                [ComposeTerminal]
+                private ValueTask<Response> TerminalAsync(Request req, string notCancellationToken)
+                    => new(new Response(200));
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(AsyncSignatureWarnings_WhenCancellationTokenIsWrongType));
+        var gen = new ComposerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Equal(2, diagnostics.Count(d => d.Id == "PKCOM009"));
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.False(emit.Success);
+    }
 }

--- a/test/PatternKit.Generators.Tests/DecoratorGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/DecoratorGeneratorTests.cs
@@ -1041,4 +1041,92 @@ public class DecoratorGeneratorTests
         var emit = updated.Emit(Stream.Null);
         Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
+
+    [Fact]
+    public void GenerateDecoratorForAbstractClass_PreservesAccessibilityRefsAndAccessors()
+    {
+        const string source = """
+            using PatternKit.Generators.Decorator;
+
+            namespace TestNamespace;
+
+            [GenerateDecorator(Composition = DecoratorCompositionMode.HelpersOnly)]
+            public abstract class RepositoryBase
+            {
+                public abstract string Name { get; internal set; }
+                public abstract int Version { set; }
+                public abstract void Copy(ref int source, out int destination, in bool enabled);
+                public abstract ref int GetCurrent();
+
+                [DecoratorIgnore]
+                public abstract string Snapshot();
+
+                protected abstract void ProtectedOperation();
+                public int NonVirtualValue => 42;
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateDecoratorForAbstractClass_PreservesAccessibilityRefsAndAccessors));
+        var gen = new DecoratorGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.DoesNotContain(r.Diagnostics, d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKDEC004" && d.GetMessage().Contains("ProtectedOperation"));
+
+        var generatedSource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "TestNamespace_RepositoryBase.Decorator.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("public abstract partial class RepositoryBaseDecoratorBase", generatedSource);
+        Assert.Contains("override string Name", generatedSource);
+        Assert.Contains("internal set => Inner.Name = value;", generatedSource);
+        Assert.Contains("override int Version", generatedSource);
+        Assert.Contains("set => Inner.Version = value;", generatedSource);
+        Assert.Contains("public override void Copy(ref int source, out int destination, in bool enabled)", generatedSource);
+        Assert.Contains("Inner.Copy(ref source, out destination, in enabled);", generatedSource);
+        Assert.Contains("public override ref int GetCurrent()", generatedSource);
+        Assert.Contains("=> ref Inner.GetCurrent();", generatedSource);
+        Assert.Contains("public sealed override string Snapshot()", generatedSource);
+        Assert.Contains("RepositoryBaseDecorators", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void DecoratorDiagnostics_ForIndexerInitPropertyFieldAndNestedType()
+    {
+        const string source = """
+            using PatternKit.Generators.Decorator;
+
+            namespace TestNamespace;
+
+            [GenerateDecorator]
+            public abstract class InvalidContract
+            {
+                public int Field;
+                public abstract string this[int index] { get; }
+                public abstract string InitOnly { get; init; }
+                public abstract event System.EventHandler? Changed;
+
+                public class NestedType
+                {
+                }
+
+                public abstract void Save();
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(DecoratorDiagnostics_ForIndexerInitPropertyFieldAndNestedType));
+        var gen = new DecoratorGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Indexer"));
+        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Init-only property"));
+        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Changed"));
+        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Field"));
+        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("NestedType"));
+    }
 }

--- a/test/PatternKit.Generators.Tests/FactoriesGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/FactoriesGeneratorTests.cs
@@ -581,4 +581,169 @@ public class FactoriesGeneratorTests
         var emit = updated.Emit(pe);
         Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
+
+    [Fact]
+    public void FactoryMethod_Async_String_NoDefault_WithParameters_EmitsNullAndCaseBranches()
+    {
+        const string user = """
+                            using System.Threading.Tasks;
+                            using PatternKit.Generators.Factories;
+
+                            namespace Demo;
+
+                            [FactoryMethod(typeof(string), CreateMethodName = "Resolve", CaseInsensitiveStrings = true)]
+                            public static partial class FormatterFactory
+                            {
+                                [FactoryCase("json")]
+                                public static Task<string> JsonAsync(string payload, int indent) => Task.FromResult($"json:{payload}:{indent}");
+
+                                [FactoryCase("xml")]
+                                public static ValueTask<string> XmlAsync(string payload, int indent) => ValueTask.FromResult($"xml:{payload}:{indent}");
+                            }
+                            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(user, assemblyName: nameof(FactoryMethod_Async_String_NoDefault_WithParameters_EmitsNullAndCaseBranches));
+        var gen = new FactoriesGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        var generated = run.Results.SelectMany(r => r.GeneratedSources)
+            .Single(g => g.HintName == "FormatterFactory.FactoryMethod.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("if (key is null) throw new global::System.ArgumentNullException", generated);
+        Assert.Contains("StringComparison.OrdinalIgnoreCase", generated);
+        Assert.Contains("ResolveAsync", generated);
+        Assert.Contains("return (false, default!);", generated);
+        Assert.Contains("JsonAsync(payload, indent)", generated);
+        Assert.Contains("XmlAsync(payload, indent)", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void FactoryMethod_Async_Numeric_NoDefault_EmitsSwitchBranches()
+    {
+        const string user = """
+                            using System.Threading.Tasks;
+                            using PatternKit.Generators.Factories;
+
+                            namespace Demo;
+
+                            [FactoryMethod(typeof(int))]
+                            public static partial class NumberFactory
+                            {
+                                [FactoryCase(1)]
+                                public static Task<string> OneAsync() => Task.FromResult("one");
+
+                                [FactoryCase(2)]
+                                public static ValueTask<string> TwoAsync() => ValueTask.FromResult("two");
+                            }
+                            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(user, assemblyName: nameof(FactoryMethod_Async_Numeric_NoDefault_EmitsSwitchBranches));
+        var gen = new FactoriesGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        var generated = run.Results.SelectMany(r => r.GeneratedSources)
+            .Single(g => g.HintName == "NumberFactory.FactoryMethod.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("switch (key)", generated);
+        Assert.Contains("case 1:", generated);
+        Assert.Contains("default:", generated);
+        Assert.Contains("throw new global::System.ArgumentOutOfRangeException(nameof(key));", generated);
+        Assert.Contains("return (false, default!);", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void FactoryClass_AsyncEnumKeysAndFactoryMethods_CoverCreationBranches()
+    {
+        const string user = """
+                            using System.Threading.Tasks;
+                            using PatternKit.Generators.Factories;
+
+                            namespace Demo;
+
+                            public enum Channel { Sms = 2, Push = 7 }
+
+                            [FactoryClass(typeof(Channel), GenerateEnumKeys = true, FactoryTypeName = "ChannelFactory")]
+                            public abstract class ChannelHandler { }
+
+                            [FactoryClassKey(Channel.Sms)]
+                            public sealed class SmsHandler : ChannelHandler
+                            {
+                                public static Task<ChannelHandler> CreateAsync() => Task.FromResult<ChannelHandler>(new SmsHandler());
+                            }
+
+                            [FactoryClassKey(Channel.Push)]
+                            public sealed class PushHandler : ChannelHandler
+                            {
+                                public static ValueTask<ChannelHandler> CreateAsync() => ValueTask.FromResult<ChannelHandler>(new PushHandler());
+                            }
+                            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(user, assemblyName: nameof(FactoryClass_AsyncEnumKeysAndFactoryMethods_CoverCreationBranches));
+        var gen = new FactoriesGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        var generated = run.Results.SelectMany(r => r.GeneratedSources)
+            .Single(g => g.HintName == "ChannelFactory.FactoryClass.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("public global::System.Threading.Tasks.ValueTask<global::Demo.ChannelHandler> CreateAsync(Keys key)", generated);
+        Assert.Contains("TryCreateAsync(Keys key)", generated);
+        Assert.Contains("return CreateAsync(MapKey(key));", generated);
+        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Demo.ChannelHandler>", generated);
+        Assert.Contains("SmsHandler.CreateAsync", generated);
+        Assert.Contains("PushHandler.CreateAsync", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void FactoryClass_StringKeysGenerateStableEnumNamesAndNullComparers()
+    {
+        const string user = """
+                            using PatternKit.Generators.Factories;
+
+                            namespace Demo;
+
+                            [FactoryClass(typeof(string), GenerateEnumKeys = true, FactoryTypeName = "TransportFactory")]
+                            public interface ITransport { }
+
+                            [FactoryClassKey("1-http")]
+                            public sealed class Http1 : ITransport { }
+
+                            [FactoryClassKey("1_http")]
+                            public sealed class Http2 : ITransport { }
+
+                            [FactoryClassKey("")]
+                            public sealed class Empty : ITransport { }
+                            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(user, assemblyName: nameof(FactoryClass_StringKeysGenerateStableEnumNamesAndNullComparers));
+        var gen = new FactoriesGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        var generated = run.Results.SelectMany(r => r.GeneratedSources)
+            .Single(g => g.HintName == "TransportFactory.FactoryClass.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("Key1Http", generated);
+        Assert.Contains("Key1Http2", generated);
+        Assert.Contains("Key", generated);
+        Assert.Contains("MapKey", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
 }

--- a/test/PatternKit.Generators.Tests/ObserverGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ObserverGeneratorTests.cs
@@ -963,4 +963,89 @@ public class ObserverGeneratorTests
             alc.Unload();
         }
     }
+
+    [Fact]
+    public void Reports_Invalid_Config_For_Generic_Nested_And_Struct_Observers()
+    {
+        const string code = """
+            using PatternKit.Generators.Observer;
+
+            namespace Test;
+
+            public record Payload(int Value);
+
+            [Observer(typeof(Payload))]
+            public partial class GenericObserver<T>
+            {
+            }
+
+            public class Outer
+            {
+                [Observer(typeof(Payload))]
+                public partial class NestedObserver
+                {
+                }
+            }
+
+            [Observer(typeof(Payload))]
+            public partial struct StructObserver
+            {
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            code,
+            assemblyName: nameof(Reports_Invalid_Config_For_Generic_Nested_And_Struct_Observers));
+
+        var gen = new Observer.ObserverGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Equal(3, diagnostics.Count(d => d.Id == "PKOBS003"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Generic observer types"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Nested observer types"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Struct observer types"));
+    }
+
+    [Fact]
+    public void ForceAsync_Internal_Record_Uses_Configured_Source_Shape()
+    {
+        const string code = """
+            using PatternKit.Generators.Observer;
+
+            public record Payload(int Value);
+
+            [Observer(
+                typeof(Payload),
+                Threading = ObserverThreadingPolicy.SingleThreadedFast,
+                Exceptions = ObserverExceptionPolicy.Stop,
+                Order = ObserverOrderPolicy.Undefined,
+                GenerateAsync = false,
+                ForceAsync = true)]
+            internal partial record class DomainEvent
+            {
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            code,
+            assemblyName: nameof(ForceAsync_Internal_Record_Uses_Configured_Source_Shape));
+
+        var gen = new Observer.ObserverGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generated = run.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Single()
+            .SourceText.ToString();
+
+        Assert.Contains("internal partial record class DomainEvent", generated);
+        Assert.Contains("PublishAsync", generated);
+        Assert.DoesNotContain("lock (_lock)", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
 }

--- a/test/PatternKit.Generators.Tests/ProxyGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ProxyGeneratorTests.cs
@@ -1095,4 +1095,232 @@ public class ProxyGeneratorTests
         Assert.Contains("get => _inner.Age", proxySource);
         Assert.Contains("set => _inner.IsActive = value", proxySource);
     }
+
+    [Fact]
+    public void GenerateProxy_DisabledAsyncBaseInterfaceAndEscapedDefaults_CoverBranches()
+    {
+        const string source = """
+            using PatternKit.Generators.Proxy;
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestNamespace;
+
+            public enum Mode { Unknown = 0, Fast = 1 }
+
+            public partial interface IBaseService
+            {
+                string FromBase(char marker = '\n');
+            }
+
+            [GenerateProxy]
+            public partial interface IWarnsForAsync : IBaseService
+            {
+                Task<string> GetAsync(CancellationToken ct = default);
+                string Format(
+                    string escaped = "line\nquote\"slash\\tab\t",
+                    char quote = '\'',
+                    float ratio = 1.5f,
+                    double score = 2.25d,
+                    decimal money = 3.75m,
+                    Mode mode = Mode.Fast);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateProxy_DisabledAsyncBaseInterfaceAndEscapedDefaults_CoverBranches));
+        var gen = new ProxyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        var proxySource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "TestNamespace_IWarnsForAsync.Proxy.g.cs")
+            .SourceText.ToString();
+        var interceptorSource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "TestNamespace_IWarnsForAsync.Proxy.Interceptor.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("FromBase", proxySource);
+        Assert.Contains("string escaped = \"line\\nquote\\\"slash\\\\tab\\t\"", proxySource);
+        Assert.Contains("char quote = '\\''", proxySource);
+        Assert.Contains("float ratio = 1.5f", proxySource);
+        Assert.Contains("double score = 2.25d", proxySource);
+        Assert.Contains("decimal money = 3.75m", proxySource);
+        Assert.Contains("Mode mode = global::TestNamespace.Mode.Fast", proxySource);
+        Assert.Contains("BeforeAsync", interceptorSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void GenerateProxy_IndexerProperty_ReportsUnsupportedMember()
+    {
+        const string source = """
+            using PatternKit.Generators.Proxy;
+
+            namespace TestNamespace;
+
+            [GenerateProxy]
+            public partial interface IIndexedService
+            {
+                string this[int index] { get; }
+                string GetValue();
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateProxy_IndexerProperty_ReportsUnsupportedMember));
+        var gen = new ProxyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Indexer"));
+    }
+
+    [Fact]
+    public void GenerateProxy_AsyncPipelineWithVoidTasksAndRefs_CoversAsyncEmission()
+    {
+        const string source = """
+            using PatternKit.Generators.Proxy;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [GenerateProxy(InterceptorMode = ProxyInterceptorMode.Pipeline, Exceptions = ProxyExceptionPolicy.Swallow)]
+            public partial interface Worker
+            {
+                void Copy(ref int source, out int destination, in bool enabled);
+                Task SaveAsync(int id, CancellationToken ct = default);
+                ValueTask FlushAsync(CancellationToken ct = default);
+                Task<int> CountAsync(CancellationToken ct = default);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateProxy_AsyncPipelineWithVoidTasksAndRefs_CoversAsyncEmission));
+        var gen = new ProxyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        var proxySource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "Worker.Proxy.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("for (int __i = 0; __i < _interceptors!.Count; __i++)", proxySource);
+        Assert.Contains("for (int __i = _interceptors!.Count - 1; __i >= 0; __i--)", proxySource);
+        Assert.Contains("_inner.Copy(ref source, out destination, in enabled);", proxySource);
+        Assert.Contains("await __task.ConfigureAwait(false);", proxySource);
+        Assert.Contains("var __result = await __task.ConfigureAwait(false);", proxySource);
+        Assert.Contains("return default!;", proxySource);
+        Assert.Contains("WorkerProxy", proxySource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void GenerateProxy_AbstractRecordAndAccessibility_CoversRecordAndProtectedBranches()
+    {
+        const string source = """
+            using PatternKit.Generators.Proxy;
+
+            namespace TestNamespace;
+
+            [GenerateProxy(ProxyTypeName = "AbstractRecordProxy")]
+            public abstract partial record class AbstractRecordService
+            {
+                public abstract string Get();
+                protected abstract string ProtectedOnly();
+                public abstract string PublicGet { get; }
+                protected abstract string ProtectedProperty { get; }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateProxy_AbstractRecordAndAccessibility_CoversRecordAndProtectedBranches));
+        var gen = new ProxyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("ProtectedOnly"));
+        Assert.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("ProtectedProperty"));
+
+        var proxySource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "TestNamespace_AbstractRecordService.Proxy.g.cs")
+            .SourceText.ToString();
+        Assert.Contains("class AbstractRecordProxy", proxySource);
+        Assert.Contains("PublicGet", proxySource);
+    }
+
+    [Fact]
+    public void GenerateProxy_NoInterceptorMode_CoversPureDelegationRefsPropertiesAndStatics()
+    {
+        const string source = """
+            using PatternKit.Generators.Proxy;
+
+            namespace TestNamespace;
+
+            [GenerateProxy(InterceptorMode = ProxyInterceptorMode.None, Exceptions = ProxyExceptionPolicy.Swallow)]
+            public abstract partial class WorkerContract
+            {
+                public abstract string Name { get; set; }
+                public abstract int Version { get; }
+                public static string StaticValue => "ignored";
+
+                public abstract void Copy(ref int source, out int destination, in bool enabled);
+                public abstract int Calculate(int value);
+                public virtual string Virtual(string value) => value;
+                public string Concrete(string value) => value;
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateProxy_NoInterceptorMode_CoversPureDelegationRefsPropertiesAndStatics));
+        var gen = new ProxyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+
+        var proxySource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Single(gs => gs.HintName == "TestNamespace_WorkerContract.Proxy.g.cs")
+            .SourceText.ToString();
+
+        Assert.Contains("Name", proxySource);
+        Assert.Contains("get => _inner.Name;", proxySource);
+        Assert.Contains("set => _inner.Name = value;", proxySource);
+        Assert.Contains("Version", proxySource);
+        Assert.Contains("_inner.Copy(ref source, out destination, in enabled);", proxySource);
+        Assert.Contains("return _inner.Calculate(value);", proxySource);
+        Assert.Contains("return _inner.Virtual(value);", proxySource);
+        Assert.DoesNotContain("Concrete", proxySource);
+        Assert.DoesNotContain("StaticValue", proxySource);
+        Assert.DoesNotContain("Interceptor", proxySource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void GenerateProxy_InterfaceWithIgnoredOnlyMembers_SkipsGeneration()
+    {
+        const string source = """
+            using PatternKit.Generators.Proxy;
+
+            namespace TestNamespace;
+
+            [GenerateProxy]
+            public partial interface IEmptyProxy
+            {
+                [ProxyIgnore]
+                void Ignored();
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(GenerateProxy_InterfaceWithIgnoredOnlyMembers_SkipsGeneration));
+        var gen = new ProxyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        Assert.Empty(result.Results.SelectMany(r => r.GeneratedSources));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix proxy generation for non-generic Task/ValueTask intercepted methods and swallowed out parameters.
- Fix abstract-class proxy members to emit override members instead of hiding abstract contracts.
- Add focused generator coverage across proxy, adapter, factories, composer, decorator, and observer branches.

## Validation
- `dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false`
- `dotnet test PatternKit.slnx --configuration Release --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[PatternKit*]*" DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests]*" RunConfiguration.TestSessionTimeout=900000`

## Coverage
- `PatternKit.Generators`: 95.2% in the local merged report.
- Overall local merged ReportGenerator view: 94.6% because it includes generated example `obj` files.
