### PR TITLE
test: cover generator helper branches

### DIFF
--- a/src/PatternKit.Generators/ComposerGenerator.cs
+++ b/src/PatternKit.Generators/ComposerGenerator.cs
@@ -581,8 +581,10 @@ public sealed class ComposerGenerator : IIncrementalGenerator
     {
         var inputTypeStr = inputType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var outputTypeStr = outputType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var valueTaskType = ValueTaskType(outputTypeStr);
+        var asyncPipelineType = AsyncPipelineType(inputTypeStr, outputTypeStr);
 
-        sb.AppendLine($"    public global::System.Threading.Tasks.ValueTask<{outputTypeStr}> {config.InvokeAsyncMethodName}({inputTypeStr} input, global::System.Threading.CancellationToken cancellationToken = default)");
+        sb.AppendLine($"    public {valueTaskType} {config.InvokeAsyncMethodName}({inputTypeStr} input, global::System.Threading.CancellationToken cancellationToken = default)");
         sb.AppendLine("    {");
 
         if (isStruct)
@@ -594,22 +596,22 @@ public sealed class ComposerGenerator : IIncrementalGenerator
             // Start with terminal wrapped as a local function using the copy
             if (terminal.IsAsync)
             {
-                if (terminal.Method.Parameters.Length > 1 &&
-                    terminal.Method.Parameters[1].Type.ToDisplayString() == "System.Threading.CancellationToken")
+                if (HasCancellationTokenParameter(terminal.Method, 1))
                 {
-                    sb.AppendLine($"        global::System.Threading.Tasks.ValueTask<{outputTypeStr}> terminalFunc({inputTypeStr} arg) => self.{terminal.Method.Name}(arg, cancellationToken);");
+                    sb.AppendLine($"        {valueTaskType} terminalFunc({inputTypeStr} arg) => {WrapAsyncCallIfNeeded(terminal.Method, outputTypeStr, "self." + terminal.Method.Name + "(arg, cancellationToken)")};");
                 }
                 else
                 {
-                    sb.AppendLine($"        global::System.Threading.Tasks.ValueTask<{outputTypeStr}> terminalFunc({inputTypeStr} arg) => self.{terminal.Method.Name}(arg);");
+                    var call = $"self.{terminal.Method.Name}(arg)";
+                    sb.AppendLine($"        {valueTaskType} terminalFunc({inputTypeStr} arg) => {WrapAsyncCallIfNeeded(terminal.Method, outputTypeStr, call)};");
                 }
             }
             else
             {
-                sb.AppendLine($"        global::System.Threading.Tasks.ValueTask<{outputTypeStr}> terminalFunc({inputTypeStr} arg) => new global::System.Threading.Tasks.ValueTask<{outputTypeStr}>(self.{terminal.Method.Name}(in arg));");
+                sb.AppendLine($"        {valueTaskType} terminalFunc({inputTypeStr} arg) => new {valueTaskType}(self.{terminal.Method.Name}(in arg));");
             }
 
-            sb.AppendLine($"        global::System.Func<{inputTypeStr}, global::System.Threading.Tasks.ValueTask<{outputTypeStr}>> pipeline = terminalFunc;");
+            sb.AppendLine($"        {asyncPipelineType} pipeline = terminalFunc;");
 
             // Wrap each step around the previous pipeline
             for (int i = orderedSteps.Count - 1; i >= 0; i--)
@@ -620,14 +622,15 @@ public sealed class ComposerGenerator : IIncrementalGenerator
                 if (step.IsAsync)
                 {
                     // Check if step has cancellationToken parameter
-                    if (step.Method.Parameters.Length > 2 &&
-                        step.Method.Parameters[2].Type.ToDisplayString() == "System.Threading.CancellationToken")
+                    if (HasCancellationTokenParameter(step.Method, 2))
                     {
-                        sb.AppendLine($"        global::System.Threading.Tasks.ValueTask<{outputTypeStr}> {funcName}({inputTypeStr} arg) => self.{step.Method.Name}(arg, pipeline, cancellationToken);");
+                        var call = $"self.{step.Method.Name}(arg, pipeline, cancellationToken)";
+                        sb.AppendLine($"        {valueTaskType} {funcName}({inputTypeStr} arg) => {WrapAsyncCallIfNeeded(step.Method, outputTypeStr, call)};");
                     }
                     else
                     {
-                        sb.AppendLine($"        global::System.Threading.Tasks.ValueTask<{outputTypeStr}> {funcName}({inputTypeStr} arg) => self.{step.Method.Name}(arg, pipeline);");
+                        var call = $"self.{step.Method.Name}(arg, pipeline)";
+                        sb.AppendLine($"        {valueTaskType} {funcName}({inputTypeStr} arg) => {WrapAsyncCallIfNeeded(step.Method, outputTypeStr, call)};");
                     }
                 }
                 else
@@ -635,7 +638,7 @@ public sealed class ComposerGenerator : IIncrementalGenerator
                     // Wrap sync step to work with async pipeline
                     // WARNING: GetAwaiter().GetResult() can deadlock in certain synchronization contexts (UI thread, ASP.NET pre-Core)
                     // Avoid using mixed sync/async pipelines in contexts with custom SynchronizationContext
-                    sb.AppendLine($"        global::System.Threading.Tasks.ValueTask<{outputTypeStr}> {funcName}({inputTypeStr} arg) => new global::System.Threading.Tasks.ValueTask<{outputTypeStr}>(self.{step.Method.Name}(in arg, inp => pipeline(inp).GetAwaiter().GetResult()));");
+                    sb.AppendLine($"        {valueTaskType} {funcName}({inputTypeStr} arg) => new {valueTaskType}(self.{step.Method.Name}(in arg, inp => pipeline(inp).GetAwaiter().GetResult()));");
                 }
 
                 sb.AppendLine($"        pipeline = {funcName};");
