### PR TITLE
test: raise generator and example coverage

### DIFF
--- a/src/PatternKit.Generators/FacadeGenerator.cs
+++ b/src/PatternKit.Generators/FacadeGenerator.cs
@@ -727,7 +727,7 @@ public sealed class FacadeGenerator : IIncrementalGenerator
         // Build method signature
         var returnType = methodSymbol.ReturnType.ToDisplayString(FullyQualifiedFormat);
         var isAsync = method.IsAsync || info.ForceAsync;
-        var asyncModifier = isAsync ? "async " : "";
+        var asyncModifier = isAsync && method.MappingMethod is not null ? "async " : "";
 
         // Prefer ValueTask for generated async methods
         if (isAsync && returnType == "void")
@@ -738,7 +738,9 @@ public sealed class FacadeGenerator : IIncrementalGenerator
         var parameters = string.Join(", ", methodSymbol.Parameters.Select(p =>
             $"{GetRefKind(p.RefKind)}{p.Type.ToDisplayString(FullyQualifiedFormat)} {p.Name}"));
 
-        sb.AppendLine($"    public {asyncModifier}{returnType} {method.ContractName}({parameters})");
+        var typeParameters = BuildTypeParameterList(methodSymbol);
+        sb.AppendLine($"    public {asyncModifier}{returnType} {method.ContractName}{typeParameters}({parameters})");
+        AppendTypeParameterConstraints(sb, methodSymbol);
         sb.AppendLine("    {");
 
         if (method.MappingMethod is null)
@@ -1106,10 +1108,14 @@ public sealed class FacadeGenerator : IIncrementalGenerator
             }
             constraints.Add(constraint);
         }
-        if (tp.HasValueTypeConstraint)
-            constraints.Add("struct");
         if (tp.HasUnmanagedTypeConstraint)
+        {
             constraints.Add("unmanaged");
+        }
+        else if (tp.HasValueTypeConstraint)
+        {
+            constraints.Add("struct");
+        }
         if (tp.HasNotNullConstraint)
             constraints.Add("notnull");
 
@@ -1122,6 +1128,26 @@ public sealed class FacadeGenerator : IIncrementalGenerator
             constraints.Add("new()");
 
         return string.Join(", ", constraints);
+    }
+
+    private static string BuildTypeParameterList(IMethodSymbol method)
+    {
+        if (method.TypeParameters.Length == 0)
+            return string.Empty;
+
+        return "<" + string.Join(", ", method.TypeParameters.Select(tp => tp.Name)) + ">";
+    }
+
+    private static void AppendTypeParameterConstraints(StringBuilder sb, IMethodSymbol method)
+    {
+        foreach (var typeParameter in method.TypeParameters)
+        {
+            var constraints = BuildTypeConstraints(typeParameter);
+            if (!string.IsNullOrWhiteSpace(constraints))
+            {
+                sb.AppendLine($"        where {typeParameter.Name} : {constraints}");
+            }
+        }
     }
 
     private static void GenerateHostMethod(
@@ -1149,7 +1175,9 @@ public sealed class FacadeGenerator : IIncrementalGenerator
         var parameters = string.Join(", ", operationParams.Select(p =>
             $"{GetRefKind(p.RefKind)}{p.Type.ToDisplayString(FullyQualifiedFormat)} {p.Name}"));
 
-        sb.AppendLine($"    public {asyncModifier}{returnType} {method.ContractName}({parameters})");
+        var typeParameters = BuildTypeParameterList(hostMethod);
+        sb.AppendLine($"    public {asyncModifier}{returnType} {method.ContractName}{typeParameters}({parameters})");
+        AppendTypeParameterConstraints(sb, hostMethod);
         sb.AppendLine("    {");
 
         // Call host method with dependencies and operation parameters
@@ -1157,7 +1185,8 @@ public sealed class FacadeGenerator : IIncrementalGenerator
         var awaitKeyword = IsAsyncMethod(hostMethod) ? "await " : "";
         var returnKeyword = returnType == "void" ? "" : "return ";
 
-        sb.AppendLine($"        {returnKeyword}{awaitKeyword}{info.TargetType.ToDisplayString(FullyQualifiedFormat)}.{hostMethod.Name}({callArgs});");
+        var hostTypeArguments = BuildTypeParameterList(hostMethod);
+        sb.AppendLine($"        {returnKeyword}{awaitKeyword}{info.TargetType.ToDisplayString(FullyQualifiedFormat)}.{hostMethod.Name}{hostTypeArguments}({callArgs});");
 
         sb.AppendLine("    }");
         sb.AppendLine();
@@ -1213,6 +1242,9 @@ public sealed class FacadeGenerator : IIncrementalGenerator
                 // Heuristic: dependencies are typically the first parameters and are reference types
                 // We'll collect all unique parameter types and let the user define them properly
                 var typeStr = param.Type.ToDisplayString(FullyQualifiedFormat);
+
+                if (param.Type is ITypeParameterSymbol)
+                    continue;
 
                 // Skip primitive types
                 if (IsPrimitiveType(param.Type))

--- a/src/PatternKit.Generators/StateMachineGenerator.cs
+++ b/src/PatternKit.Generators/StateMachineGenerator.cs
@@ -966,7 +966,9 @@ public sealed class StateMachineGenerator : IIncrementalGenerator
                         ? (isAsync 
                             ? (hookHasCt ? $"await {exitHook.Method.Name}(cancellationToken){configureAwait};" : $"await {exitHook.Method.Name}(){configureAwait};")
                             : (hookHasCt ? $"{exitHook.Method.Name}(global::System.Threading.CancellationToken.None).GetAwaiter().GetResult();" : $"{exitHook.Method.Name}().GetAwaiter().GetResult();"))
-                        : $"{exitHook.Method.Name}();";
+                        : (hookHasCt
+                            ? (isAsync ? $"{exitHook.Method.Name}(cancellationToken);" : $"{exitHook.Method.Name}(global::System.Threading.CancellationToken.None);")
+                            : $"{exitHook.Method.Name}();");
                     sb.AppendLine($"                        {hookCall}");
                 }
 