@@ -650,19 +653,20 @@ public sealed class ComposerGenerator : IIncrementalGenerator
             // If terminal is async, use it directly; otherwise wrap in ValueTask.FromResult
             if (terminal.IsAsync)
             {
-                if (terminal.Method.Parameters.Length > 1 &&
-                    terminal.Method.Parameters[1].Type.ToDisplayString() == "System.Threading.CancellationToken")
+                if (HasCancellationTokenParameter(terminal.Method, 1))
                 {
-                    sb.AppendLine($"        global::System.Func<{inputTypeStr}, global::System.Threading.Tasks.ValueTask<{outputTypeStr}>> pipeline = (arg) => {terminal.Method.Name}(arg, cancellationToken);");
+                    var call = $"{terminal.Method.Name}(arg, cancellationToken)";
+                    sb.AppendLine($"        {asyncPipelineType} pipeline = (arg) => {WrapAsyncCallIfNeeded(terminal.Method, outputTypeStr, call)};");
                 }
                 else
                 {
-                    sb.AppendLine($"        global::System.Func<{inputTypeStr}, global::System.Threading.Tasks.ValueTask<{outputTypeStr}>> pipeline = (arg) => {terminal.Method.Name}(arg);");
+                    var call = $"{terminal.Method.Name}(arg)";
+                    sb.AppendLine($"        {asyncPipelineType} pipeline = (arg) => {WrapAsyncCallIfNeeded(terminal.Method, outputTypeStr, call)};");
                 }
             }
             else
             {
-                sb.AppendLine($"        global::System.Func<{inputTypeStr}, global::System.Threading.Tasks.ValueTask<{outputTypeStr}>> pipeline = (arg) => new global::System.Threading.Tasks.ValueTask<{outputTypeStr}>({terminal.Method.Name}(in arg));");
+                sb.AppendLine($"        {asyncPipelineType} pipeline = (arg) => new {valueTaskType}({terminal.Method.Name}(in arg));");
             }
 
             // Wrap each step around the previous pipeline
@@ -673,14 +677,15 @@ public sealed class ComposerGenerator : IIncrementalGenerator
                 if (step.IsAsync)
                 {
                     // Check if step has cancellationToken parameter
-                    if (step.Method.Parameters.Length > 2 &&
-                        step.Method.Parameters[2].Type.ToDisplayString() == "System.Threading.CancellationToken")
+                    if (HasCancellationTokenParameter(step.Method, 2))
                     {
-                        sb.AppendLine($"        pipeline = (arg) => {step.Method.Name}(arg, pipeline, cancellationToken);");
+                        var call = $"{step.Method.Name}(arg, pipeline, cancellationToken)";
+                        sb.AppendLine($"        pipeline = (arg) => {WrapAsyncCallIfNeeded(step.Method, outputTypeStr, call)};");
                     }
                     else
                     {
-                        sb.AppendLine($"        pipeline = (arg) => {step.Method.Name}(arg, pipeline);");
+                        var call = $"{step.Method.Name}(arg, pipeline)";
+                        sb.AppendLine($"        pipeline = (arg) => {WrapAsyncCallIfNeeded(step.Method, outputTypeStr, call)};");
                     }
                 }
                 else