@@ -981,7 +983,10 @@ public sealed class StateMachineGenerator : IIncrementalGenerator
                 }
                 else
                 {
-                    sb.AppendLine($"                        {transition.Method.Name}();");
+                    var transitionCall = transitionHasCt
+                        ? (isAsync ? $"{transition.Method.Name}(cancellationToken);" : $"{transition.Method.Name}(global::System.Threading.CancellationToken.None);")
+                        : $"{transition.Method.Name}();";
+                    sb.AppendLine($"                        {transitionCall}");
                 }
 
                 // Update state
@@ -996,7 +1001,9 @@ public sealed class StateMachineGenerator : IIncrementalGenerator
                         ? (isAsync 
                             ? (entryHasCt ? $"await {entryHook.Method.Name}(cancellationToken){configureAwait};" : $"await {entryHook.Method.Name}(){configureAwait};")
                             : (entryHasCt ? $"{entryHook.Method.Name}(global::System.Threading.CancellationToken.None).GetAwaiter().GetResult();" : $"{entryHook.Method.Name}().GetAwaiter().GetResult();"))
-                        : $"{entryHook.Method.Name}();";
+                        : (entryHasCt
+                            ? (isAsync ? $"{entryHook.Method.Name}(cancellationToken);" : $"{entryHook.Method.Name}(global::System.Threading.CancellationToken.None);")
+                            : $"{entryHook.Method.Name}();");
                     sb.AppendLine($"                        {hookCall}");
                 }
 

--- a/test/PatternKit.Examples.Tests/MementoDemo/MementoDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/MementoDemo/MementoDemoTests.cs
@@ -187,4 +187,77 @@ public sealed class MementoDemoTests(ITestOutputHelper output) : TinyBddXunitBas
             .Then("declined batch does not commit a new version", r => r.noCommitVersion == r.startVersion)
             .And("nested batches are rejected", r => r.nested is not null)
             .AssertPassed();