@@ -690,7 +695,7 @@ public sealed class ComposerGenerator : IIncrementalGenerator
                     // Avoid using mixed sync/async pipelines in contexts with custom SynchronizationContext
                     sb.AppendLine($"        {{");
                     sb.AppendLine($"            var prevPipeline = pipeline;");
-                    sb.AppendLine($"            pipeline = (arg) => new global::System.Threading.Tasks.ValueTask<{outputTypeStr}>({step.Method.Name}(in arg, inp => prevPipeline(inp).GetAwaiter().GetResult()));");
+                    sb.AppendLine($"            pipeline = (arg) => new {valueTaskType}({step.Method.Name}(in arg, inp => prevPipeline(inp).GetAwaiter().GetResult()));");
                     sb.AppendLine($"        }}");
                 }
             }
@@ -700,6 +705,34 @@ public sealed class ComposerGenerator : IIncrementalGenerator
         }
 
         sb.AppendLine("    }");
+    }
+
+    private static bool HasCancellationTokenParameter(IMethodSymbol method, int index)
+    {
+        return method.Parameters.Length > index &&
+            method.Parameters[index].Type.ToDisplayString() == "System.Threading.CancellationToken";
+    }
+
+    private static string ValueTaskType(string outputTypeStr)
+    {
+        return $"global::System.Threading.Tasks.ValueTask<{outputTypeStr}>";
+    }
+
+    private static string AsyncPipelineType(string inputTypeStr, string outputTypeStr)
+    {
+        return $"global::System.Func<{inputTypeStr}, {ValueTaskType(outputTypeStr)}>";
+    }
+
+    private static string WrapAsyncCallIfNeeded(IMethodSymbol method, string outputTypeStr, string call)
+    {
+        if (method.ReturnType is INamedTypeSymbol namedType &&
+            namedType.Name == "Task" &&
+            namedType.TypeArguments.Length > 0)
+        {
+            return $"new {ValueTaskType(outputTypeStr)}({call})";
+        }
+
+        return call;
     }
 
     private bool IsAsyncMethod(IMethodSymbol method)

--- a/test/PatternKit.Generators.Tests/ComposerGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ComposerGeneratorTests.cs
@@ -908,4 +908,147 @@ public class ComposerGeneratorTests
         var emit = updated.Emit(Stream.Null);
         Assert.False(emit.Success);
     }