+
+    [Scenario("Caret movement, replacement, and delete variants cover editor state edges")]
+    [Fact]
+    public Task Editor_StateAndDeleteVariants_AreStable()
+        => Given("an editor with sample text", () =>
+            {
+                var editor = new Editor();
+                editor.Insert("abcdef");
+                return editor;
+            })
+            .When("moving outside document bounds", ed =>
+            {
+                ed.MoveCaret(-100);
+                var clampedStart = ed.State;
+                var versionAtStart = ed.Version;
+                var repeatStartVersion = ed.MoveCaret(0);
+                ed.MoveCaret(100);
+                var clampedEnd = ed.State;
+                return (ed, clampedStart, versionAtStart, repeatStartVersion, clampedEnd);
+            })
+            .Then("caret positions are clamped and repeated movement is a no-op", r =>
+                r.clampedStart.Caret == 0
+                && r.repeatStartVersion == r.versionAtStart
+                && r.clampedEnd.Caret == r.ed.State.Text.Length)
+            .When("replacing without a selection and formatting selected state", r =>
+            {
+                var editor = r.ed;
+                editor.MoveCaret(3);
+                editor.ReplaceSelection("XYZ");
+                var afterInsertReplace = editor.State;
+                editor.Select(2, 4);
+                var selected = editor.State;
+                var selectedText = selected.ToString();
+                editor.Backspace();
+                var afterSelectionBackspace = editor.State;
+                return (editor, afterInsertReplace, selected, selectedText, afterSelectionBackspace);
+            })
+            .Then("replace without selection behaves like insert", r => r.afterInsertReplace.Text == "abcXYZdef")
+            .And("selected state exposes selection range and formatted selection", r =>
+                r.selected.HasSelection
+                && r.selected.SelectionStart == 2
+                && r.selected.SelectionEnd == 6
+                && r.selectedText.Contains("Sel=[2,6)"))
+            .And("backspace deletes selected text", r => r.afterSelectionBackspace.Text == "abdef")
+            .When("using multi-character backspace and delete-forward", r =>
+            {
+                var editor = r.editor;
+                editor.MoveCaret(editor.State.Text.Length);
+                editor.Backspace(2);
+                var afterMultiBackspace = editor.State;
+                editor.MoveCaret(1);
+                editor.DeleteForward(10);
+                var afterMultiDelete = editor.State;
+                return (editor, afterMultiBackspace, afterMultiDelete);
+            })
+            .Then("multi-character backspace removes the requested prefix before the caret", r => r.afterMultiBackspace.Text == "abd")
+            .And("delete-forward clamps count to remaining text", r => r.afterMultiDelete.Text == "a")
+            .AssertPassed();
+
+    [Scenario("Undo and redo report false when no snapshot movement is available")]
+    [Fact]
+    public Task Editor_UndoRedo_NoMovement_ReturnFalse()
+        => Given("a new editor", () => new Editor())
+            .When("undo and redo are requested before edits", ed =>
+            {
+                var undo = ed.Undo();
+                var redo = ed.Redo();
+                return (ed, undo, redo, state: ed.State.ToString());
+            })
+            .Then("undo is unavailable", r => !r.undo)
+            .And("redo is unavailable", r => !r.redo)
+            .And("unselected state formatting omits a selection", r => !r.state.Contains("Sel="))
+            .AssertPassed();
 }

--- a/test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs
@@ -101,6 +101,69 @@ public sealed class ResilientCheckoutDemoTests
         Assert.Equal(["primary-card", "dropship-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
     }
 
+    [Fact]
+    public void Run_UsesPreferredGiftCardWhenBalanceCoversTotal()
+    {
+        var services = new CheckoutServices();
+        var request = CreateRequest("order-preferred-gift", total: 42m, giftCardBalance: 50m) with
+        {
+            PreferGiftCard = true
+        };
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.ManualReview);
+        Assert.Equal("primary-gift-card", result.FinalRoute);
+        Assert.Single(result.Attempts);
+        Assert.StartsWith("giftcard-order-preferred-gift-", result.PaymentId, StringComparison.Ordinal);
+        Assert.Empty(services.Inventory.ReleasedReservations);
+        Assert.Empty(services.Payments.RefundedPayments);
+    }
+
+    [Fact]
+    public void Run_EmptyCartValidationFailureEscalatesToManualReview()
+    {
+        var services = new CheckoutServices();
+        var request = new CheckoutRequest(
+            "order-empty",
+            "customer-42",
+            []);
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.ManualReview);
+        Assert.Equal("manual-review", result.FinalRoute);
+        Assert.Equal(["primary-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
+        Assert.Equal(CheckoutFailureKind.ValidationFailed, result.Attempts[0].FailureKind);
+        Assert.Contains("cart-empty", result.Attempts[0].Message, StringComparison.Ordinal);
+        Assert.Null(result.ReservationId);
+        Assert.Null(result.PaymentId);
+        Assert.Null(result.ShipmentId);
+    }
+
+    [Fact]
+    public void Run_CardDeclineWithoutGiftCardFallbackEscalatesToManualReviewAndReleasesInventory()
+    {
+        var services = new CheckoutServices
+        {
+            Payments = new PaymentGateway { CardApproved = false }
+        };
+        var request = CreateRequest("order-card-decline-review", total: 80m, giftCardBalance: 10m);
+
+        var result = ResilientCheckoutDemo.Run(request, services);
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.ManualReview);
+        Assert.Equal("manual-review", result.FinalRoute);
+        Assert.Equal(["primary-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
+        Assert.Equal(CheckoutFailureKind.PaymentDeclined, result.Attempts[0].FailureKind);
+        Assert.Single(services.Inventory.ReleasedReservations);
+        Assert.Empty(services.Payments.RefundedPayments);
+        Assert.Contains(result.Audit, static entry => entry.StartsWith("inventory:released:", StringComparison.Ordinal));
+    }
+
     private static CheckoutRequest CreateRequest(string orderId, decimal total, decimal giftCardBalance = 0m)
         => new(
             orderId,

--- a/test/PatternKit.Generators.Tests/FacadeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/FacadeGeneratorTests.cs
@@ -1770,5 +1770,147 @@ public class FacadeGeneratorTests
         Assert.Contains("this.myTarget = myTarget ?? throw new System.ArgumentNullException(nameof(myTarget));", generatedSource);
     }
 
+    [Fact]
+    public void ContractFirst_MissingMapIgnore_CoversAsyncDefaultReturnBranches()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Facade;
+
+            namespace TestNs;
+
+            [GenerateFacade(MissingMap = FacadeMissingMapPolicy.Ignore)]
+            public partial interface IAsyncDefaultsFacade
+            {
+                ValueTask<string> ReadValueAsync();
+                Task<int> CountAsync();
+                ValueTask SaveAsync();
+                Task FlushAsync();
+                string ReadName();
+                void Touch();
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(ContractFirst_MissingMapIgnore_CoversAsyncDefaultReturnBranches),
+            extra: [CoreRef, CommonRef]);
+
+        var gen = new FacadeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generatedSource = run.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
+        Assert.Contains("ValueTask.FromResult<string>(default!)", generatedSource);
+        Assert.Contains("Task.FromResult<int>(default!)", generatedSource);
+        Assert.Contains("ValueTask.CompletedTask", generatedSource);
+        Assert.Contains("Task.CompletedTask", generatedSource);
+        Assert.Contains("return default!;", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void HostFirst_GenericConstraintsAndDependencyNameCollisions_GenerateCompilableFacade()
+    {
+        const string source = """
+            using System;
+            using PatternKit.Generators.Facade;
+
+            namespace TestNs.Alpha
+            {
+                public interface IClient { }
+            }
+
+            namespace TestNs.Beta
+            {
+                public interface IClient { }
+            }
+
+            namespace TestNs
+            {
+                public interface IService { }
+                public sealed class Service : IService { }
+                public sealed class Request { }
+
+                [GenerateFacade(FacadeTypeName = "OperationsFacade")]
+                public static partial class Operations
+                {
+                    [FacadeExpose]
+                    public static T Create<T>(IService service) where T : class, new() => new T();
+
+                    [FacadeExpose(MethodName = "Choose")]
+                    public static T Pick<T>(IService service, T value)
+                        where T : notnull, IComparable<T>
+                        => value;
+
+                    [FacadeExpose]
+                    public static TNumber Identity<TNumber>(Request request, TNumber value) where TNumber : unmanaged => value;
+
+                    [FacadeExpose]
+                    public static string FromAlpha(Alpha.IClient client) => "alpha";
+
+                    [FacadeExpose]
+                    public static string FromBeta(Beta.IClient client) => "beta";
+                }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(HostFirst_GenericConstraintsAndDependencyNameCollisions_GenerateCompilableFacade),
+            extra: [CoreRef, CommonRef]);
+
+        var gen = new FacadeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generatedSource = run.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
+        Assert.Contains("where T : class, new()", generatedSource);
+        Assert.Contains("where T : notnull, global::System.IComparable<T>", generatedSource);
+        Assert.Contains("where TNumber : unmanaged", generatedSource);
+        Assert.Contains("private readonly global::TestNs.IService _service;", generatedSource);
+        Assert.Contains("private readonly global::TestNs.Request _request;", generatedSource);
+        Assert.Contains("private readonly global::TestNs.Alpha.IClient _client;", generatedSource);
+        Assert.Contains("private readonly global::TestNs.Beta.IClient _client1;", generatedSource);
+        Assert.Contains("T value", generatedSource);
+        Assert.Contains("TNumber value", generatedSource);
+        Assert.Contains("Choose", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void AutoFacade_NoPublicMethods_ReportsDiagnostic()
+    {
+        const string source = """
+            using PatternKit.Generators.Facade;
+
+            namespace TestNs;
+
+            public interface IPropertyOnly
+            {
+                string Name { get; }
+            }
+
+            [GenerateFacade(TargetTypeName = "TestNs.IPropertyOnly")]
+            public partial interface IPropertyOnlyFacade { }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(AutoFacade_NoPublicMethods_ReportsDiagnostic),
+            extra: [CoreRef, CommonRef]);
+
+        var gen = new FacadeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        Assert.Contains(run.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKFAC003");
+    }
+
     #endregion
 }

--- a/test/PatternKit.Generators.Tests/FlyweightGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/FlyweightGeneratorTests.cs
@@ -78,4 +78,36 @@ public class FlyweightGeneratorTests
         var diags = result.Results.SelectMany(r => r.Diagnostics);
         Assert.Contains(diags, d => d.Id == "PKFLY006");
     }
+
+    [Fact]
+    public void ReportsNonPartialAndNonStaticFactory()
+    {
+        const string source = """
+            using PatternKit.Generators.Flyweight;
+
+            namespace TestNamespace;
+
+            [Flyweight(typeof(string))]
+            public readonly record struct NonPartialGlyph(char Value)
+            {
+                [FlyweightFactory]
+                private static NonPartialGlyph Create(string key) => new(key[0]);
+            }
+
+            [Flyweight(typeof(string))]
+            public readonly partial record struct NonStaticFactoryGlyph(char Value)
+            {
+                [FlyweightFactory]
+                private NonStaticFactoryGlyph Create(string key) => new(key[0]);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsNonPartialAndNonStaticFactory));
+        var gen = new FlyweightGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diags = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Contains(diags, d => d.Id == "PKFLY001");
+        Assert.Contains(diags, d => d.Id == "PKFLY004");
+    }
 }

--- a/test/PatternKit.Generators.Tests/IteratorGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/IteratorGeneratorTests.cs
@@ -58,4 +58,40 @@ public class IteratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
         Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKIT002");
     }
+
+    [Fact]
+    public void ReportsNonPartialAndBadStepSignature()
+    {
+        const string source = """
+            using PatternKit.Generators.Iterator;
+
+            namespace TestNamespace;
+
+            [Iterator]
+            public struct NonPartialCounter
+            {
+                [IteratorStep]
+                private bool Step(out int item)
+                {
+                    item = 1;
+                    return true;
+                }
+            }
+
+            [Iterator]
+            public partial struct BadStepCounter
+            {
+                [IteratorStep]
+                private int Step() => 1;
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsNonPartialAndBadStepSignature));
+        var gen = new IteratorGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Contains(diagnostics, d => d.Id == "PKIT001");
+        Assert.Contains(diagnostics, d => d.Id == "PKIT004");
+    }
 }