+
+    [Fact]
+    public void InvalidStep_WithTooFewParameters_ReportsDiagnostic()
+    {
+        var source = """
+            using PatternKit.Generators.Composer;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Composer]
+            public partial class RequestPipeline
+            {
+                [ComposeStep(0)]
+                private Response Step(in Request req) => new(200);
+
+                [ComposeTerminal]
+                private Response Terminal(in Request req) => new(200);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(InvalidStep_WithTooFewParameters_ReportsDiagnostic));
+        var gen = new ComposerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diagnostic = Assert.Single(result.Results.SelectMany(r => r.Diagnostics));
+        Assert.Equal("PKCOM006", diagnostic.Id);
+        Assert.Contains("Step", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InvalidTerminal_WithTooManyParameters_ReportsDiagnostic()
+    {
+        var source = """
+            using PatternKit.Generators.Composer;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Composer]
+            public partial class RequestPipeline
+            {
+                [ComposeStep(0)]
+                private Response Step(in Request req, System.Func<Request, Response> next) => next(req);
+
+                [ComposeTerminal]
+                private Response Terminal(in Request req, int extra, string other) => new(200);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(InvalidTerminal_WithTooManyParameters_ReportsDiagnostic));
+        var gen = new ComposerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
+
+        var diagnostic = Assert.Single(result.Results.SelectMany(r => r.Diagnostics));
+        Assert.Equal("PKCOM007", diagnostic.Id);
+        Assert.Contains("Terminal", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TaskBasedAsyncPipeline_CustomAsyncName_GeneratesTaskUnwrapAndNoCancellationTokenCalls()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Composer;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Composer(InvokeAsyncMethodName = "ExecuteAsync")]
+            public partial class RequestPipeline
+            {
+                [ComposeStep(2, Name = "Second")]
+                private Task<Response> SecondAsync(Request req, Func<Request, ValueTask<Response>> next)
+                    => next(req).AsTask();
+
+                [ComposeStep(1)]
+                private Response First(in Request req, Func<Request, Response> next)
+                    => next(req);
+
+                [ComposeTerminal]
+                private Task<Response> TerminalAsync(Request req)
+                    => Task.FromResult(new Response(200));
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(TaskBasedAsyncPipeline_CustomAsyncName_GeneratesTaskUnwrapAndNoCancellationTokenCalls));
+        var gen = new ComposerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generatedSource = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
+        Assert.Contains("ExecuteAsync", generatedSource);
+        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(TerminalAsync(arg))", generatedSource);
+        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(SecondAsync(arg, pipeline))", generatedSource);
+        Assert.Contains("First(in arg, inp => prevPipeline(inp).GetAwaiter().GetResult())", generatedSource);
+        Assert.DoesNotContain("namespace ", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void StructTaskBasedAsyncPipeline_WithCancellationToken_WrapsTaskCalls()
+    {
+        var source = """
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Composer;
+
+            public readonly record struct Request(string Path);
+            public readonly record struct Response(int Status);
+
+            [Composer(InvokeAsyncMethodName = "ExecuteAsync")]
+            public partial struct RequestPipeline
+            {
+                [ComposeStep(0)]
+                private Task<Response> StepAsync(Request req, Func<Request, ValueTask<Response>> next, CancellationToken ct)
+                    => next(req).AsTask();
+
+                [ComposeTerminal]
+                private Task<Response> TerminalAsync(Request req, CancellationToken ct)
+                    => Task.FromResult(new Response(200));
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(StructTaskBasedAsyncPipeline_WithCancellationToken_WrapsTaskCalls));
+        var gen = new ComposerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+
+        var generatedSource = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
+        Assert.Contains("var self = this;", generatedSource);
+        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(self.TerminalAsync(arg, cancellationToken))", generatedSource);
+        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(self.StepAsync(arg, pipeline, cancellationToken))", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
 }

--- a/test/PatternKit.Generators.Tests/FactoriesGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/FactoriesGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Loader;
+using Microsoft.CodeAnalysis;
 using PatternKit.Generators.Factories;
 
 namespace PatternKit.Generators.Tests;
@@ -745,5 +746,118 @@ public class FactoriesGeneratorTests
 
         var emit = updated.Emit(Stream.Null);
         Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Fact]
+    public void InternalHelpers_FormatKeysAsyncReturnsAndArguments()
+    {
+        const string user = """
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Factories;
+
+            namespace Demo;
+
+            public enum Channel { Email = 1, Sms = 2 }
+            public interface IMessage { }
+            public abstract class MessageBase : IMessage { }
+            public sealed class EmailMessage : MessageBase { }
+            public sealed class Other { }
+
+            public static class KeySamples
+            {
+                [FactoryCase("hello-world")]
+                public static string StringKey() => "";
+
+                [FactoryCase(true)]
+                public static string BoolKey() => "";
+
+                [FactoryCase(42)]
+                public static string NumberKey() => "";
+
+                [FactoryCase(Channel.Email)]
+                public static string EnumKey() => "";
+            }
+
+            public static class SignatureSamples
+            {
+                public static Task<string> TaskResult(ref int count, in string name, out bool ok)
+                {
+                    ok = true;
+                    return Task.FromResult(name + count);
+                }
+            }
+            """;
+
+        var compilation = RoslynTestHelpers.CreateCompilation(user, nameof(InternalHelpers_FormatKeysAsyncReturnsAndArguments));
+        var keySamples = compilation.GetTypeByMetadataName("Demo.KeySamples")!;
+        var signatureSamples = compilation.GetTypeByMetadataName("Demo.SignatureSamples")!;
+        var message = compilation.GetTypeByMetadataName("Demo.IMessage")!;
+        var messageBase = compilation.GetTypeByMetadataName("Demo.MessageBase")!;
+        var email = compilation.GetTypeByMetadataName("Demo.EmailMessage")!;
+        var other = compilation.GetTypeByMetadataName("Demo.Other")!;
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        var boolType = compilation.GetSpecialType(SpecialType.System_Boolean);
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+
+        var constants = keySamples.GetMembers().OfType<IMethodSymbol>()
+            .ToDictionary(
+                static method => method.Name,
+                static method => method.GetAttributes().Single().ConstructorArguments.Single());
+
+        Assert.Equal("\"hello-world\"", InvokeFactoryHelper<string>("ToLiteral", constants["StringKey"]));
+        Assert.Equal("true", InvokeFactoryHelper<string>("ToLiteral", constants["BoolKey"]));
+        Assert.Equal("42", InvokeFactoryHelper<string>("ToLiteral", constants["NumberKey"]));
+        Assert.Equal("global::Demo.Channel.Email", InvokeFactoryHelper<string>("ToLiteral", constants["EnumKey"]));
+
+        Assert.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, stringType, constants["StringKey"]));
+        Assert.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, boolType, constants["BoolKey"]));
+        Assert.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, intType, constants["NumberKey"]));
+        Assert.False(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, stringType, constants["NumberKey"]));
+        Assert.True(InvokeFactoryHelper<bool>("NeedsNullCheck", stringType));
+        Assert.False(InvokeFactoryHelper<bool>("NeedsNullCheck", intType));
+        Assert.True(InvokeFactoryHelper<bool>("IsStringType", stringType));
+
+        var existing = new HashSet<string>(StringComparer.Ordinal);
+        Assert.Equal("HelloWorld", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["StringKey"], stringType, existing));
+        Assert.Equal("True", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["BoolKey"], boolType, existing));
+        Assert.Equal("Key42", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["NumberKey"], intType, existing));
+        Assert.Equal("Email", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["EnumKey"], constants["EnumKey"].Type!, existing));
+        Assert.Equal("HelloWorld2", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["StringKey"], stringType, existing));
+
+        Assert.True(InvokeFactoryHelper<bool>("Implements", email, message));
+        Assert.True(InvokeFactoryHelper<bool>("Implements", email, messageBase));
+        Assert.False(InvokeFactoryHelper<bool>("Implements", other, message));
+        Assert.Equal("MessageFactory", InvokeFactoryHelper<string>("BuildDefaultFactoryName", message));
+        Assert.Equal("MessageBaseFactory", InvokeFactoryHelper<string>("BuildDefaultFactoryName", messageBase));
+
+        var taskMethod = (IMethodSymbol)signatureSamples.GetMembers("TaskResult").Single();
+        var taskSignature = InvokeFactoryHelper<object>("BuildSignature", taskMethod, compilation);
+        var parameterArray = (System.Collections.Immutable.ImmutableArray<IParameterSymbol>)taskSignature.GetType().GetProperty("Parameters")!.GetValue(taskSignature)!;
+        Assert.Contains("ref int count", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
+        Assert.Contains("in string name", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
+        Assert.Contains("out bool ok", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
+        Assert.Equal("ref count, in name, out ok", InvokeFactoryHelper<string>("BuildArgumentList", parameterArray));
+
+        var asyncKindType = typeof(FactoriesGenerator).GetNestedType("AsyncKind", System.Reflection.BindingFlags.NonPublic)!;
+        var sync = Enum.Parse(asyncKindType, "Sync");
+        var task = Enum.Parse(asyncKindType, "Task");
+        var valueTask = Enum.Parse(asyncKindType, "ValueTask");
+        Assert.Equal("return invocation();", InvokeFactoryHelper<string>("BuildAsyncReturn", valueTask, "string", "invocation()"));
+        Assert.Equal("return new global::System.Threading.Tasks.ValueTask<string>(invocation());", InvokeFactoryHelper<string>("BuildAsyncReturn", task, "string", "invocation()"));
+        Assert.Equal("return global::System.Threading.Tasks.ValueTask.FromResult<string>(invocation());", InvokeFactoryHelper<string>("BuildAsyncReturn", sync, "string", "invocation()"));
+        Assert.Equal("invocation()", InvokeFactoryHelper<string>("BuildSyncValue", sync, "invocation()"));
+        Assert.Equal("invocation().GetAwaiter().GetResult()", InvokeFactoryHelper<string>("BuildSyncValue", task, "invocation()"));
+        Assert.Equal("invocation()", InvokeFactoryHelper<string>("BuildAwaitedValue", sync, "invocation()"));
+        Assert.Equal("await invocation()", InvokeFactoryHelper<string>("BuildAwaitedValue", valueTask, "invocation()"));
+    }
+
+    private static T InvokeFactoryHelper<T>(string name, params object?[] args)
+    {
+        var method = typeof(FactoriesGenerator)
+            .GetMethods(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            .Where(m => m.Name == name && m.GetParameters().Length == args.Length)
+            .Single();
+
+        return (T)method.Invoke(null, args)!;
     }
 }


### PR DESCRIPTION
## Summary
- add generator helper coverage for factory key/literal/async-return/ref argument branches
- add Composer diagnostics and Task<T> async pipeline coverage
- fix Composer Task<T> async step/terminal generation by wrapping Task<T> calls in ValueTask<T>

## Validation
- dotnet test test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:UseSharedCompilation=false

Note: a full local solution test hit the 10-minute timeout after stale build/compiler server buildup; build servers were shut down and the touched generator test project passes cleanly.