--- a/test/PatternKit.Generators.Tests/StateMachineGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/StateMachineGeneratorTests.cs
@@ -1033,4 +1033,155 @@ public class StateMachineGeneratorTests
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
         Assert.Contains(diagnostics, d => d.Id == "PKST010");
     }
+
+    [Fact]
+    public void AsyncMembersWithGenerateAsyncFalse_ReportsDiagnosticAndGeneratesSyncOnly()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            using PatternKit.Generators.State;
+
+            namespace PatternKit.Examples;
+
+            public enum State { A, B }
+            public enum Trigger { T1 }
+
+            [StateMachine(typeof(State), typeof(Trigger), GenerateAsync = false, FireMethodName = "Move")]
+            public partial class Machine
+            {
+                [StateTransition(From = State.A, Trigger = Trigger.T1, To = State.B)]
+                private ValueTask OnTransitionAsync() => ValueTask.CompletedTask;
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(AsyncMembersWithGenerateAsyncFalse_ReportsDiagnosticAndGeneratesSyncOnly));
+        var gen = new StateMachineGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        Assert.Contains(diagnostics, d => d.Id == "PKST008");
+
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
+        Assert.Contains("void Move(", generated);
+        Assert.DoesNotContain("FireAsync", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void InvalidTransitionGuardAndHookSignatures_ReportDiagnostics()
+    {
+        var transitionSource = """
+            using PatternKit.Generators.State;
+            namespace PatternKit.Examples;
+            public enum State { A, B }
+            public enum Trigger { T1 }
+            [StateMachine(typeof(State), typeof(Trigger))]
+            public partial class TransitionMachine
+            {
+                [StateTransition(From = State.A, Trigger = Trigger.T1, To = State.B)]
+                private int BadTransition() => 0;
+            }
+            """;
+
+        var guardSource = """
+            using PatternKit.Generators.State;
+            namespace PatternKit.Examples;
+            public enum State { A, B }
+            public enum Trigger { T1 }
+            [StateMachine(typeof(State), typeof(Trigger))]
+            public partial class GuardMachine
+            {
+                [StateGuard(From = State.A, Trigger = Trigger.T1)]
+                private string BadGuard(int invalidParameter) => "";
+
+                [StateTransition(From = State.A, Trigger = Trigger.T1, To = State.B)]
+                private void Move() { }
+            }
+            """;
+
+        var hookSource = """
+            using PatternKit.Generators.State;
+            namespace PatternKit.Examples;
+            public enum State { A, B }
+            public enum Trigger { T1 }
+            [StateMachine(typeof(State), typeof(Trigger))]
+            public partial class HookMachine
+            {
+                [StateEntry(State.B)]
+                private int BadEntry() => 0;
+
+                [StateTransition(From = State.A, Trigger = Trigger.T1, To = State.B)]
+                private void Move() { }
+            }
+            """;
+
+        AssertDiagnostic(transitionSource, "PKST005", nameof(InvalidTransitionGuardAndHookSignatures_ReportDiagnostics) + "Transition");
+        AssertDiagnostic(guardSource, "PKST006", nameof(InvalidTransitionGuardAndHookSignatures_ReportDiagnostics) + "Guard");
+        AssertDiagnostic(hookSource, "PKST007", nameof(InvalidTransitionGuardAndHookSignatures_ReportDiagnostics) + "Hook");
+
+        static void AssertDiagnostic(string source, string id, string assemblyName)
+        {
+            var comp = RoslynTestHelpers.CreateCompilation(source, assemblyName);
+            var gen = new StateMachineGenerator();
+            _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+            Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == id);
+        }
+    }
+
+    [Fact]
+    public void ForceAsyncWithCustomNamesAndIgnorePolicies_GeneratesNoOpBranches()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.State;
+
+            namespace PatternKit.Examples;
+
+            public enum State { A, B }
+            public enum Trigger { T1, Unknown }
+
+            [StateMachine(
+                typeof(State),
+                typeof(Trigger),
+                FireMethodName = "Move",
+                FireAsyncMethodName = "MoveAsync",
+                CanFireMethodName = "CanMove",
+                ForceAsync = true,
+                InvalidTrigger = StateMachineInvalidTriggerPolicy.Ignore,
+                GuardFailure = StateMachineGuardFailurePolicy.Ignore)]
+            public partial struct Machine
+            {
+                [StateExit(State.A)]
+                private ValueTask LeavingAsync(CancellationToken ct) => ValueTask.CompletedTask;
+
+                [StateEntry(State.B)]
+                private ValueTask EnteringAsync(CancellationToken ct) => ValueTask.CompletedTask;
+
+                [StateGuard(From = State.A, Trigger = Trigger.T1)]
+                private bool CanTransition() => false;
+
+                [StateTransition(From = State.A, Trigger = Trigger.T1, To = State.B)]
+                private void OnTransition(CancellationToken ct) { }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ForceAsyncWithCustomNamesAndIgnorePolicies_GeneratesNoOpBranches));
+        var gen = new StateMachineGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generated = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
+        Assert.Contains("void Move(", generated);
+        Assert.Contains("ValueTask MoveAsync", generated);
+        Assert.Contains("bool CanMove", generated);
+        Assert.Contains("LeavingAsync(cancellationToken).ConfigureAwait(false)", generated);
+        Assert.Contains("EnteringAsync(cancellationToken).ConfigureAwait(false)", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
 }


### PR DESCRIPTION
## Summary
- add generator coverage for facade generics/default async returns, state-machine async/sync cancellation paths, and iterator/flyweight diagnostics
- add example coverage for memento editor edge cases and resilient checkout fallback routes
- fix generated facade generic method constraints/type arguments and state-machine cancellation-token invocation for generated hooks/transitions

## Validation
- dotnet test PatternKit.slnx --configuration Release --no-restore -p:UseSharedCompilation=false