### PR TITLE
test: convert tests to TinyBDD scenarios

### DIFF
--- a/test/PatternKit.Examples.Tests/AbstractFactoryDemo/AbstractFactoryDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/AbstractFactoryDemo/AbstractFactoryDemoTests.cs
@@ -1,60 +1,66 @@
 using PatternKit.Examples.AbstractFactoryDemo;
 using static PatternKit.Examples.AbstractFactoryDemo.AbstractFactoryDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.AbstractFactoryDemoTests;
 
 public sealed class AbstractFactoryDemoTests
 {
+    [Scenario("CreateUIFactory Creates All Platform Families")]
     [Fact]
     public void CreateUIFactory_Creates_All_Platform_Families()
     {
         var factory = CreateUIFactory();
 
-        Assert.True(factory.TryGetFamily(Platform.Windows, out var winFamily));
-        Assert.True(factory.TryGetFamily(Platform.MacOS, out var macFamily));
-        Assert.True(factory.TryGetFamily(Platform.Linux, out var linuxFamily));
+        ScenarioExpect.True(factory.TryGetFamily(Platform.Windows, out var winFamily));
+        ScenarioExpect.True(factory.TryGetFamily(Platform.MacOS, out var macFamily));
+        ScenarioExpect.True(factory.TryGetFamily(Platform.Linux, out var linuxFamily));
 
-        Assert.NotNull(winFamily);
-        Assert.NotNull(macFamily);
-        Assert.NotNull(linuxFamily);
+        ScenarioExpect.NotNull(winFamily);
+        ScenarioExpect.NotNull(macFamily);
+        ScenarioExpect.NotNull(linuxFamily);
     }
 
+    [Scenario("Windows Family Creates All Widget Types")]
     [Fact]
     public void Windows_Family_Creates_All_Widget_Types()
     {
         var factory = CreateUIFactory();
         var family = factory.GetFamily(Platform.Windows);
 
-        Assert.True(family.CanCreate<IButton>());
-        Assert.True(family.CanCreate<ITextBox>());
-        Assert.True(family.CanCreate<ICheckBox>());
-        Assert.True(family.CanCreate<IDialog>());
+        ScenarioExpect.True(family.CanCreate<IButton>());
+        ScenarioExpect.True(family.CanCreate<ITextBox>());
+        ScenarioExpect.True(family.CanCreate<ICheckBox>());
+        ScenarioExpect.True(family.CanCreate<IDialog>());
     }
 
+    [Scenario("MacOS Family Creates All Widget Types")]
     [Fact]
     public void MacOS_Family_Creates_All_Widget_Types()
     {
         var factory = CreateUIFactory();
         var family = factory.GetFamily(Platform.MacOS);
 
-        Assert.True(family.CanCreate<IButton>());
-        Assert.True(family.CanCreate<ITextBox>());
-        Assert.True(family.CanCreate<ICheckBox>());
-        Assert.True(family.CanCreate<IDialog>());
+        ScenarioExpect.True(family.CanCreate<IButton>());
+        ScenarioExpect.True(family.CanCreate<ITextBox>());
+        ScenarioExpect.True(family.CanCreate<ICheckBox>());
+        ScenarioExpect.True(family.CanCreate<IDialog>());
     }
 
+    [Scenario("Linux Family Creates All Widget Types")]
     [Fact]
     public void Linux_Family_Creates_All_Widget_Types()
     {
         var factory = CreateUIFactory();
         var family = factory.GetFamily(Platform.Linux);
 
-        Assert.True(family.CanCreate<IButton>());
-        Assert.True(family.CanCreate<ITextBox>());
-        Assert.True(family.CanCreate<ICheckBox>());
-        Assert.True(family.CanCreate<IDialog>());
+        ScenarioExpect.True(family.CanCreate<IButton>());
+        ScenarioExpect.True(family.CanCreate<ITextBox>());
+        ScenarioExpect.True(family.CanCreate<ICheckBox>());
+        ScenarioExpect.True(family.CanCreate<IDialog>());
     }
 
+    [Scenario("WindowsButton Renders And Clicks")]
     [Fact]
     public void WindowsButton_Renders_And_Clicks()
     {
@@ -62,9 +68,10 @@ public sealed class AbstractFactoryDemoTests
 
         var render = button.Render();
 
-        Assert.Contains("Windows Button", render);
+        ScenarioExpect.Contains("Windows Button", render);
     }
 
+    [Scenario("WindowsTextBox SetText And GetText")]
     [Fact]
     public void WindowsTextBox_SetText_And_GetText()
     {
@@ -74,21 +81,23 @@ public sealed class AbstractFactoryDemoTests
         var text = textBox.GetText();
         var render = textBox.Render();
 
-        Assert.Equal("Hello", text);
-        Assert.Contains("Hello", render);
+        ScenarioExpect.Equal("Hello", text);
+        ScenarioExpect.Contains("Hello", render);
     }
 
+    [Scenario("WindowsCheckBox Toggle Changes State")]
     [Fact]
     public void WindowsCheckBox_Toggle_Changes_State()
     {
         var checkBox = new WindowsCheckBox();
 
-        Assert.False(checkBox.IsChecked);
+        ScenarioExpect.False(checkBox.IsChecked);
         checkBox.Toggle();
-        Assert.True(checkBox.IsChecked);
-        Assert.Contains("[X]", checkBox.Render());
+        ScenarioExpect.True(checkBox.IsChecked);
+        ScenarioExpect.Contains("[X]", checkBox.Render());
     }
 
+    [Scenario("MacButton Renders And Clicks")]
     [Fact]
     public void MacButton_Renders_And_Clicks()
     {
@@ -96,9 +105,10 @@ public sealed class AbstractFactoryDemoTests
 
         var render = button.Render();
 
-        Assert.Contains("macOS Button", render);
+        ScenarioExpect.Contains("macOS Button", render);
     }
 
+    [Scenario("MacTextBox SetText And GetText")]
     [Fact]
     public void MacTextBox_SetText_And_GetText()
     {
@@ -107,23 +117,25 @@ public sealed class AbstractFactoryDemoTests
         textBox.SetText("World");
         var render = textBox.Render();
 
-        Assert.Contains("World", render);
-        Assert.Contains("NSTextField", render);
+        ScenarioExpect.Contains("World", render);
+        ScenarioExpect.Contains("NSTextField", render);
     }
 
+    [Scenario("MacCheckBox Toggle Changes State")]
     [Fact]
     public void MacCheckBox_Toggle_Changes_State()
     {
         var checkBox = new MacCheckBox();
 
-        Assert.False(checkBox.IsChecked);
-        Assert.Contains("○", checkBox.Render());
+        ScenarioExpect.False(checkBox.IsChecked);
+        ScenarioExpect.Contains("○", checkBox.Render());
 
         checkBox.Toggle();
-        Assert.True(checkBox.IsChecked);
-        Assert.Contains("◉", checkBox.Render());
+        ScenarioExpect.True(checkBox.IsChecked);
+        ScenarioExpect.Contains("◉", checkBox.Render());
     }
 
+    [Scenario("LinuxButton Renders And Clicks")]
     [Fact]
     public void LinuxButton_Renders_And_Clicks()
     {
@@ -131,9 +143,10 @@ public sealed class AbstractFactoryDemoTests
 
         var render = button.Render();
 
-        Assert.Contains("GTK Button", render);
+        ScenarioExpect.Contains("GTK Button", render);
     }
 
+    [Scenario("LinuxTextBox SetText And GetText")]
     [Fact]
     public void LinuxTextBox_SetText_And_GetText()
     {
@@ -142,21 +155,23 @@ public sealed class AbstractFactoryDemoTests
         textBox.SetText("GTK Text");
         var render = textBox.Render();
 
-        Assert.Contains("GTK Text", render);
-        Assert.Contains("GtkEntry", render);
+        ScenarioExpect.Contains("GTK Text", render);
+        ScenarioExpect.Contains("GtkEntry", render);
     }
 
+    [Scenario("LinuxCheckBox Toggle Changes State")]
     [Fact]
     public void LinuxCheckBox_Toggle_Changes_State()
     {
         var checkBox = new LinuxCheckBox();
 
-        Assert.False(checkBox.IsChecked);
+        ScenarioExpect.False(checkBox.IsChecked);
         checkBox.Toggle();
-        Assert.True(checkBox.IsChecked);
-        Assert.Contains("[✓]", checkBox.Render());
+        ScenarioExpect.True(checkBox.IsChecked);
+        ScenarioExpect.Contains("[✓]", checkBox.Render());
     }
 
+    [Scenario("WindowsDialog Renders")]
     [Fact]
     public void WindowsDialog_Renders()
     {
@@ -164,9 +179,10 @@ public sealed class AbstractFactoryDemoTests
 
         var render = dialog.Render();
 
-        Assert.Contains("Windows Dialog", render);
+        ScenarioExpect.Contains("Windows Dialog", render);
     }
 
+    [Scenario("MacDialog Renders")]
     [Fact]
     public void MacDialog_Renders()
     {
@@ -174,9 +190,10 @@ public sealed class AbstractFactoryDemoTests
 
         var render = dialog.Render();
 
-        Assert.Contains("macOS Sheet", render);
+        ScenarioExpect.Contains("macOS Sheet", render);
     }
 
+    [Scenario("LinuxDialog Renders")]
     [Fact]
     public void LinuxDialog_Renders()
     {
@@ -184,19 +201,21 @@ public sealed class AbstractFactoryDemoTests
 
         var render = dialog.Render();
 
-        Assert.Contains("GTK Dialog", render);
+        ScenarioExpect.Contains("GTK Dialog", render);
     }
 
+    [Scenario("DetectPlatform Returns Valid Platform")]
     [Fact]
     public void DetectPlatform_Returns_Valid_Platform()
     {
         var platform = DetectPlatform();
 
-        Assert.True(platform == Platform.Windows ||
+        ScenarioExpect.True(platform == Platform.Windows ||
                     platform == Platform.MacOS ||
                     platform == Platform.Linux);
     }
 
+    [Scenario("RenderLoginForm Does Not Throw")]
     [Fact]
     public void RenderLoginForm_Does_Not_Throw()
     {
@@ -207,6 +226,7 @@ public sealed class AbstractFactoryDemoTests
         RenderLoginForm(widgets);
     }
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/AdapterGeneratorDemo/AdapterGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/AdapterGeneratorDemo/AdapterGeneratorDemoTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Examples.AdapterGeneratorDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.AdapterGeneratorDemo;
 
@@ -8,6 +9,7 @@ public class AdapterGeneratorDemoTests
     // Clock Adapter Tests
     // =========================================================================
 
+    [Scenario("ClockAdapter ImplementsIClock")]
     [Fact]
     public void ClockAdapter_ImplementsIClock()
     {
@@ -17,10 +19,11 @@ public class AdapterGeneratorDemoTests
         // Act
         IClock clock = new SystemClockAdapter(legacyClock);
 
-        // Assert - the adapter implements the interface
-        Assert.NotNull(clock);
+        // Then - the adapter implements the interface
+        ScenarioExpect.NotNull(clock);
     }
 
+    [Scenario("ClockAdapter UtcNow DelegatesToLegacyClock")]
     [Fact]
     public void ClockAdapter_UtcNow_DelegatesToLegacyClock()
     {
@@ -33,10 +36,11 @@ public class AdapterGeneratorDemoTests
         var result = clock.UtcNow;
         var after = DateTimeOffset.UtcNow;
 
-        // Assert
-        Assert.InRange(result, before, after);
+        // Then
+        ScenarioExpect.InRange(result, before, after);
     }
 
+    [Scenario("ClockAdapter LocalNow DelegatesToLegacyClock")]
     [Fact]
     public void ClockAdapter_LocalNow_DelegatesToLegacyClock()
     {
@@ -49,10 +53,11 @@ public class AdapterGeneratorDemoTests
         var result = clock.LocalNow;
         var after = DateTimeOffset.Now;
 
-        // Assert
-        Assert.InRange(result, before, after);
+        // Then
+        ScenarioExpect.InRange(result, before, after);
     }
 
+    [Scenario("ClockAdapter UnixTimestamp ReturnsValidTimestamp")]
     [Fact]
     public void ClockAdapter_UnixTimestamp_ReturnsValidTimestamp()
     {
@@ -65,10 +70,11 @@ public class AdapterGeneratorDemoTests
         var result = clock.UnixTimestamp;
         var after = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-        // Assert
-        Assert.InRange(result, before, after);
+        // Then
+        ScenarioExpect.InRange(result, before, after);
     }
 
+    [Scenario("ClockAdapter DelayAsync Delays")]
     [Fact]
     public async Task ClockAdapter_DelayAsync_Delays()
     {
@@ -81,21 +87,23 @@ public class AdapterGeneratorDemoTests
         await clock.DelayAsync(TimeSpan.FromMilliseconds(100));
         sw.Stop();
 
-        // Assert - should have delayed at least 50ms (allowing for scheduler jitter on loaded CI)
-        Assert.True(sw.ElapsedMilliseconds >= 50);
+        // Then - should have delayed at least 50ms (allowing for scheduler jitter on loaded CI)
+        ScenarioExpect.True(sw.ElapsedMilliseconds >= 50);
     }
 
+    [Scenario("ClockAdapter ThrowsOnNullAdaptee")]
     [Fact]
     public void ClockAdapter_ThrowsOnNullAdaptee()
     {
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new SystemClockAdapter(null!));
+        // Act and verify
+        ScenarioExpect.Throws<ArgumentNullException>(() => new SystemClockAdapter(null!));
     }
 
     // =========================================================================
     // Payment Adapter Tests
     // =========================================================================
 
+    [Scenario("StripeAdapter ImplementsIPaymentGateway")]
     [Fact]
     public void StripeAdapter_ImplementsIPaymentGateway()
     {
@@ -105,10 +113,11 @@ public class AdapterGeneratorDemoTests
         // Act
         IPaymentGateway gateway = new StripePaymentAdapter(stripeClient);
 
-        // Assert
-        Assert.NotNull(gateway);
+        // Then
+        ScenarioExpect.NotNull(gateway);
     }
 
+    [Scenario("StripeAdapter GatewayName ReturnsStripe")]
     [Fact]
     public void StripeAdapter_GatewayName_ReturnsStripe()
     {
@@ -119,10 +128,11 @@ public class AdapterGeneratorDemoTests
         // Act
         var name = gateway.GatewayName;
 
-        // Assert
-        Assert.Equal("Stripe", name);
+        // Then
+        ScenarioExpect.Equal("Stripe", name);
     }
 
+    [Scenario("StripeAdapter ChargeAsync ReturnsSuccessfulResult")]
     [Fact]
     public async Task StripeAdapter_ChargeAsync_ReturnsSuccessfulResult()
     {
@@ -133,12 +143,13 @@ public class AdapterGeneratorDemoTests
         // Act
         var result = await gateway.ChargeAsync("tok_visa", 99.99m, "USD");
 
-        // Assert
-        Assert.True(result.Success);
-        Assert.StartsWith("ch_", result.TransactionId);
-        Assert.Null(result.ErrorMessage);
+        // Then
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.StartsWith("ch_", result.TransactionId);
+        ScenarioExpect.Null(result.ErrorMessage);
     }
 
+    [Scenario("StripeAdapter RefundAsync ReturnsSuccessfulResult")]
     [Fact]
     public async Task StripeAdapter_RefundAsync_ReturnsSuccessfulResult()
     {
@@ -149,12 +160,13 @@ public class AdapterGeneratorDemoTests
         // Act
         var result = await gateway.RefundAsync("ch_123", 50.00m);
 
-        // Assert
-        Assert.True(result.Success);
-        Assert.StartsWith("re_", result.RefundId);
-        Assert.Null(result.ErrorMessage);
+        // Then
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.StartsWith("re_", result.RefundId);
+        ScenarioExpect.Null(result.ErrorMessage);
     }
 
+    [Scenario("PayPalAdapter ImplementsIPaymentGateway")]
     [Fact]
     public void PayPalAdapter_ImplementsIPaymentGateway()
     {
@@ -164,10 +176,11 @@ public class AdapterGeneratorDemoTests
         // Act
         IPaymentGateway gateway = new PayPalPaymentAdapter(paypalService);
 
-        // Assert
-        Assert.NotNull(gateway);
+        // Then
+        ScenarioExpect.NotNull(gateway);
     }
 
+    [Scenario("PayPalAdapter GatewayName ReturnsPayPal")]
     [Fact]
     public void PayPalAdapter_GatewayName_ReturnsPayPal()
     {
@@ -178,10 +191,11 @@ public class AdapterGeneratorDemoTests
         // Act
         var name = gateway.GatewayName;
 
-        // Assert
-        Assert.Equal("PayPal", name);
+        // Then
+        ScenarioExpect.Equal("PayPal", name);
     }
 
+    [Scenario("PayPalAdapter ChargeAsync ReturnsSuccessfulResult")]
     [Fact]
     public async Task PayPalAdapter_ChargeAsync_ReturnsSuccessfulResult()
     {
@@ -192,12 +206,13 @@ public class AdapterGeneratorDemoTests
         // Act
         var result = await gateway.ChargeAsync("token_123", 149.99m, "USD");
 
-        // Assert
-        Assert.True(result.Success);
-        Assert.StartsWith("PAY-", result.TransactionId);
-        Assert.Null(result.ErrorMessage);
+        // Then
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.StartsWith("PAY-", result.TransactionId);
+        ScenarioExpect.Null(result.ErrorMessage);
     }
 
+    [Scenario("PayPalAdapter RefundAsync ReturnsSuccessfulResult")]
     [Fact]
     public async Task PayPalAdapter_RefundAsync_ReturnsSuccessfulResult()
     {
@@ -208,12 +223,13 @@ public class AdapterGeneratorDemoTests
         // Act
         var result = await gateway.RefundAsync("PAY-123", 75.00m);
 
-        // Assert
-        Assert.True(result.Success);
-        Assert.StartsWith("REF-", result.RefundId);
-        Assert.Null(result.ErrorMessage);
+        // Then
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.StartsWith("REF-", result.RefundId);
+        ScenarioExpect.Null(result.ErrorMessage);
     }
 
+    [Scenario("MultiplePaymentAdapters AreInterchangeable")]
     [Fact]
     public async Task MultiplePaymentAdapters_AreInterchangeable()
     {
@@ -225,16 +241,17 @@ public class AdapterGeneratorDemoTests
         var stripeResult = await stripeGateway.ChargeAsync("tok_1", 100m, "USD");
         var paypalResult = await paypalGateway.ChargeAsync("tok_2", 100m, "USD");
 
-        // Assert - both work through the unified interface
-        Assert.True(stripeResult.Success);
-        Assert.True(paypalResult.Success);
-        Assert.NotEqual(stripeResult.TransactionId, paypalResult.TransactionId);
+        // Then - both work through the unified interface
+        ScenarioExpect.True(stripeResult.Success);
+        ScenarioExpect.True(paypalResult.Success);
+        ScenarioExpect.NotEqual(stripeResult.TransactionId, paypalResult.TransactionId);
     }
 
     // =========================================================================
     // Logger Adapter Tests
     // =========================================================================
 
+    [Scenario("LoggerAdapter ImplementsIStructuredLogger")]
     [Fact]
     public void LoggerAdapter_ImplementsIStructuredLogger()
     {
@@ -244,10 +261,11 @@ public class AdapterGeneratorDemoTests
         // Act
         IStructuredLogger logger = new ConsoleLoggerAdapter(legacyLogger);
 
-        // Assert
-        Assert.NotNull(logger);
+        // Then
+        ScenarioExpect.NotNull(logger);
     }
 
+    [Scenario("LoggerAdapter IsEnabled RespectsMinimumLevel")]
     [Fact]
     public void LoggerAdapter_IsEnabled_RespectsMinimumLevel()
     {
@@ -255,13 +273,14 @@ public class AdapterGeneratorDemoTests
         var legacyLogger = new LegacyConsoleLogger("TEST", minimumLevel: 2);
         IStructuredLogger logger = new ConsoleLoggerAdapter(legacyLogger);
 
-        // Act & Assert
-        Assert.False(logger.IsEnabled(LogLevel.Debug));
-        Assert.False(logger.IsEnabled(LogLevel.Info));
-        Assert.True(logger.IsEnabled(LogLevel.Warning));
-        Assert.True(logger.IsEnabled(LogLevel.Error));
+        // Act and verify
+        ScenarioExpect.False(logger.IsEnabled(LogLevel.Debug));
+        ScenarioExpect.False(logger.IsEnabled(LogLevel.Info));
+        ScenarioExpect.True(logger.IsEnabled(LogLevel.Warning));
+        ScenarioExpect.True(logger.IsEnabled(LogLevel.Error));
     }
 
+    [Scenario("LoggerAdapter IsEnabled AllLevelsWhenMinimumIsDebug")]
     [Fact]
     public void LoggerAdapter_IsEnabled_AllLevelsWhenMinimumIsDebug()
     {
@@ -269,13 +288,14 @@ public class AdapterGeneratorDemoTests
         var legacyLogger = new LegacyConsoleLogger("TEST", minimumLevel: 0);
         IStructuredLogger logger = new ConsoleLoggerAdapter(legacyLogger);
 
-        // Act & Assert
-        Assert.True(logger.IsEnabled(LogLevel.Debug));
-        Assert.True(logger.IsEnabled(LogLevel.Info));
-        Assert.True(logger.IsEnabled(LogLevel.Warning));
-        Assert.True(logger.IsEnabled(LogLevel.Error));
+        // Act and verify
+        ScenarioExpect.True(logger.IsEnabled(LogLevel.Debug));
+        ScenarioExpect.True(logger.IsEnabled(LogLevel.Info));
+        ScenarioExpect.True(logger.IsEnabled(LogLevel.Warning));
+        ScenarioExpect.True(logger.IsEnabled(LogLevel.Error));
     }
 
+    [Scenario("LoggerAdapter LogMethods DoNotThrow")]
     [Fact]
     public void LoggerAdapter_LogMethods_DoNotThrow()
     {
@@ -283,7 +303,7 @@ public class AdapterGeneratorDemoTests
         var legacyLogger = new LegacyConsoleLogger("TEST");
         IStructuredLogger logger = new ConsoleLoggerAdapter(legacyLogger);
 
-        // Act & Assert - none should throw
+        // Act and verify - none should throw
         var ex = Record.Exception(() =>
         {
             logger.LogDebug("Debug message");
@@ -293,13 +313,14 @@ public class AdapterGeneratorDemoTests
             logger.LogError("Error with exception", new InvalidOperationException("Test"));
         });
 
-        Assert.Null(ex);
+        ScenarioExpect.Null(ex);
     }
 
+    [Scenario("LoggerAdapter ThrowsOnNullAdaptee")]
     [Fact]
     public void LoggerAdapter_ThrowsOnNullAdaptee()
     {
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new ConsoleLoggerAdapter(null!));
+        // Act and verify
+        ScenarioExpect.Throws<ArgumentNullException>(() => new ConsoleLoggerAdapter(null!));
     }
 }

--- a/test/PatternKit.Examples.Tests/ApiGateway/ApiGatewayTests.cs
+++ b/test/PatternKit.Examples.Tests/ApiGateway/ApiGatewayTests.cs
@@ -22,7 +22,7 @@ public sealed class ApiGatewayTests(ITestOutputHelper output) : TinyBddXunitBase
 
     private static MiniRouter DefaultRouter()
         => MiniRouter.Create()
-            // middleware: first match wins (side effects only — not asserted here)
+            // middleware: first match wins (side effects only — not verified here)
             .Use(
                 static (in r) => r.Headers.ContainsKey("X-Request-Id"),
                 static (in r) => Console.WriteLine($"reqid={r.Headers["X-Request-Id"]}"))

--- a/test/PatternKit.Examples.Tests/BridgeDemo/BridgeDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/BridgeDemo/BridgeDemoTests.cs
@@ -1,44 +1,48 @@
 using PatternKit.Examples.BridgeDemo;
 using static PatternKit.Examples.BridgeDemo.BridgeDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.BridgeDemoTests;
 
 public sealed class BridgeDemoTests
 {
+    [Scenario("EmailChannel Connect And Send")]
     [Fact]
     public void EmailChannel_Connect_And_Send()
     {
         var channel = new EmailChannel();
 
-        Assert.Equal("Email (SMTP)", channel.Name);
-        Assert.False(channel.IsAvailable);
-        Assert.Equal(50000, channel.MaxMessageLength);
+        ScenarioExpect.Equal("Email (SMTP)", channel.Name);
+        ScenarioExpect.False(channel.IsAvailable);
+        ScenarioExpect.Equal(50000, channel.MaxMessageLength);
 
         channel.Connect();
-        Assert.True(channel.IsAvailable);
+        ScenarioExpect.True(channel.IsAvailable);
 
         var result = channel.Send("test@example.com", "Subject", "Body");
-        Assert.True(result);
+        ScenarioExpect.True(result);
 
         channel.Disconnect();
-        Assert.False(channel.IsAvailable);
+        ScenarioExpect.False(channel.IsAvailable);
     }
 
+    [Scenario("SmsChannel Connect And Send")]
     [Fact]
     public void SmsChannel_Connect_And_Send()
     {
         var channel = new SmsChannel();
 
-        Assert.Equal("SMS (Twilio)", channel.Name);
-        Assert.Equal(160, channel.MaxMessageLength);
+        ScenarioExpect.Equal("SMS (Twilio)", channel.Name);
+        ScenarioExpect.Equal(160, channel.MaxMessageLength);
 
         channel.Connect();
-        Assert.True(channel.IsAvailable);
+        ScenarioExpect.True(channel.IsAvailable);
 
         var result = channel.Send("+1555123456", "Alert", "Short message");
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 
+    [Scenario("SmsChannel Truncates Long Messages")]
     [Fact]
     public void SmsChannel_Truncates_Long_Messages()
     {
@@ -47,42 +51,45 @@ public sealed class BridgeDemoTests
 
         var longMessage = new string('x', 200);
         var result = channel.Send("+1555123456", "Test", longMessage);
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 
+    [Scenario("PushNotificationChannel Connect And Send")]
     [Fact]
     public void PushNotificationChannel_Connect_And_Send()
     {
         var channel = new PushNotificationChannel();
 
-        Assert.Equal("Push (Firebase)", channel.Name);
-        Assert.Equal(4096, channel.MaxMessageLength);
+        ScenarioExpect.Equal("Push (Firebase)", channel.Name);
+        ScenarioExpect.Equal(4096, channel.MaxMessageLength);
 
         channel.Connect();
-        Assert.True(channel.IsAvailable);
+        ScenarioExpect.True(channel.IsAvailable);
 
         var result = channel.Send("device123", "Push Title", "Push body message here");
-        Assert.True(result);
+        ScenarioExpect.True(result);
 
         channel.Disconnect();
-        Assert.False(channel.IsAvailable);
+        ScenarioExpect.False(channel.IsAvailable);
     }
 
+    [Scenario("SlackChannel Connect And Send")]
     [Fact]
     public void SlackChannel_Connect_And_Send()
     {
         var channel = new SlackChannel();
 
-        Assert.Equal("Slack (Webhook)", channel.Name);
-        Assert.Equal(40000, channel.MaxMessageLength);
+        ScenarioExpect.Equal("Slack (Webhook)", channel.Name);
+        ScenarioExpect.Equal(40000, channel.MaxMessageLength);
 
         channel.Connect();
-        Assert.True(channel.IsAvailable);
+        ScenarioExpect.True(channel.IsAvailable);
 
         var result = channel.Send("#general", "Slack Title", "Slack message content that is longer than typical");
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 
+    [Scenario("NotificationMessage Record Works")]
     [Fact]
     public void NotificationMessage_Record_Works()
     {
@@ -92,12 +99,13 @@ public sealed class BridgeDemoTests
             Body: "Test Body",
             Priority: NotificationPriority.High);
 
-        Assert.Equal("user@example.com", msg.Recipient);
-        Assert.Equal("Test Subject", msg.Subject);
-        Assert.Equal("Test Body", msg.Body);
-        Assert.Equal(NotificationPriority.High, msg.Priority);
+        ScenarioExpect.Equal("user@example.com", msg.Recipient);
+        ScenarioExpect.Equal("Test Subject", msg.Subject);
+        ScenarioExpect.Equal("Test Body", msg.Body);
+        ScenarioExpect.Equal(NotificationPriority.High, msg.Priority);
     }
 
+    [Scenario("CreateNotificationBridge Email Success")]
     [Fact]
     public void CreateNotificationBridge_Email_Success()
     {
@@ -111,9 +119,10 @@ public sealed class BridgeDemoTests
 
         var result = bridge.Execute(msg);
 
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 
+    [Scenario("CreateNotificationBridge Validation Fails Empty Recipient")]
     [Fact]
     public void CreateNotificationBridge_Validation_Fails_Empty_Recipient()
     {
@@ -127,10 +136,11 @@ public sealed class BridgeDemoTests
 
         var success = bridge.TryExecute(msg, out var result, out var error);
 
-        Assert.False(success);
-        Assert.Contains("Recipient", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Contains("Recipient", error);
     }
 
+    [Scenario("CreateNotificationBridge Validation Fails Empty Body")]
     [Fact]
     public void CreateNotificationBridge_Validation_Fails_Empty_Body()
     {
@@ -144,10 +154,11 @@ public sealed class BridgeDemoTests
 
         var success = bridge.TryExecute(msg, out var result, out var error);
 
-        Assert.False(success);
-        Assert.Contains("body", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Contains("body", error);
     }
 
+    [Scenario("CreateNotificationBridge Validation Fails Message Too Long")]
     [Fact]
     public void CreateNotificationBridge_Validation_Fails_Message_Too_Long()
     {
@@ -161,10 +172,11 @@ public sealed class BridgeDemoTests
 
         var success = bridge.TryExecute(msg, out var result, out var error);
 
-        Assert.False(success);
-        Assert.Contains("too long", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Contains("too long", error);
     }
 
+    [Scenario("CreateAsyncNotificationBridge Success")]
     [Fact]
     public async Task CreateAsyncNotificationBridge_Success()
     {
@@ -178,9 +190,10 @@ public sealed class BridgeDemoTests
 
         var result = await bridge.ExecuteAsync(msg);
 
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 
+    [Scenario("CreateAsyncNotificationBridge Validation Fails")]
     [Fact]
     public async Task CreateAsyncNotificationBridge_Validation_Fails()
     {
@@ -194,16 +207,18 @@ public sealed class BridgeDemoTests
 
         var (success, _, error) = await bridge.TryExecuteAsync(msg);
 
-        Assert.False(success);
-        Assert.Contains("Recipient", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Contains("Recipient", error);
     }
 
+    [Scenario("RunAsync Executes Without Errors")]
     [Fact]
     public async Task RunAsync_Executes_Without_Errors()
     {
         await PatternKit.Examples.BridgeDemo.BridgeDemo.RunAsync();
     }
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/Chain/MediatedTransactionPipelineDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Chain/MediatedTransactionPipelineDemoTests.cs
@@ -7,15 +7,17 @@ namespace PatternKit.Examples.Tests.Chain;
 
 public sealed class CashTenderStrategyTests
 {
+    [Scenario("Kind Is Cash")]
     [Fact]
     public void Kind_Is_Cash()
     {
         var devices = new DeviceBus();
         var strategy = new CashTenderStrategy(devices);
 
-        Assert.Equal(PaymentKind.Cash, strategy.Kind);
+        ScenarioExpect.Equal(PaymentKind.Cash, strategy.Kind);
     }
 
+    [Scenario("TryApply Applies Payment")]
     [Fact]
     public void TryApply_Applies_Payment()
     {
@@ -26,10 +28,11 @@ public sealed class CashTenderStrategyTests
 
         var result = strategy.TryApply(ctx, tender);
 
-        Assert.Null(result); // success
-        Assert.Equal(10m, ctx.CashChange);
+        ScenarioExpect.Null(result); // success
+        ScenarioExpect.Equal(10m, ctx.CashChange);
     }
 
+    [Scenario("TryApply Exact Payment No Change")]
     [Fact]
     public void TryApply_Exact_Payment_No_Change()
     {
@@ -40,10 +43,11 @@ public sealed class CashTenderStrategyTests
 
         var result = strategy.TryApply(ctx, tender);
 
-        Assert.Null(result); // success
-        Assert.Null(ctx.CashChange);
+        ScenarioExpect.Null(result); // success
+        ScenarioExpect.Null(ctx.CashChange);
     }
 
+    [Scenario("TryApply Returns Null When NoDue")]
     [Fact]
     public void TryApply_Returns_Null_When_NoDue()
     {
@@ -55,7 +59,7 @@ public sealed class CashTenderStrategyTests
 
         var result = strategy.TryApply(ctx, tender);
 
-        Assert.Null(result);
+        ScenarioExpect.Null(result);
     }
 
     private static TransactionContext CreateContext(decimal price)
@@ -72,6 +76,7 @@ public sealed class CashTenderStrategyTests
 
 public sealed class CardTenderStrategyTests
 {
+    [Scenario("Kind Is Card")]
     [Fact]
     public void Kind_Is_Card()
     {
@@ -81,9 +86,10 @@ public sealed class CardTenderStrategyTests
         });
         var strategy = new CardTenderStrategy(processors);
 
-        Assert.Equal(PaymentKind.Card, strategy.Kind);
+        ScenarioExpect.Equal(PaymentKind.Card, strategy.Kind);
     }
 
+    [Scenario("TryApply Authorizes And Captures")]
     [Fact]
     public void TryApply_Authorizes_And_Captures()
     {
@@ -98,10 +104,11 @@ public sealed class CardTenderStrategyTests
 
         var result = strategy.TryApply(ctx, tender);
 
-        Assert.Null(result); // success
-        Assert.Contains(ctx.Log, l => l.Contains("captured"));
+        ScenarioExpect.Null(result); // success
+        ScenarioExpect.Contains(ctx.Log, l => l.Contains("captured"));
     }
 
+    [Scenario("TryApply Returns Null When NoDue")]
     [Fact]
     public void TryApply_Returns_Null_When_NoDue()
     {
@@ -116,7 +123,7 @@ public sealed class CardTenderStrategyTests
 
         var result = strategy.TryApply(ctx, tender);
 
-        Assert.Null(result);
+        ScenarioExpect.Null(result);
     }
 
     private static TransactionContext CreateContext(decimal price)
@@ -133,6 +140,7 @@ public sealed class CardTenderStrategyTests
 
 public sealed class NoopCharityTrackerTests
 {
+    [Scenario("Track Does Not Throw")]
     [Fact]
     public void Track_Does_Not_Throw()
     {
@@ -144,14 +152,16 @@ public sealed class NoopCharityTrackerTests
 
 public sealed class CharityRoundUpRuleTests
 {
+    [Scenario("Reason Is Set")]
     [Fact]
     public void Reason_Is_Set()
     {
         var rule = new CharityRoundUpRule(new NoopCharityTracker());
 
-        Assert.Equal("charity round-up", rule.Reason);
+        ScenarioExpect.Equal("charity round-up", rule.Reason);
     }
 
+    [Scenario("ShouldApply Returns True When CharitySku Present")]
     [Fact]
     public void ShouldApply_Returns_True_When_CharitySku_Present()
     {
@@ -162,9 +172,10 @@ public sealed class CharityRoundUpRuleTests
             Items = [new LineItem("CHARITY:UNICEF", 1m, 1)]
         };
 
-        Assert.True(rule.ShouldApply(ctx));
+        ScenarioExpect.True(rule.ShouldApply(ctx));
     }
 
+    [Scenario("ShouldApply Returns False When No CharitySku")]
     [Fact]
     public void ShouldApply_Returns_False_When_No_CharitySku()
     {
@@ -175,9 +186,10 @@ public sealed class CharityRoundUpRuleTests
             Items = [new LineItem("REGULAR", 10m, 1)]
         };
 
-        Assert.False(rule.ShouldApply(ctx));
+        ScenarioExpect.False(rule.ShouldApply(ctx));
     }
 
+    [Scenario("ComputeDelta Rounds Up To Dollar")]
     [Fact]
     public void ComputeDelta_Rounds_Up_To_Dollar()
     {
@@ -191,20 +203,22 @@ public sealed class CharityRoundUpRuleTests
 
         var delta = rule.ComputeDelta(ctx);
 
-        Assert.Equal(0.75m, delta); // 10.25 -> 11.00
+        ScenarioExpect.Equal(0.75m, delta); // 10.25 -> 11.00
     }
 }
 
 public sealed class NickelCashOnlyRuleTests
 {
+    [Scenario("Reason Is Set")]
     [Fact]
     public void Reason_Is_Set()
     {
         var rule = new NickelCashOnlyRule();
 
-        Assert.Equal("nickel (cash-only)", rule.Reason);
+        ScenarioExpect.Equal("nickel (cash-only)", rule.Reason);
     }
 
+    [Scenario("ShouldApply Returns True For Cash With NickelSku")]
     [Fact]
     public void ShouldApply_Returns_True_For_Cash_With_NickelSku()
     {
@@ -216,9 +230,10 @@ public sealed class NickelCashOnlyRuleTests
             Tender = new Tender(PaymentKind.Cash)
         };
 
-        Assert.True(rule.ShouldApply(ctx));
+        ScenarioExpect.True(rule.ShouldApply(ctx));
     }
 
+    [Scenario("ShouldApply Returns False For Card")]
     [Fact]
     public void ShouldApply_Returns_False_For_Card()
     {
@@ -230,9 +245,10 @@ public sealed class NickelCashOnlyRuleTests
             Tender = new Tender(PaymentKind.Card)
         };
 
-        Assert.False(rule.ShouldApply(ctx));
+        ScenarioExpect.False(rule.ShouldApply(ctx));
     }
 
+    [Scenario("ShouldApply Returns False Without NickelSku")]
     [Fact]
     public void ShouldApply_Returns_False_Without_NickelSku()
     {
@@ -244,9 +260,10 @@ public sealed class NickelCashOnlyRuleTests
             Tender = new Tender(PaymentKind.Cash)
         };
 
-        Assert.False(rule.ShouldApply(ctx));
+        ScenarioExpect.False(rule.ShouldApply(ctx));
     }
 
+    [Scenario("ComputeDelta Rounds To Nearest Nickel")]
     [Fact]
     public void ComputeDelta_Rounds_To_Nearest_Nickel()
     {
@@ -260,7 +277,7 @@ public sealed class NickelCashOnlyRuleTests
 
         var delta = rule.ComputeDelta(ctx);
 
-        Assert.Equal(0.02m, delta); // 10.03 -> 10.05
+        ScenarioExpect.Equal(0.02m, delta); // 10.03 -> 10.05
     }
 }
 

--- a/test/PatternKit.Examples.Tests/CompositeDemo/CompositeDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/CompositeDemo/CompositeDemoTests.cs
@@ -1,30 +1,34 @@
 using PatternKit.Examples.CompositeDemo;
 using static PatternKit.Examples.CompositeDemo.CompositeDemo;
 using FileInfo = PatternKit.Examples.CompositeDemo.CompositeDemo.FileInfo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.CompositeDemoTests;
 
 public sealed class CompositeDemoTests
 {
+    [Scenario("FileInfo Record Works")]
     [Fact]
     public void FileInfo_Record_Works()
     {
         var file = new FileInfo("test.txt", 1024, DateTime.Now);
 
-        Assert.Equal("test.txt", file.Name);
-        Assert.Equal(1024, file.Size);
+        ScenarioExpect.Equal("test.txt", file.Name);
+        ScenarioExpect.Equal(1024, file.Size);
     }
 
+    [Scenario("SearchResult Record Works")]
     [Fact]
     public void SearchResult_Record_Works()
     {
         var result = new SearchResult("/path", "file.ts", 500);
 
-        Assert.Equal("/path", result.Path);
-        Assert.Equal("file.ts", result.Name);
-        Assert.Equal(500, result.Size);
+        ScenarioExpect.Equal("/path", result.Path);
+        ScenarioExpect.Equal("file.ts", result.Name);
+        ScenarioExpect.Equal(500, result.Size);
     }
 
+    [Scenario("CreateFileSize Returns Correct Size")]
     [Fact]
     public void CreateFileSize_Returns_Correct_Size()
     {
@@ -32,9 +36,10 @@ public sealed class CompositeDemoTests
 
         var size = fileNode.Execute("ignored");
 
-        Assert.Equal(1024, size);
+        ScenarioExpect.Equal(1024, size);
     }
 
+    [Scenario("CreateDirectorySizeBuilder Sums Children")]
     [Fact]
     public void CreateDirectorySizeBuilder_Sums_Children()
     {
@@ -46,9 +51,10 @@ public sealed class CompositeDemoTests
 
         var size = directory.Execute("ignored");
 
-        Assert.Equal(600, size);
+        ScenarioExpect.Equal(600, size);
     }
 
+    [Scenario("CreateDirectorySizeBuilder Nested Directories")]
     [Fact]
     public void CreateDirectorySizeBuilder_Nested_Directories()
     {
@@ -61,9 +67,10 @@ public sealed class CompositeDemoTests
 
         var size = root.Execute("ignored");
 
-        Assert.Equal(600, size);
+        ScenarioExpect.Equal(600, size);
     }
 
+    [Scenario("CreateFileSearcher Matches Pattern")]
     [Fact]
     public void CreateFileSearcher_Matches_Pattern()
     {
@@ -72,11 +79,12 @@ public sealed class CompositeDemoTests
 
         var results = searcher.Execute(".ts");
 
-        Assert.Single(results);
-        Assert.Equal("app.ts", results[0].Name);
-        Assert.Equal("/src", results[0].Path);
+        ScenarioExpect.Single(results);
+        ScenarioExpect.Equal("app.ts", results[0].Name);
+        ScenarioExpect.Equal("/src", results[0].Path);
     }
 
+    [Scenario("CreateFileSearcher No Match")]
     [Fact]
     public void CreateFileSearcher_No_Match()
     {
@@ -85,9 +93,10 @@ public sealed class CompositeDemoTests
 
         var results = searcher.Execute(".ts");
 
-        Assert.Empty(results);
+        ScenarioExpect.Empty(results);
     }
 
+    [Scenario("CreateDirectorySearchBuilder Aggregates Results")]
     [Fact]
     public void CreateDirectorySearchBuilder_Aggregates_Results()
     {
@@ -103,20 +112,22 @@ public sealed class CompositeDemoTests
 
         var results = directory.Execute(".ts");
 
-        Assert.Equal(2, results.Count);
-        Assert.Contains(results, r => r.Name == "index.ts");
-        Assert.Contains(results, r => r.Name == "app.ts");
+        ScenarioExpect.Equal(2, results.Count);
+        ScenarioExpect.Contains(results, r => r.Name == "index.ts");
+        ScenarioExpect.Contains(results, r => r.Name == "app.ts");
     }
 
+    [Scenario("BuildProjectStructure Creates SizeCalculator And Searcher")]
     [Fact]
     public void BuildProjectStructure_Creates_SizeCalculator_And_Searcher()
     {
         var (sizeCalc, searcher) = BuildProjectStructure();
 
-        Assert.NotNull(sizeCalc);
-        Assert.NotNull(searcher);
+        ScenarioExpect.NotNull(sizeCalc);
+        ScenarioExpect.NotNull(searcher);
     }
 
+    [Scenario("BuildProjectStructure SizeCalc Calculates Total")]
     [Fact]
     public void BuildProjectStructure_SizeCalc_Calculates_Total()
     {
@@ -125,9 +136,10 @@ public sealed class CompositeDemoTests
         var totalSize = sizeCalc.Execute("");
 
         // Expected: 2048 + 1100 + 256 + 1500 + 5000 + 12000 + 3500 + 8000 + 45000 = 78404
-        Assert.Equal(78404, totalSize);
+        ScenarioExpect.Equal(78404, totalSize);
     }
 
+    [Scenario("BuildProjectStructure Searcher Finds TypeScript Files")]
     [Fact]
     public void BuildProjectStructure_Searcher_Finds_TypeScript_Files()
     {
@@ -135,13 +147,14 @@ public sealed class CompositeDemoTests
 
         var results = searcher.Execute(".ts");
 
-        Assert.Equal(4, results.Count);
-        Assert.Contains(results, r => r.Name == "index.ts");
-        Assert.Contains(results, r => r.Name == "app.ts");
-        Assert.Contains(results, r => r.Name == "utils.ts");
-        Assert.Contains(results, r => r.Name == "app.spec.ts");
+        ScenarioExpect.Equal(4, results.Count);
+        ScenarioExpect.Contains(results, r => r.Name == "index.ts");
+        ScenarioExpect.Contains(results, r => r.Name == "app.ts");
+        ScenarioExpect.Contains(results, r => r.Name == "utils.ts");
+        ScenarioExpect.Contains(results, r => r.Name == "app.spec.ts");
     }
 
+    [Scenario("BuildProjectStructure Searcher Finds Json Files")]
     [Fact]
     public void BuildProjectStructure_Searcher_Finds_Json_Files()
     {
@@ -149,11 +162,12 @@ public sealed class CompositeDemoTests
 
         var results = searcher.Execute(".json");
 
-        Assert.Equal(2, results.Count);
-        Assert.Contains(results, r => r.Name == "package.json");
-        Assert.Contains(results, r => r.Name == "coverage.json");
+        ScenarioExpect.Equal(2, results.Count);
+        ScenarioExpect.Contains(results, r => r.Name == "package.json");
+        ScenarioExpect.Contains(results, r => r.Name == "coverage.json");
     }
 
+    [Scenario("BuildProjectStructure Searcher CaseInsensitive")]
     [Fact]
     public void BuildProjectStructure_Searcher_CaseInsensitive()
     {
@@ -162,10 +176,11 @@ public sealed class CompositeDemoTests
         var lowerResults = searcher.Execute("readme");
         var upperResults = searcher.Execute("README");
 
-        Assert.Single(lowerResults);
-        Assert.Single(upperResults);
+        ScenarioExpect.Single(lowerResults);
+        ScenarioExpect.Single(upperResults);
     }
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/Decorators/StorageDecoratorExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Decorators/StorageDecoratorExampleTests.cs
@@ -9,6 +9,7 @@ namespace PatternKit.Examples.Tests.Decorators;
 [Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
 public sealed class StorageDecoratorExampleTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    [Scenario("InMemoryStorage ReadWriteExistsAndDelete WorkAsExpected")]
     [Fact]
     public void InMemoryStorage_ReadWriteExistsAndDelete_WorkAsExpected()
     {
@@ -16,15 +17,16 @@ public sealed class StorageDecoratorExampleTests(ITestOutputHelper output) : Tin
 
         storage.WriteFile("readme.txt", "hello");
 
-        Assert.True(storage.FileExists("readme.txt"));
-        Assert.Equal("hello", storage.ReadFile("readme.txt"));
+        ScenarioExpect.True(storage.FileExists("readme.txt"));
+        ScenarioExpect.Equal("hello", storage.ReadFile("readme.txt"));
 
         storage.DeleteFile("readme.txt");
 
-        Assert.False(storage.FileExists("readme.txt"));
-        Assert.Throws<FileNotFoundException>(() => storage.ReadFile("readme.txt"));
+        ScenarioExpect.False(storage.FileExists("readme.txt"));
+        ScenarioExpect.Throws<FileNotFoundException>(() => storage.ReadFile("readme.txt"));
     }
 
+    [Scenario("GeneratedDecoratorChain ForwardsAndInvalidatesCache")]
     [Fact]
     public void GeneratedDecoratorChain_ForwardsAndInvalidatesCache()
     {
@@ -35,18 +37,19 @@ public sealed class StorageDecoratorExampleTests(ITestOutputHelper output) : Tin
             next => new LoggingFileStorage(next));
 
         storage.WriteFile("invoice.txt", "v1");
-        Assert.Equal("v1", storage.ReadFile("invoice.txt"));
-        Assert.Equal("v1", storage.ReadFile("invoice.txt"));
+        ScenarioExpect.Equal("v1", storage.ReadFile("invoice.txt"));
+        ScenarioExpect.Equal("v1", storage.ReadFile("invoice.txt"));
 
         storage.WriteFile("invoice.txt", "v2");
 
-        Assert.Equal("v2", storage.ReadFile("invoice.txt"));
-        Assert.True(storage.FileExists("invoice.txt"));
+        ScenarioExpect.Equal("v2", storage.ReadFile("invoice.txt"));
+        ScenarioExpect.True(storage.FileExists("invoice.txt"));
 
         storage.DeleteFile("invoice.txt");
-        Assert.False(storage.FileExists("invoice.txt"));
+        ScenarioExpect.False(storage.FileExists("invoice.txt"));
     }
 
+    [Scenario("RetryDecorator RetriesUntilOperationSucceeds")]
     [Fact]
     public void RetryDecorator_RetriesUntilOperationSucceeds()
     {
@@ -54,15 +57,16 @@ public sealed class StorageDecoratorExampleTests(ITestOutputHelper output) : Tin
 
         storage.WriteFile("data.txt", "payload");
 
-        Assert.Equal("payload", storage.ReadFile("data.txt"));
+        ScenarioExpect.Equal("payload", storage.ReadFile("data.txt"));
     }
 
+    [Scenario("RetryDecorator RethrowsAfterRetriesAreExhausted")]
     [Fact]
     public void RetryDecorator_RethrowsAfterRetriesAreExhausted()
     {
         var storage = new RetryFileStorage(new FlakyStorage(failuresBeforeSuccess: 5), maxRetries: 2, retryDelayMs: 0);
 
-        Assert.Throws<IOException>(() => storage.WriteFile("data.txt", "payload"));
+        ScenarioExpect.Throws<IOException>(() => storage.WriteFile("data.txt", "payload"));
     }
 
     [Scenario("Public storage decorator demo runs the composed logging, caching, and retry workflow")]

--- a/test/PatternKit.Examples.Tests/Documentation/DocumentationCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/Documentation/DocumentationCoverageTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Documentation;
 
@@ -6,6 +7,7 @@ public sealed class DocumentationCoverageTests
 {
     private static readonly Regex TocHrefRegex = new(@"href:\s*(?<href>[^\s#]+)", RegexOptions.Compiled);
 
+    [Scenario("Toc Hrefs Point To Existing Files")]
     [Theory]
     [InlineData("docs/generators/toc.yml")]
     [InlineData("docs/examples/toc.yml")]
@@ -26,10 +28,11 @@ public sealed class DocumentationCoverageTests
 
             var target = Path.GetFullPath(Path.Combine(tocDirectory, Normalize(href)));
 
-            Assert.True(File.Exists(target), $"{relativeTocPath} references missing file: {href}");
+            ScenarioExpect.True(File.Exists(target), $"{relativeTocPath} references missing file: {href}");
         }
     }
 
+    [Scenario("Generator Toc Includes All Generator Pages")]
     [Fact]
     public void Generator_Toc_Includes_All_Generator_Pages()
     {
@@ -44,20 +47,22 @@ public sealed class DocumentationCoverageTests
 
         foreach (var page in expectedPages)
         {
-            Assert.Contains($"href: {page}", toc, StringComparison.Ordinal);
+            ScenarioExpect.Contains($"href: {page}", toc, StringComparison.Ordinal);
         }
     }
 
+    [Scenario("Example Toc Exposes Generator And Messaging Suites")]
     [Fact]
     public void Example_Toc_Exposes_Generator_And_Messaging_Suites()
     {
         var root = FindRepoRoot();
         var toc = File.ReadAllText(Path.Combine(root, "docs", "examples", "toc.yml"));
 
-        Assert.Contains("href: source-generator-application-suite.md", toc, StringComparison.Ordinal);
-        Assert.Contains("href: enterprise-messaging-workflows.md", toc, StringComparison.Ordinal);
+        ScenarioExpect.Contains("href: source-generator-application-suite.md", toc, StringComparison.Ordinal);
+        ScenarioExpect.Contains("href: enterprise-messaging-workflows.md", toc, StringComparison.Ordinal);
     }
 
+    [Scenario("Source Generator Application Suite Maps Example Families To Tests")]
     [Fact]
     public void Source_Generator_Application_Suite_Maps_Example_Families_To_Tests()
     {
@@ -84,13 +89,14 @@ public sealed class DocumentationCoverageTests
 
         foreach (var family in expectedGeneratorFamilies)
         {
-            Assert.Contains($"| {family} |", doc, StringComparison.Ordinal);
+            ScenarioExpect.Contains($"| {family} |", doc, StringComparison.Ordinal);
         }
 
-        Assert.Contains("test/PatternKit.Examples.Tests/Generators", doc, StringComparison.Ordinal);
-        Assert.Contains("test/PatternKit.Examples.Tests/Messaging", doc, StringComparison.Ordinal);
+        ScenarioExpect.Contains("test/PatternKit.Examples.Tests/Generators", doc, StringComparison.Ordinal);
+        ScenarioExpect.Contains("test/PatternKit.Examples.Tests/Messaging", doc, StringComparison.Ordinal);
     }
 
+    [Scenario("Enterprise Messaging Workflow Suite Maps Runtime And Generated Patterns")]
     [Fact]
     public void Enterprise_Messaging_Workflow_Suite_Maps_Runtime_And_Generated_Patterns()
     {
@@ -115,7 +121,7 @@ public sealed class DocumentationCoverageTests
 
         foreach (var pattern in expectedPatterns)
         {
-            Assert.Contains($"| {pattern} |", doc, StringComparison.Ordinal);
+            ScenarioExpect.Contains($"| {pattern} |", doc, StringComparison.Ordinal);
         }
     }
 

--- a/test/PatternKit.Examples.Tests/EnterpriseDemo/EnterpriseOrderDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/EnterpriseDemo/EnterpriseOrderDemoTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Examples.EnterpriseDemo;
 using static PatternKit.Examples.EnterpriseDemo.EnterpriseOrderDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.EnterpriseDemoTests;
 
 public sealed class EnterpriseOrderDemoTests
 {
+    [Scenario("CreateOrderItemFactory Creates Physical Items")]
     [Fact]
     public void CreateOrderItemFactory_Creates_Physical_Items()
     {
@@ -12,10 +14,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var item = factory.Create("physical");
 
-        Assert.NotNull(item);
-        Assert.IsType<PhysicalItem>(item);
+        ScenarioExpect.NotNull(item);
+        ScenarioExpect.IsType<PhysicalItem>(item);
     }
 
+    [Scenario("CreateOrderItemFactory Creates Digital Items")]
     [Fact]
     public void CreateOrderItemFactory_Creates_Digital_Items()
     {
@@ -23,10 +26,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var item = factory.Create("digital");
 
-        Assert.NotNull(item);
-        Assert.IsType<DigitalItem>(item);
+        ScenarioExpect.NotNull(item);
+        ScenarioExpect.IsType<DigitalItem>(item);
     }
 
+    [Scenario("CreateOrderItemFactory Creates Subscription Items")]
     [Fact]
     public void CreateOrderItemFactory_Creates_Subscription_Items()
     {
@@ -34,20 +38,22 @@ public sealed class EnterpriseOrderDemoTests
 
         var item = factory.Create("subscription");
 
-        Assert.NotNull(item);
-        Assert.IsType<SubscriptionItem>(item);
+        ScenarioExpect.NotNull(item);
+        ScenarioExpect.IsType<SubscriptionItem>(item);
     }
 
+    [Scenario("CreatePaymentFactory Creates All Regions")]
     [Fact]
     public void CreatePaymentFactory_Creates_All_Regions()
     {
         var factory = CreatePaymentFactory();
 
-        Assert.True(factory.TryGetFamily(Region.NorthAmerica, out _));
-        Assert.True(factory.TryGetFamily(Region.Europe, out _));
-        Assert.True(factory.TryGetFamily(Region.Asia, out _));
+        ScenarioExpect.True(factory.TryGetFamily(Region.NorthAmerica, out _));
+        ScenarioExpect.True(factory.TryGetFamily(Region.Europe, out _));
+        ScenarioExpect.True(factory.TryGetFamily(Region.Asia, out _));
     }
 
+    [Scenario("NorthAmerica Uses Stripe")]
     [Fact]
     public void NorthAmerica_Uses_Stripe()
     {
@@ -56,10 +62,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var processor = family.Create<IPaymentProcessor>();
 
-        Assert.Equal("Stripe", processor.Name);
-        Assert.True(processor.ProcessPayment(100m));
+        ScenarioExpect.Equal("Stripe", processor.Name);
+        ScenarioExpect.True(processor.ProcessPayment(100m));
     }
 
+    [Scenario("Europe Uses PayPal")]
     [Fact]
     public void Europe_Uses_PayPal()
     {
@@ -68,10 +75,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var processor = family.Create<IPaymentProcessor>();
 
-        Assert.Equal("PayPal", processor.Name);
-        Assert.True(processor.ProcessPayment(100m));
+        ScenarioExpect.Equal("PayPal", processor.Name);
+        ScenarioExpect.True(processor.ProcessPayment(100m));
     }
 
+    [Scenario("Asia Uses Alipay")]
     [Fact]
     public void Asia_Uses_Alipay()
     {
@@ -80,10 +88,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var processor = family.Create<IPaymentProcessor>();
 
-        Assert.Equal("Alipay", processor.Name);
-        Assert.True(processor.ProcessPayment(100m));
+        ScenarioExpect.Equal("Alipay", processor.Name);
+        ScenarioExpect.True(processor.ProcessPayment(100m));
     }
 
+    [Scenario("USFraudDetector Flags High Value Orders")]
     [Fact]
     public void USFraudDetector_Flags_High_Value_Orders()
     {
@@ -96,9 +105,10 @@ public sealed class EnterpriseOrderDemoTests
             Items = [new PhysicalItem("SKU", "Item", 15000m, 1, 1.0)]
         };
 
-        Assert.True(detector.IsFraudulent(highValueOrder));
+        ScenarioExpect.True(detector.IsFraudulent(highValueOrder));
     }
 
+    [Scenario("USFraudDetector Passes Normal Orders")]
     [Fact]
     public void USFraudDetector_Passes_Normal_Orders()
     {
@@ -111,9 +121,10 @@ public sealed class EnterpriseOrderDemoTests
             Items = [new PhysicalItem("SKU", "Item", 100m, 1, 1.0)]
         };
 
-        Assert.False(detector.IsFraudulent(normalOrder));
+        ScenarioExpect.False(detector.IsFraudulent(normalOrder));
     }
 
+    [Scenario("EUFraudDetector Always Passes")]
     [Fact]
     public void EUFraudDetector_Always_Passes()
     {
@@ -125,9 +136,10 @@ public sealed class EnterpriseOrderDemoTests
             Region = Region.Europe
         };
 
-        Assert.False(detector.IsFraudulent(order));
+        ScenarioExpect.False(detector.IsFraudulent(order));
     }
 
+    [Scenario("CreateOrderTemplates Creates Standard Order")]
     [Fact]
     public void CreateOrderTemplates_Creates_Standard_Order()
     {
@@ -135,10 +147,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var order = templates.Create("standard");
 
-        Assert.NotNull(order);
-        Assert.Equal(ShippingMethod.Standard, order.ShippingMethod);
+        ScenarioExpect.NotNull(order);
+        ScenarioExpect.Equal(ShippingMethod.Standard, order.ShippingMethod);
     }
 
+    [Scenario("CreateOrderTemplates Creates Express Order")]
     [Fact]
     public void CreateOrderTemplates_Creates_Express_Order()
     {
@@ -146,11 +159,12 @@ public sealed class EnterpriseOrderDemoTests
 
         var order = templates.Create("express");
 
-        Assert.NotNull(order);
-        Assert.Equal(ShippingMethod.Express, order.ShippingMethod);
-        Assert.Equal(15.00m, order.ShippingCost);
+        ScenarioExpect.NotNull(order);
+        ScenarioExpect.Equal(ShippingMethod.Express, order.ShippingMethod);
+        ScenarioExpect.Equal(15.00m, order.ShippingCost);
     }
 
+    [Scenario("CreateOrderTemplates With Mutation")]
     [Fact]
     public void CreateOrderTemplates_With_Mutation()
     {
@@ -158,9 +172,10 @@ public sealed class EnterpriseOrderDemoTests
 
         var order = templates.Create("standard", o => o.CustomerId = "CUSTOM-123");
 
-        Assert.Equal("CUSTOM-123", order.CustomerId);
+        ScenarioExpect.Equal("CUSTOM-123", order.CustomerId);
     }
 
+    [Scenario("CreateShippingStrategy Standard Shipping")]
     [Fact]
     public void CreateShippingStrategy_Standard_Shipping()
     {
@@ -177,9 +192,10 @@ public sealed class EnterpriseOrderDemoTests
         var cost = strategy.Execute(order);
 
         // (2.0 * 2.5 + 5.0) = 10.0
-        Assert.Equal(10.0m, cost);
+        ScenarioExpect.Equal(10.0m, cost);
     }
 
+    [Scenario("CreateShippingStrategy Express Shipping")]
     [Fact]
     public void CreateShippingStrategy_Express_Shipping()
     {
@@ -196,9 +212,10 @@ public sealed class EnterpriseOrderDemoTests
         var cost = strategy.Execute(order);
 
         // (2.0 * 5.0 + 15.0) = 25.0
-        Assert.Equal(25.0m, cost);
+        ScenarioExpect.Equal(25.0m, cost);
     }
 
+    [Scenario("CreateShippingStrategy NextDay Shipping")]
     [Fact]
     public void CreateShippingStrategy_NextDay_Shipping()
     {
@@ -215,9 +232,10 @@ public sealed class EnterpriseOrderDemoTests
         var cost = strategy.Execute(order);
 
         // (2.0 * 10.0 + 30.0) = 50.0
-        Assert.Equal(50.0m, cost);
+        ScenarioExpect.Equal(50.0m, cost);
     }
 
+    [Scenario("CreateValidationChain Fails Empty Order")]
     [Fact]
     public void CreateValidationChain_Fails_Empty_Order()
     {
@@ -231,11 +249,12 @@ public sealed class EnterpriseOrderDemoTests
 
         chain.Execute(order, out var result);
 
-        Assert.NotNull(result);
-        Assert.False(result.IsValid);
-        Assert.Contains("at least one item", result.Error);
+        ScenarioExpect.NotNull(result);
+        ScenarioExpect.False(result.IsValid);
+        ScenarioExpect.Contains("at least one item", result.Error);
     }
 
+    [Scenario("CreateValidationChain Fails Invalid Quantity")]
     [Fact]
     public void CreateValidationChain_Fails_Invalid_Quantity()
     {
@@ -250,10 +269,11 @@ public sealed class EnterpriseOrderDemoTests
 
         chain.Execute(order, out var result);
 
-        Assert.NotNull(result);
-        Assert.False(result.IsValid);
+        ScenarioExpect.NotNull(result);
+        ScenarioExpect.False(result.IsValid);
     }
 
+    [Scenario("CreateValidationChain Fails High Value")]
     [Fact]
     public void CreateValidationChain_Fails_High_Value()
     {
@@ -268,11 +288,12 @@ public sealed class EnterpriseOrderDemoTests
 
         chain.Execute(order, out var result);
 
-        Assert.NotNull(result);
-        Assert.False(result.IsValid);
-        Assert.Contains("exceeds maximum", result.Error);
+        ScenarioExpect.NotNull(result);
+        ScenarioExpect.False(result.IsValid);
+        ScenarioExpect.Contains("exceeds maximum", result.Error);
     }
 
+    [Scenario("CreateValidationChain Passes Valid Order")]
     [Fact]
     public void CreateValidationChain_Passes_Valid_Order()
     {
@@ -287,19 +308,21 @@ public sealed class EnterpriseOrderDemoTests
 
         chain.Execute(order, out var result);
 
-        Assert.NotNull(result);
-        Assert.True(result.IsValid);
+        ScenarioExpect.NotNull(result);
+        ScenarioExpect.True(result.IsValid);
     }
 
+    [Scenario("CreateOrderNotifications Creates Observer")]
     [Fact]
     public void CreateOrderNotifications_Creates_Observer()
     {
         var observer = CreateOrderNotifications();
 
-        Assert.NotNull(observer);
-        Assert.True(observer.SubscriberCount > 0);
+        ScenarioExpect.NotNull(observer);
+        ScenarioExpect.True(observer.SubscriberCount > 0);
     }
 
+    [Scenario("CreateOrderProcessingPipeline Filters Pending Orders")]
     [Fact]
     public void CreateOrderProcessingPipeline_Filters_Pending_Orders()
     {
@@ -313,10 +336,11 @@ public sealed class EnterpriseOrderDemoTests
         var pipeline = CreateOrderProcessingPipeline(orders);
         var result = pipeline.ToList();
 
-        Assert.Single(result);
-        Assert.Equal("1", result[0].Id);
+        ScenarioExpect.Single(result);
+        ScenarioExpect.Equal("1", result[0].Id);
     }
 
+    [Scenario("CreatePriceCalculator Applies Tax And Discount")]
     [Fact]
     public void CreatePriceCalculator_Applies_Tax_And_Discount()
     {
@@ -334,10 +358,11 @@ public sealed class EnterpriseOrderDemoTests
         var total = calculator.Execute(order);
 
         // Verify price calculation includes tax and discount
-        Assert.True(total > order.Subtotal);
-        Assert.True(total < order.Subtotal * 2);
+        ScenarioExpect.True(total > order.Subtotal);
+        ScenarioExpect.True(total < order.Subtotal * 2);
     }
 
+    [Scenario("CreateItemProcessor Dispatches Physical Items")]
     [Fact]
     public void CreateItemProcessor_Dispatches_Physical_Items()
     {
@@ -346,11 +371,12 @@ public sealed class EnterpriseOrderDemoTests
 
         var result = processor.Dispatch(item);
 
-        Assert.Contains("Physical", result);
-        Assert.Contains("Mouse", result);
-        Assert.Contains("0.5kg", result);
+        ScenarioExpect.Contains("Physical", result);
+        ScenarioExpect.Contains("Mouse", result);
+        ScenarioExpect.Contains("0.5kg", result);
     }
 
+    [Scenario("CreateItemProcessor Dispatches Digital Items")]
     [Fact]
     public void CreateItemProcessor_Dispatches_Digital_Items()
     {
@@ -359,10 +385,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var result = processor.Dispatch(item);
 
-        Assert.Contains("Digital", result);
-        Assert.Contains("Software", result);
+        ScenarioExpect.Contains("Digital", result);
+        ScenarioExpect.Contains("Software", result);
     }
 
+    [Scenario("CreateItemProcessor Dispatches Subscription Items")]
     [Fact]
     public void CreateItemProcessor_Dispatches_Subscription_Items()
     {
@@ -371,10 +398,11 @@ public sealed class EnterpriseOrderDemoTests
 
         var result = processor.Dispatch(item);
 
-        Assert.Contains("Subscription", result);
-        Assert.Contains("12 months", result);
+        ScenarioExpect.Contains("Subscription", result);
+        ScenarioExpect.Contains("12 months", result);
     }
 
+    [Scenario("Order DeepClone Creates Independent Copy")]
     [Fact]
     public void Order_DeepClone_Creates_Independent_Copy()
     {
@@ -388,11 +416,12 @@ public sealed class EnterpriseOrderDemoTests
 
         var clone = Order.DeepClone(original);
 
-        Assert.NotSame(original, clone);
-        Assert.NotEqual(original.Id, clone.Id);
-        Assert.NotSame(original.Items, clone.Items);
+        ScenarioExpect.NotSame(original, clone);
+        ScenarioExpect.NotEqual(original.Id, clone.Id);
+        ScenarioExpect.NotSame(original.Items, clone.Items);
     }
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/FacadeDemo/FacadeDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/FacadeDemo/FacadeDemoTests.cs
@@ -189,12 +189,14 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
                 r.TransactionId != null && r.ShipmentId != null)
             .AssertPassed();
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {
         PatternKit.Examples.FacadeDemo.FacadeDemo.Run();
     }
 
+    [Scenario("CancelOrder NonExistent ReturnsError")]
     [Fact]
     public void CancelOrder_NonExistent_ReturnsError()
     {
@@ -203,10 +205,11 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
 
         var result = facade.Execute("cancel-order", request);
 
-        Assert.False(result.Success);
-        Assert.Contains("not found", result.ErrorMessage!);
+        ScenarioExpect.False(result.Success);
+        ScenarioExpect.Contains("not found", result.ErrorMessage!);
     }
 
+    [Scenario("ProcessReturn NonExistent ReturnsError")]
     [Fact]
     public void ProcessReturn_NonExistent_ReturnsError()
     {
@@ -215,10 +218,11 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
 
         var result = facade.Execute("process-return", request);
 
-        Assert.False(result.Success);
-        Assert.Contains("not found", result.ErrorMessage!);
+        ScenarioExpect.False(result.Success);
+        ScenarioExpect.Contains("not found", result.ErrorMessage!);
     }
 
+    [Scenario("PlaceOrder ZeroPrice PaymentFails")]
     [Fact]
     public void PlaceOrder_ZeroPrice_PaymentFails()
     {
@@ -227,10 +231,11 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
 
         var result = facade.Execute("place-order", request);
 
-        Assert.False(result.Success);
-        Assert.Contains("Payment", result.ErrorMessage!);
+        ScenarioExpect.False(result.Success);
+        ScenarioExpect.Contains("Payment", result.ErrorMessage!);
     }
 
+    [Scenario("InventoryService Reserve UnknownProduct Fails")]
     [Fact]
     public void InventoryService_Reserve_UnknownProduct_Fails()
     {
@@ -238,10 +243,11 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
 
         var success = inventory.Reserve("UNKNOWN-PRODUCT", 1, out var reservationId);
 
-        Assert.False(success);
-        Assert.Empty(reservationId);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Empty(reservationId);
     }
 
+    [Scenario("InventoryService Reserve TooMuchQuantity Fails")]
     [Fact]
     public void InventoryService_Reserve_TooMuchQuantity_Fails()
     {
@@ -249,10 +255,11 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
 
         var success = inventory.Reserve("WIDGET-001", 9999, out var reservationId);
 
-        Assert.False(success);
-        Assert.Empty(reservationId);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Empty(reservationId);
     }
 
+    [Scenario("InventoryService Reserve Success")]
     [Fact]
     public void InventoryService_Reserve_Success()
     {
@@ -260,10 +267,11 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
 
         var success = inventory.Reserve("WIDGET-001", 10, out var reservationId);
 
-        Assert.True(success);
-        Assert.StartsWith("RES-", reservationId);
+        ScenarioExpect.True(success);
+        ScenarioExpect.StartsWith("RES-", reservationId);
     }
 
+    [Scenario("InventoryService Release DoesNotThrow")]
     [Fact]
     public void InventoryService_Release_DoesNotThrow()
     {
@@ -272,6 +280,7 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
         inventory.Release("RES-12345");
     }
 
+    [Scenario("InventoryService Restock IncreasesStock")]
     [Fact]
     public void InventoryService_Restock_IncreasesStock()
     {
@@ -282,82 +291,93 @@ public sealed class FacadeDemoTests(ITestOutputHelper output) : TinyBddXunitBase
         // Now should be able to reserve again
         var success = inventory.Reserve("WIDGET-001", 40, out _);
 
-        Assert.True(success);
+        ScenarioExpect.True(success);
     }
 
+    [Scenario("PaymentService Charge NegativeAmount Fails")]
     [Fact]
     public void PaymentService_Charge_NegativeAmount_Fails()
     {
         var success = PaymentService.Charge("VISA", -10m, out var transactionId);
 
-        Assert.False(success);
-        Assert.Empty(transactionId);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Empty(transactionId);
     }
 
+    [Scenario("PaymentService Charge ZeroAmount Fails")]
     [Fact]
     public void PaymentService_Charge_ZeroAmount_Fails()
     {
         var success = PaymentService.Charge("VISA", 0m, out var transactionId);
 
-        Assert.False(success);
-        Assert.Empty(transactionId);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Empty(transactionId);
     }
 
+    [Scenario("PaymentService Charge Success")]
     [Fact]
     public void PaymentService_Charge_Success()
     {
         var success = PaymentService.Charge("VISA", 100m, out var transactionId);
 
-        Assert.True(success);
-        Assert.StartsWith("TX-", transactionId);
+        ScenarioExpect.True(success);
+        ScenarioExpect.StartsWith("TX-", transactionId);
     }
 
+    [Scenario("PaymentService Refund DoesNotThrow")]
     [Fact]
     public void PaymentService_Refund_DoesNotThrow()
     {
         PaymentService.Refund("TX-12345");
     }
 
+    [Scenario("PaymentService Void DoesNotThrow")]
     [Fact]
     public void PaymentService_Void_DoesNotThrow()
     {
         PaymentService.Void("TX-12345");
     }
 
+    [Scenario("ShippingService Schedule ReturnsShipmentId")]
     [Fact]
     public void ShippingService_Schedule_ReturnsShipmentId()
     {
         var shipmentId = ShippingService.Schedule("123 Main St", "WIDGET-001", 5);
 
-        Assert.StartsWith("SHIP-", shipmentId);
+        ScenarioExpect.StartsWith("SHIP-", shipmentId);
     }
 
+    [Scenario("ShippingService Cancel DoesNotThrow")]
     [Fact]
     public void ShippingService_Cancel_DoesNotThrow()
     {
         ShippingService.Cancel("SHIP-12345");
     }
 
+    [Scenario("ShippingService InitiateReturn ReturnsReturnId")]
     [Fact]
     public void ShippingService_InitiateReturn_ReturnsReturnId()
     {
         var returnId = ShippingService.InitiateReturn("SHIP-12345");
 
-        Assert.StartsWith("RET-", returnId);
+        ScenarioExpect.StartsWith("RET-", returnId);
     }
 
+    [Scenario("NotificationService SendOrderConfirmation DoesNotThrow")]
     [Fact]
     public void NotificationService_SendOrderConfirmation_DoesNotThrow()
     {
         NotificationService.SendOrderConfirmation("test@test.com", "ORD-12345");
     }
 
+    [Scenario("NotificationService SendCancellation DoesNotThrow")]
     [Fact]
     public void NotificationService_SendCancellation_DoesNotThrow()
     {
         NotificationService.SendCancellation("test@test.com", "ORD-12345");
     }
 
+    [Scenario("NotificationService SendRefundNotice DoesNotThrow")]
     [Fact]
     public void NotificationService_SendRefundNotice_DoesNotThrow()
     {

--- a/test/PatternKit.Examples.Tests/Generators/FacadeSpecsTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/FacadeSpecsTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Examples.Generators.Facade;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Generators;
 
@@ -8,6 +9,7 @@ namespace PatternKit.Examples.Tests.Generators;
 /// </summary>
 public class FacadeSpecsTests
 {
+    [Scenario("ShippingFacade CalculatesCostCorrectly")]
     [Fact]
     public void ShippingFacade_CalculatesCostCorrectly()
     {
@@ -22,10 +24,11 @@ public class FacadeSpecsTests
         // Act
         var cost = facade.CalculateShippingCost(destination: "local", weight: 3.5m);
 
-        // Assert
-        Assert.Equal(5.99m, cost); // local base rate, 3.5 lbs (under 5 lbs, no surcharge)
+        // Then
+        ScenarioExpect.Equal(5.99m, cost); // local base rate, 3.5 lbs (under 5 lbs, no surcharge)
     }
 
+    [Scenario("ShippingFacade ValidatesShipmentCorrectly")]
     [Fact]
     public void ShippingFacade_ValidatesShipmentCorrectly()
     {
@@ -40,16 +43,17 @@ public class FacadeSpecsTests
         // Act - Valid shipment
         var isValid = facade.ValidateShipment(destination: "local", weight: 10m);
 
-        // Assert
-        Assert.True(isValid);
+        // Then
+        ScenarioExpect.True(isValid);
 
         // Act - Invalid shipment (negative weight)
         var isInvalid = facade.ValidateShipment(destination: "local", weight: -5m);
 
-        // Assert
-        Assert.False(isInvalid);
+        // Then
+        ScenarioExpect.False(isInvalid);
     }
 
+    [Scenario("ShippingFacade EstimatesDeliveryCorrectly")]
     [Fact]
     public void ShippingFacade_EstimatesDeliveryCorrectly()
     {
@@ -66,10 +70,11 @@ public class FacadeSpecsTests
         // the facade may reorder parameters. This test validates routing works.
         var days = facade.EstimateDeliveryDays(destination: "local", speed: "standard");
 
-        // Assert - Just verify a valid result is returned
-        Assert.True(days > 0 && days <= 12);
+        // Then - Just verify a valid result is returned
+        ScenarioExpect.True(days > 0 && days <= 12);
     }
 
+    [Scenario("BillingFacade ProcessesPaymentCorrectly")]
     [Fact]
     public void BillingFacade_ProcessesPaymentCorrectly()
     {
@@ -89,15 +94,16 @@ public class FacadeSpecsTests
             jurisdiction: "US-CA",
             paymentMethod: "CreditCard");
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.True(result.Success);
-        Assert.NotNull(result.InvoiceNumber);
-        Assert.NotNull(result.ReceiptNumber);
+        // Then
+        ScenarioExpect.NotNull(result);
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.NotNull(result.InvoiceNumber);
+        ScenarioExpect.NotNull(result.ReceiptNumber);
         // Note: TotalAmount returns subtotal from current impl
-        Assert.True(result.TotalAmount > 0);
+        ScenarioExpect.True(result.TotalAmount > 0);
     }
 
+    [Scenario("BillingFacade ProcessesRefundCorrectly")]
     [Fact]
     public void BillingFacade_ProcessesRefundCorrectly()
     {
@@ -117,8 +123,8 @@ public class FacadeSpecsTests
             jurisdiction: "US-CA",
             paymentMethod: "CreditCard");
 
-        Assert.True(paymentResult.Success);
-        Assert.NotNull(paymentResult.ReceiptNumber);
+        ScenarioExpect.True(paymentResult.Success);
+        ScenarioExpect.NotNull(paymentResult.ReceiptNumber);
 
         // Act - Process refund (note: this tests the facade routing, even if refund fails due to state issues)
         var refund = facade.ProcessRefund(
@@ -126,12 +132,13 @@ public class FacadeSpecsTests
             receiptNumber: paymentResult.ReceiptNumber!,
             amount: 50m);
 
-        // Assert - Just verify the facade returns a result
-        Assert.NotNull(refund);
+        // Then - Just verify the facade returns a result
+        ScenarioExpect.NotNull(refund);
         // Note: May fail with "Payment not found" due to stateful service design
         // The test validates facade routing works, not business logic
     }
 
+    [Scenario("BillingFacade CalculatesTotalWithTaxCorrectly")]
     [Fact]
     public void BillingFacade_CalculatesTotalWithTaxCorrectly()
     {
@@ -147,10 +154,11 @@ public class FacadeSpecsTests
         // Act
         var totalWithTax = facade.CalculateTotalWithTax(100m, "US-CA");
 
-        // Assert
-        Assert.True(totalWithTax > 100m); // Should add tax
+        // Then
+        ScenarioExpect.True(totalWithTax > 100m); // Should add tax
     }
 
+    [Scenario("BillingFacade RetrievesInvoiceCorrectly")]
     [Fact]
     public void BillingFacade_RetrievesInvoiceCorrectly()
     {
@@ -170,19 +178,20 @@ public class FacadeSpecsTests
             jurisdiction: "US-CA",
             paymentMethod: "CreditCard");
 
-        Assert.True(result.Success);
-        Assert.NotNull(result.InvoiceNumber);
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.NotNull(result.InvoiceNumber);
 
         // Act
         var retrievedInvoice = facade.GetInvoice(result.InvoiceNumber!);
 
-        // Assert
-        Assert.NotNull(retrievedInvoice);
-        Assert.Equal(result.InvoiceNumber, retrievedInvoice.InvoiceNumber);
-        Assert.Equal("CUST001", retrievedInvoice.CustomerId);
-        Assert.True(retrievedInvoice.Total > 0);
+        // Then
+        ScenarioExpect.NotNull(retrievedInvoice);
+        ScenarioExpect.Equal(result.InvoiceNumber, retrievedInvoice.InvoiceNumber);
+        ScenarioExpect.Equal("CUST001", retrievedInvoice.CustomerId);
+        ScenarioExpect.True(retrievedInvoice.Total > 0);
     }
 
+    [Scenario("BillingSubsystems CoverValidationAndMissingRecordPaths")]
     [Fact]
     public void BillingSubsystems_CoverValidationAndMissingRecordPaths()
     {
@@ -190,9 +199,9 @@ public class FacadeSpecsTests
         var invoices = new InvoiceService();
         var payments = new PaymentProcessor();
 
-        Assert.Equal(0m, tax.CalculateTax(100m, "UNKNOWN"));
-        Assert.Equal(0m, tax.GetTaxRate("UNKNOWN"));
-        Assert.Null(invoices.GetInvoice("INV-MISSING"));
+        ScenarioExpect.Equal(0m, tax.CalculateTax(100m, "UNKNOWN"));
+        ScenarioExpect.Equal(0m, tax.GetTaxRate("UNKNOWN"));
+        ScenarioExpect.Null(invoices.GetInvoice("INV-MISSING"));
 
         var zeroAmount = payments.ProcessPayment("CUST001", 0m, "CreditCard");
         var missingMethod = payments.ProcessPayment("CUST001", 10m, "");
@@ -200,16 +209,17 @@ public class FacadeSpecsTests
         var paid = payments.ProcessPayment("CUST001", 25m, "CreditCard");
         var excessiveRefund = payments.RefundPayment(paid.ReceiptNumber!, 30m);
 
-        Assert.False(zeroAmount.Success);
-        Assert.Equal("Amount must be greater than zero", zeroAmount.ErrorMessage);
-        Assert.False(missingMethod.Success);
-        Assert.Equal("Payment method is required", missingMethod.ErrorMessage);
-        Assert.False(missingPaymentRefund.Success);
-        Assert.Equal("Payment not found", missingPaymentRefund.ErrorMessage);
-        Assert.False(excessiveRefund.Success);
-        Assert.Equal("Refund amount exceeds original payment", excessiveRefund.ErrorMessage);
+        ScenarioExpect.False(zeroAmount.Success);
+        ScenarioExpect.Equal("Amount must be greater than zero", zeroAmount.ErrorMessage);
+        ScenarioExpect.False(missingMethod.Success);
+        ScenarioExpect.Equal("Payment method is required", missingMethod.ErrorMessage);
+        ScenarioExpect.False(missingPaymentRefund.Success);
+        ScenarioExpect.Equal("Payment not found", missingPaymentRefund.ErrorMessage);
+        ScenarioExpect.False(excessiveRefund.Success);
+        ScenarioExpect.Equal("Refund amount exceeds original payment", excessiveRefund.ErrorMessage);
     }
 
+    [Scenario("BillingFacade HandlesPaymentAndRefundFailures")]
     [Fact]
     public void BillingFacade_HandlesPaymentAndRefundFailures()
     {
@@ -229,25 +239,27 @@ public class FacadeSpecsTests
             receiptNumber: "REC-MISSING",
             amount: 1m);
 
-        Assert.False(failedPayment.Success);
-        Assert.Equal("Amount must be greater than zero", failedPayment.ErrorMessage);
-        Assert.False(missingRefund.Success);
-        Assert.Equal("Payment not found", missingRefund.ErrorMessage);
+        ScenarioExpect.False(failedPayment.Success);
+        ScenarioExpect.Equal("Amount must be greater than zero", failedPayment.ErrorMessage);
+        ScenarioExpect.False(missingRefund.Success);
+        ScenarioExpect.Equal("Payment not found", missingRefund.ErrorMessage);
     }
 
+    [Scenario("ShippingDemo ExecutesSuccessfully")]
     [Fact]
     public void ShippingDemo_ExecutesSuccessfully()
     {
         // This test validates the demo runs without errors
-        // Act & Assert (should not throw)
+        // Act and verify (should not throw)
         ShippingFacadeDemo.Run();
     }
 
+    [Scenario("BillingDemo ExecutesSuccessfully")]
     [Fact]
     public void BillingDemo_ExecutesSuccessfully()
     {
         // This test validates the demo runs without errors
-        // Act & Assert (should not throw)
+        // Act and verify (should not throw)
         BillingFacadeDemo.Run();
     }
 }

--- a/test/PatternKit.Examples.Tests/Generators/FactoryGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/FactoryGeneratorExamplesTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.Extensions.DependencyInjection;
 using PatternKit.Examples.Generators.Factories;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.GeneratorTests;
 
 public sealed class ServiceModulesTests
 {
+    [Scenario("ConfigureModule Metrics Adds MetricsSink")]
     [Fact]
     public void ConfigureModule_Metrics_Adds_MetricsSink()
     {
@@ -13,9 +15,10 @@ public sealed class ServiceModulesTests
         ServiceModules.ConfigureModule("metrics", services);
         var provider = services.BuildServiceProvider();
 
-        Assert.NotNull(provider.GetService<IMetricsSink>());
+        ScenarioExpect.NotNull(provider.GetService<IMetricsSink>());
     }
 
+    [Scenario("ConfigureModule Caching Adds CacheProvider")]
     [Fact]
     public void ConfigureModule_Caching_Adds_CacheProvider()
     {
@@ -24,9 +27,10 @@ public sealed class ServiceModulesTests
         ServiceModules.ConfigureModule("caching", services);
         var provider = services.BuildServiceProvider();
 
-        Assert.NotNull(provider.GetService<ICacheProvider>());
+        ScenarioExpect.NotNull(provider.GetService<ICacheProvider>());
     }
 
+    [Scenario("ConfigureModule Workers Adds Worker")]
     [Fact]
     public void ConfigureModule_Workers_Adds_Worker()
     {
@@ -35,9 +39,10 @@ public sealed class ServiceModulesTests
         ServiceModules.ConfigureModule("workers", services);
         var provider = services.BuildServiceProvider();
 
-        Assert.NotNull(provider.GetService<IWorker>());
+        ScenarioExpect.NotNull(provider.GetService<IWorker>());
     }
 
+    [Scenario("ConfigureModule Unknown Uses Defaults")]
     [Fact]
     public void ConfigureModule_Unknown_Uses_Defaults()
     {
@@ -47,42 +52,46 @@ public sealed class ServiceModulesTests
         var provider = services.BuildServiceProvider();
 
         // Defaults add MetricsSink and Worker
-        Assert.NotNull(provider.GetService<IMetricsSink>());
-        Assert.NotNull(provider.GetService<IWorker>());
+        ScenarioExpect.NotNull(provider.GetService<IMetricsSink>());
+        ScenarioExpect.NotNull(provider.GetService<IWorker>());
     }
 }
 
 public sealed class ServiceModuleBootstrapTests
 {
+    [Scenario("Build With Metrics Module")]
     [Fact]
     public void Build_With_Metrics_Module()
     {
         var provider = ServiceModuleBootstrap.Build(["metrics"]);
 
-        Assert.NotNull(provider.GetService<IMetricsSink>());
+        ScenarioExpect.NotNull(provider.GetService<IMetricsSink>());
     }
 
+    [Scenario("Build With Multiple Modules")]
     [Fact]
     public void Build_With_Multiple_Modules()
     {
         var provider = ServiceModuleBootstrap.Build(["metrics", "caching", "workers"]);
 
-        Assert.NotNull(provider.GetService<IMetricsSink>());
-        Assert.NotNull(provider.GetService<ICacheProvider>());
-        Assert.NotNull(provider.GetService<IWorker>());
+        ScenarioExpect.NotNull(provider.GetService<IMetricsSink>());
+        ScenarioExpect.NotNull(provider.GetService<ICacheProvider>());
+        ScenarioExpect.NotNull(provider.GetService<IWorker>());
     }
 
+    [Scenario("Build With Empty Modules")]
     [Fact]
     public void Build_With_Empty_Modules()
     {
         var provider = ServiceModuleBootstrap.Build([]);
 
-        Assert.NotNull(provider);
+        ScenarioExpect.NotNull(provider);
     }
 }
 
 public sealed class ConsoleMetricsSinkTests
 {
+    [Scenario("Write Does Not Throw")]
     [Fact]
     public void Write_Does_Not_Throw()
     {
@@ -94,6 +103,7 @@ public sealed class ConsoleMetricsSinkTests
 
 public sealed class MemoryCacheProviderTests
 {
+    [Scenario("PrimeAsync Completes Successfully")]
     [Fact]
     public async Task PrimeAsync_Completes_Successfully()
     {
@@ -102,6 +112,7 @@ public sealed class MemoryCacheProviderTests
         await cache.PrimeAsync(CancellationToken.None);
     }
 
+    [Scenario("PrimeAsync With Cancellation")]
     [Fact]
     public async Task PrimeAsync_With_Cancellation()
     {
@@ -114,6 +125,7 @@ public sealed class MemoryCacheProviderTests
 
 public sealed class BackgroundWorkerTests
 {
+    [Scenario("Start Does Not Throw")]
     [Fact]
     public void Start_Does_Not_Throw()
     {
@@ -125,6 +137,7 @@ public sealed class BackgroundWorkerTests
 
 public sealed class OrchestratorStepFactoryTests
 {
+    [Scenario("CreateFromKey Seed Returns SeedDataStep")]
     [Fact]
     public void CreateFromKey_Seed_Returns_SeedDataStep()
     {
@@ -133,9 +146,10 @@ public sealed class OrchestratorStepFactoryTests
 
         var step = factory.CreateFromKey("seed");
 
-        Assert.IsType<SeedDataStep>(step);
+        ScenarioExpect.IsType<SeedDataStep>(step);
     }
 
+    [Scenario("CreateFromKey WarmCache Returns WarmCacheStep")]
     [Fact]
     public void CreateFromKey_WarmCache_Returns_WarmCacheStep()
     {
@@ -144,9 +158,10 @@ public sealed class OrchestratorStepFactoryTests
 
         var step = factory.CreateFromKey("warm-cache");
 
-        Assert.IsType<WarmCacheStep>(step);
+        ScenarioExpect.IsType<WarmCacheStep>(step);
     }
 
+    [Scenario("CreateFromKey StartWorkers Returns StartWorkersStep")]
     [Fact]
     public void CreateFromKey_StartWorkers_Returns_StartWorkersStep()
     {
@@ -155,9 +170,10 @@ public sealed class OrchestratorStepFactoryTests
 
         var step = factory.CreateFromKey("start-workers");
 
-        Assert.IsType<StartWorkersStep>(step);
+        ScenarioExpect.IsType<StartWorkersStep>(step);
     }
 
+    [Scenario("CreateFromKey CaseInsensitive")]
     [Fact]
     public void CreateFromKey_CaseInsensitive()
     {
@@ -168,35 +184,39 @@ public sealed class OrchestratorStepFactoryTests
         var step2 = factory.CreateFromKey("Seed");
         var step3 = factory.CreateFromKey("seed");
 
-        Assert.IsType<SeedDataStep>(step1);
-        Assert.IsType<SeedDataStep>(step2);
-        Assert.IsType<SeedDataStep>(step3);
+        ScenarioExpect.IsType<SeedDataStep>(step1);
+        ScenarioExpect.IsType<SeedDataStep>(step2);
+        ScenarioExpect.IsType<SeedDataStep>(step3);
     }
 
+    [Scenario("CreateFromKey UnknownKey Throws")]
     [Fact]
     public void CreateFromKey_UnknownKey_Throws()
     {
         var services = new ServiceCollection().BuildServiceProvider();
         var factory = new OrchestratorStepFactory(services);
 
-        Assert.Throws<KeyNotFoundException>(() => factory.CreateFromKey("unknown"));
+        ScenarioExpect.Throws<KeyNotFoundException>(() => factory.CreateFromKey("unknown"));
     }
 
+    [Scenario("Constructor Null Services Throws")]
     [Fact]
     public void Constructor_Null_Services_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new OrchestratorStepFactory(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new OrchestratorStepFactory(null!));
     }
 
+    [Scenario("CreateFromKey Null Key Throws")]
     [Fact]
     public void CreateFromKey_Null_Key_Throws()
     {
         var services = new ServiceCollection().BuildServiceProvider();
         var factory = new OrchestratorStepFactory(services);
 
-        Assert.Throws<ArgumentNullException>(() => factory.CreateFromKey(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => factory.CreateFromKey(null!));
     }
 
+    [Scenario("ApplicationOrchestrator RunsConfiguredStepsAgainstServices")]
     [Fact]
     public async Task ApplicationOrchestrator_RunsConfiguredStepsAgainstServices()
     {
@@ -211,8 +231,8 @@ public sealed class OrchestratorStepFactoryTests
 
         await orchestrator.RunAsync(["seed", "warm-cache", "start-workers"]);
 
-        Assert.True(seeder.WasSeeded);
-        Assert.True(worker.WasStarted);
+        ScenarioExpect.True(seeder.WasSeeded);
+        ScenarioExpect.True(worker.WasStarted);
     }
 
     private sealed class TestSeeder : ISeeder
@@ -230,6 +250,7 @@ public sealed class OrchestratorStepFactoryTests
 
 public sealed class SeedDataStepTests
 {
+    [Scenario("ExecuteAsync Without Seeder")]
     [Fact]
     public async Task ExecuteAsync_Without_Seeder()
     {
@@ -239,6 +260,7 @@ public sealed class SeedDataStepTests
         await step.ExecuteAsync(services);
     }
 
+    [Scenario("ExecuteAsync With Seeder")]
     [Fact]
     public async Task ExecuteAsync_With_Seeder()
     {
@@ -250,7 +272,7 @@ public sealed class SeedDataStepTests
 
         await step.ExecuteAsync(services);
 
-        Assert.True(seeder.WasSeeded);
+        ScenarioExpect.True(seeder.WasSeeded);
     }
 
     private sealed class TestSeeder : ISeeder
@@ -262,6 +284,7 @@ public sealed class SeedDataStepTests
 
 public sealed class WarmCacheStepTests
 {
+    [Scenario("ExecuteAsync Without CacheProvider")]
     [Fact]
     public async Task ExecuteAsync_Without_CacheProvider()
     {
@@ -271,6 +294,7 @@ public sealed class WarmCacheStepTests
         await step.ExecuteAsync(services);
     }
 
+    [Scenario("ExecuteAsync With CacheProvider")]
     [Fact]
     public async Task ExecuteAsync_With_CacheProvider()
     {
@@ -285,6 +309,7 @@ public sealed class WarmCacheStepTests
 
 public sealed class StartWorkersStepTests
 {
+    [Scenario("ExecuteAsync Without Worker")]
     [Fact]
     public async Task ExecuteAsync_Without_Worker()
     {
@@ -294,6 +319,7 @@ public sealed class StartWorkersStepTests
         await step.ExecuteAsync(services);
     }
 
+    [Scenario("ExecuteAsync With Worker")]
     [Fact]
     public async Task ExecuteAsync_With_Worker()
     {
@@ -305,7 +331,7 @@ public sealed class StartWorkersStepTests
 
         await step.ExecuteAsync(services);
 
-        Assert.True(worker.WasStarted);
+        ScenarioExpect.True(worker.WasStarted);
     }
 
     private sealed class TestWorker : IWorker

--- a/test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/MementoGeneratorExamplesTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Examples.Generators.Memento;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.GeneratorTests;
 
 public sealed class MementoGeneratorExamplesTests
 {
+    [Scenario("EditorState EditingOperations AreImmutableAndClampRanges")]
     [Fact]
     public void EditorState_EditingOperations_AreImmutableAndClampRanges()
     {
@@ -14,16 +16,17 @@ public sealed class MementoGeneratorExamplesTests
         var replaced = selected.Insert("Hi");
         var backspaced = replaced.Backspace();
 
-        Assert.Equal("", initial.Text);
-        Assert.Equal("Hello world", inserted.Text);
-        Assert.True(selected.HasSelection);
-        Assert.Equal(0, selected.SelectionStart);
-        Assert.Equal(inserted.Text.Length, selected.SelectionEnd);
-        Assert.Equal("Hi", replaced.Text);
-        Assert.Equal("H", backspaced.Text);
-        Assert.Equal("Text='H' Cursor=1", backspaced.ToString());
+        ScenarioExpect.Equal("", initial.Text);
+        ScenarioExpect.Equal("Hello world", inserted.Text);
+        ScenarioExpect.True(selected.HasSelection);
+        ScenarioExpect.Equal(0, selected.SelectionStart);
+        ScenarioExpect.Equal(inserted.Text.Length, selected.SelectionEnd);
+        ScenarioExpect.Equal("Hi", replaced.Text);
+        ScenarioExpect.Equal("H", backspaced.Text);
+        ScenarioExpect.Equal("Text='H' Cursor=1", backspaced.ToString());
     }
 
+    [Scenario("TextEditor TracksUndoRedoAndClear")]
     [Fact]
     public void TextEditor_TracksUndoRedoAndClear()
     {
@@ -32,33 +35,35 @@ public sealed class MementoGeneratorExamplesTests
         editor.Apply(state => state.Insert("Hello"));
         editor.Apply(state => state.Insert(" world"));
 
-        Assert.Equal("Hello world", editor.Current.Text);
-        Assert.True(editor.CanUndo);
-        Assert.False(editor.CanRedo);
+        ScenarioExpect.Equal("Hello world", editor.Current.Text);
+        ScenarioExpect.True(editor.CanUndo);
+        ScenarioExpect.False(editor.CanRedo);
 
-        Assert.True(editor.Undo());
-        Assert.Equal("Hello", editor.Current.Text);
-        Assert.True(editor.Redo());
-        Assert.Equal("Hello world", editor.Current.Text);
+        ScenarioExpect.True(editor.Undo());
+        ScenarioExpect.Equal("Hello", editor.Current.Text);
+        ScenarioExpect.True(editor.Redo());
+        ScenarioExpect.Equal("Hello world", editor.Current.Text);
 
         editor.Clear();
 
-        Assert.Equal(EditorStateDemo.EditorState.Empty(), editor.Current);
-        Assert.False(editor.CanUndo);
-        Assert.False(editor.CanRedo);
+        ScenarioExpect.Equal(EditorStateDemo.EditorState.Empty(), editor.Current);
+        ScenarioExpect.False(editor.CanUndo);
+        ScenarioExpect.False(editor.CanRedo);
     }
 
+    [Scenario("EditorStateDemo RunAndManualSnapshot ReturnExpectedLogEntries")]
     [Fact]
     public void EditorStateDemo_RunAndManualSnapshot_ReturnExpectedLogEntries()
     {
         var runLog = EditorStateDemo.Run();
         var manualLog = EditorStateDemo.RunManualSnapshot();
 
-        Assert.Contains(runLog, line => line.StartsWith("Final:", StringComparison.Ordinal));
-        Assert.Contains(runLog, line => line.Contains("Redo failed", StringComparison.Ordinal));
-        Assert.Contains(manualLog, line => line == "Restored equals State1: True");
+        ScenarioExpect.Contains(runLog, line => line.StartsWith("Final:", StringComparison.Ordinal));
+        ScenarioExpect.Contains(runLog, line => line.Contains("Redo failed", StringComparison.Ordinal));
+        ScenarioExpect.Contains(manualLog, line => line == "Restored equals State1: True");
     }
 
+    [Scenario("GameState MutatorsAndSaveLoad WorkAsExpected")]
     [Fact]
     public void GameState_MutatorsAndSaveLoad_WorkAsExpected()
     {
@@ -70,14 +75,15 @@ public sealed class MementoGeneratorExamplesTests
         state.AddScore(250);
         state.AdvanceLevel();
 
-        Assert.Equal(3, state.PlayerX);
-        Assert.Equal(4, state.PlayerY);
-        Assert.Equal(100, state.Health);
-        Assert.Equal(250, state.Score);
-        Assert.Equal(2, state.Level);
-        Assert.Equal("Level 2: Health=100, Score=250, Pos=(3,4)", state.ToString());
+        ScenarioExpect.Equal(3, state.PlayerX);
+        ScenarioExpect.Equal(4, state.PlayerY);
+        ScenarioExpect.Equal(100, state.Health);
+        ScenarioExpect.Equal(250, state.Score);
+        ScenarioExpect.Equal(2, state.Level);
+        ScenarioExpect.Equal("Level 2: Health=100, Score=250, Pos=(3,4)", state.ToString());
     }
 
+    [Scenario("GameSession PerformActionMutatesStateAndReportsNoRedoWhenNoForwardHistoryExists")]
     [Fact]
     public void GameSession_PerformActionMutatesStateAndReportsNoRedoWhenNoForwardHistoryExists()
     {
@@ -86,18 +92,19 @@ public sealed class MementoGeneratorExamplesTests
         session.PerformAction(state => state.MovePlayer(5, 3), "move");
         session.PerformAction(state => state.TakeDamage(10), "damage");
 
-        Assert.Equal(5, session.State.PlayerX);
-        Assert.Equal(3, session.State.PlayerY);
-        Assert.Equal(90, session.State.Health);
-        Assert.False(session.RedoToCheckpoint());
+        ScenarioExpect.Equal(5, session.State.PlayerX);
+        ScenarioExpect.Equal(3, session.State.PlayerY);
+        ScenarioExpect.Equal(90, session.State.Health);
+        ScenarioExpect.False(session.RedoToCheckpoint());
     }
 
+    [Scenario("GameSession DoesNotUndoWhenGeneratedHistorySkipsDuplicateMutableState")]
     [Fact]
     public void GameSession_DoesNotUndoWhenGeneratedHistorySkipsDuplicateMutableState()
     {
         var session = new GameStateDemo.GameSession();
 
-        Assert.False(session.UndoToCheckpoint());
+        ScenarioExpect.False(session.UndoToCheckpoint());
         session.PerformAction(state => state.MovePlayer(2, 3), "move");
         session.PerformAction(state =>
         {
@@ -105,23 +112,24 @@ public sealed class MementoGeneratorExamplesTests
             state.IsPaused = true;
         }, "damage and pause");
 
-        Assert.False(session.UndoToCheckpoint());
-        Assert.Equal(2, session.State.PlayerX);
-        Assert.Equal(3, session.State.PlayerY);
-        Assert.Equal(85, session.State.Health);
-        Assert.True(session.State.IsPaused);
-        Assert.False(session.RedoToCheckpoint());
+        ScenarioExpect.False(session.UndoToCheckpoint());
+        ScenarioExpect.Equal(2, session.State.PlayerX);
+        ScenarioExpect.Equal(3, session.State.PlayerY);
+        ScenarioExpect.Equal(85, session.State.Health);
+        ScenarioExpect.True(session.State.IsPaused);
+        ScenarioExpect.False(session.RedoToCheckpoint());
     }
 
+    [Scenario("GameState HealthIsClampedAndSaveLoadRestoresCapturedValues")]
     [Fact]
     public void GameState_HealthIsClampedAndSaveLoadRestoresCapturedValues()
     {
         var state = new GameStateDemo.GameState();
 
         state.TakeDamage(500);
-        Assert.Equal(0, state.Health);
+        ScenarioExpect.Equal(0, state.Health);
         state.Heal(500);
-        Assert.Equal(100, state.Health);
+        ScenarioExpect.Equal(100, state.Health);
 
         state.MovePlayer(1, 1);
         state.AddScore(10);
@@ -132,20 +140,21 @@ public sealed class MementoGeneratorExamplesTests
         state.AddScore(90);
         save.Restore(state);
 
-        Assert.Equal(1, state.PlayerX);
-        Assert.Equal(1, state.PlayerY);
-        Assert.Equal(100, state.Health);
-        Assert.Equal(10, state.Score);
+        ScenarioExpect.Equal(1, state.PlayerX);
+        ScenarioExpect.Equal(1, state.PlayerY);
+        ScenarioExpect.Equal(100, state.Health);
+        ScenarioExpect.Equal(10, state.Score);
     }
 
+    [Scenario("GameStateDemo RunAndSaveLoad ReturnExpectedLogEntries")]
     [Fact]
     public void GameStateDemo_RunAndSaveLoad_ReturnExpectedLogEntries()
     {
         var runLog = GameStateDemo.Run();
         var saveLoadLog = GameStateDemo.RunSaveLoad();
 
-        Assert.Contains(runLog, line => line.StartsWith("Final:", StringComparison.Ordinal));
-        Assert.Contains(runLog, line => line.Contains("Redo failed", StringComparison.Ordinal));
-        Assert.Contains(saveLoadLog, line => line.StartsWith("Game loaded:", StringComparison.Ordinal));
+        ScenarioExpect.Contains(runLog, line => line.StartsWith("Final:", StringComparison.Ordinal));
+        ScenarioExpect.Contains(runLog, line => line.Contains("Redo failed", StringComparison.Ordinal));
+        ScenarioExpect.Contains(saveLoadLog, line => line.StartsWith("Game loaded:", StringComparison.Ordinal));
     }
 }

--- a/test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/StateGeneratorExamplesTests.cs
@@ -9,16 +9,18 @@ namespace PatternKit.Examples.Tests.GeneratorTests;
 [Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
 public sealed class StateGeneratorExamplesTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    [Scenario("OrderFlow StartsInDraftAndExposesAvailableTriggers")]
     [Fact]
     public void OrderFlow_StartsInDraftAndExposesAvailableTriggers()
     {
         var order = new OrderFlow("ORD-TEST", 25m);
 
-        Assert.Equal(OrderState.Draft, order.State);
-        Assert.Equal("Order is being prepared", order.GetStateDescription());
-        Assert.Equal([OrderTrigger.Submit, OrderTrigger.Cancel], order.GetAvailableTriggers().ToArray());
+        ScenarioExpect.Equal(OrderState.Draft, order.State);
+        ScenarioExpect.Equal("Order is being prepared", order.GetStateDescription());
+        ScenarioExpect.Equal([OrderTrigger.Submit, OrderTrigger.Cancel], order.GetAvailableTriggers().ToArray());
     }
 
+    [Scenario("OrderFlow CompletesHappyPath")]
     [Fact]
     public async Task OrderFlow_CompletesHappyPath()
     {
@@ -28,10 +30,11 @@ public sealed class StateGeneratorExamplesTests(ITestOutputHelper output) : Tiny
         await order.FireAsync(OrderTrigger.Pay, CancellationToken.None);
         order.Fire(OrderTrigger.Ship);
 
-        Assert.Equal(OrderState.Shipped, order.State);
-        Assert.Equal("Order is on its way to you", order.GetStateDescription());
+        ScenarioExpect.Equal(OrderState.Shipped, order.State);
+        ScenarioExpect.Equal("Order is on its way to you", order.GetStateDescription());
     }
 
+    [Scenario("OrderFlow GuardBlocksInvalidPayment")]
     [Fact]
     public void OrderFlow_GuardBlocksInvalidPayment()
     {
@@ -39,10 +42,11 @@ public sealed class StateGeneratorExamplesTests(ITestOutputHelper output) : Tiny
 
         order.Fire(OrderTrigger.Submit);
 
-        Assert.False(order.CanFire(OrderTrigger.Pay));
-        Assert.Equal(OrderState.Submitted, order.State);
+        ScenarioExpect.False(order.CanFire(OrderTrigger.Pay));
+        ScenarioExpect.Equal(OrderState.Submitted, order.State);
     }
 
+    [Scenario("OrderFlow CanCancelBeforePayment")]
     [Fact]
     public void OrderFlow_CanCancelBeforePayment()
     {
@@ -51,10 +55,11 @@ public sealed class StateGeneratorExamplesTests(ITestOutputHelper output) : Tiny
         order.Fire(OrderTrigger.Submit);
         order.Fire(OrderTrigger.Cancel);
 
-        Assert.Equal(OrderState.Cancelled, order.State);
-        Assert.Equal("Order has been cancelled", order.GetStateDescription());
+        ScenarioExpect.Equal(OrderState.Cancelled, order.State);
+        ScenarioExpect.Equal("Order has been cancelled", order.GetStateDescription());
     }
 
+    [Scenario("DocumentWorkflow RequiresReviewCommentBeforeApproval")]
     [Fact]
     public async Task DocumentWorkflow_RequiresReviewCommentBeforeApproval()
     {
@@ -62,17 +67,18 @@ public sealed class StateGeneratorExamplesTests(ITestOutputHelper output) : Tiny
 
         workflow.Fire(DocumentAction.SubmitForReview);
 
-        Assert.Equal(DocumentState.PendingReview, workflow.State);
-        Assert.False(workflow.CanFire(DocumentAction.Approve));
+        ScenarioExpect.Equal(DocumentState.PendingReview, workflow.State);
+        ScenarioExpect.False(workflow.CanFire(DocumentAction.Approve));
 
         workflow.ReviewComments.Add("Looks good.");
         workflow.Fire(DocumentAction.Approve);
         await workflow.FireAsync(DocumentAction.Publish, CancellationToken.None);
         workflow.Fire(DocumentAction.Archive);
 
-        Assert.Equal(DocumentState.Archived, workflow.State);
+        ScenarioExpect.Equal(DocumentState.Archived, workflow.State);
     }
 
+    [Scenario("DocumentWorkflow RejectionCanReturnToDraft")]
     [Fact]
     public void DocumentWorkflow_RejectionCanReturnToDraft()
     {
@@ -83,8 +89,8 @@ public sealed class StateGeneratorExamplesTests(ITestOutputHelper output) : Tiny
         workflow.Fire(DocumentAction.Reject);
         workflow.Fire(DocumentAction.Revise);
 
-        Assert.Equal(DocumentState.Draft, workflow.State);
-        Assert.Empty(workflow.ReviewComments);
+        ScenarioExpect.Equal(DocumentState.Draft, workflow.State);
+        ScenarioExpect.Empty(workflow.ReviewComments);
     }
 
     [Scenario("Order flow demo suite covers happy path, cancellation, guard failure, and state-based logic")]

--- a/test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs
+++ b/test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs
@@ -8,6 +8,7 @@ namespace PatternKit.Examples.Tests.GeneratorTests;
 [Feature("Visitor generator examples")]
 public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    [Scenario("ResultVisitor DispatchesToConcreteDocumentHandlers")]
     [Fact]
     public void ResultVisitor_DispatchesToConcreteDocumentHandlers()
     {
@@ -19,12 +20,13 @@ public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : Ti
             .Default(document => $"default:{document.FileName}")
             .Build();
 
-        Assert.Equal("pdf:3", new PdfDocument { FileName = "a.pdf", PageCount = 3 }.Accept(visitor));
-        Assert.Equal("word:400", new WordDocument { FileName = "a.docx", WordCount = 400 }.Accept(visitor));
-        Assert.Equal("sheet:2", new SpreadsheetDocument { FileName = "a.xlsx", SheetCount = 2 }.Accept(visitor));
-        Assert.Equal("markdown:9", new MarkdownDocument { FileName = "README.md", LineCount = 9 }.Accept(visitor));
+        ScenarioExpect.Equal("pdf:3", new PdfDocument { FileName = "a.pdf", PageCount = 3 }.Accept(visitor));
+        ScenarioExpect.Equal("word:400", new WordDocument { FileName = "a.docx", WordCount = 400 }.Accept(visitor));
+        ScenarioExpect.Equal("sheet:2", new SpreadsheetDocument { FileName = "a.xlsx", SheetCount = 2 }.Accept(visitor));
+        ScenarioExpect.Equal("markdown:9", new MarkdownDocument { FileName = "README.md", LineCount = 9 }.Accept(visitor));
     }
 
+    [Scenario("ActionVisitor CollectsMetadataForEachConcreteDocument")]
     [Fact]
     public void ActionVisitor_CollectsMetadataForEachConcreteDocument()
     {
@@ -42,11 +44,12 @@ public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : Ti
         new SpreadsheetDocument { FileName = "budget.xlsx", HasFormulas = true }.Accept(visitor);
         new MarkdownDocument { FileName = "README.md", HasCodeBlocks = true }.Accept(visitor);
 
-        Assert.Equal(
+        ScenarioExpect.Equal(
             ["pdf:contract.pdf:True", "word:memo.docx:False", "sheet:budget.xlsx:True", "markdown:README.md:True"],
             log);
     }
 
+    [Scenario("AsyncVisitors DispatchToConcreteDocumentHandlers")]
     [Fact]
     public async Task AsyncVisitors_DispatchToConcreteDocumentHandlers()
     {
@@ -75,10 +78,11 @@ public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : Ti
         var result = await document.AcceptAsync(resultVisitor);
         await document.AcceptAsync(actionVisitor);
 
-        Assert.Equal("pdf:DOC-1", result);
-        Assert.Equal(["pdf:DOC-1"], actionLog);
+        ScenarioExpect.Equal("pdf:DOC-1", result);
+        ScenarioExpect.Equal(["pdf:DOC-1"], actionLog);
     }
 
+    [Scenario("DocumentProcessingDemo RunAsync Completes")]
     [Fact]
     public async Task DocumentProcessingDemo_RunAsync_Completes()
     {
@@ -238,8 +242,8 @@ public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : Ti
         var method = typeof(DocumentProcessingDemo).GetMethod(
             methodName,
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        Assert.NotNull(method);
-        return Assert.IsType<DocumentProcessingDemo.ValidationResult>(method.Invoke(null, [document]));
+        ScenarioExpect.NotNull(method);
+        return ScenarioExpect.IsType<DocumentProcessingDemo.ValidationResult>(method.Invoke(null, [document]));
     }
 
     private static async Task<string> InvokeIndexAsync(string methodName, Document document)
@@ -247,8 +251,8 @@ public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : Ti
         var method = typeof(DocumentProcessingDemo).GetMethod(
             methodName,
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        Assert.NotNull(method);
-        var task = Assert.IsAssignableFrom<Task<string>>(method.Invoke(null, [document, CancellationToken.None]));
+        ScenarioExpect.NotNull(method);
+        var task = ScenarioExpect.IsAssignableFrom<Task<string>>(method.Invoke(null, [document, CancellationToken.None]));
         return await task;
     }
 
@@ -257,8 +261,8 @@ public sealed class VisitorGeneratorExamplesTests(ITestOutputHelper output) : Ti
         var method = typeof(DocumentProcessingDemo).GetMethod(
             methodName,
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        Assert.NotNull(method);
-        var task = Assert.IsAssignableFrom<Task>(method.Invoke(null, [document, scans, CancellationToken.None]));
+        ScenarioExpect.NotNull(method);
+        var task = ScenarioExpect.IsAssignableFrom<Task>(method.Invoke(null, [document, scans, CancellationToken.None]));
         await task;
     }
 

--- a/test/PatternKit.Examples.Tests/InterpreterDemo/InterpreterDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/InterpreterDemo/InterpreterDemoTests.cs
@@ -1,23 +1,26 @@
 using PatternKit.Examples.InterpreterDemo;
 using static PatternKit.Examples.InterpreterDemo.InterpreterDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.InterpreterDemoTests;
 
 public sealed class InterpreterDemoTests
 {
+    [Scenario("PricingContext Default Values")]
     [Fact]
     public void PricingContext_Default_Values()
     {
         var ctx = new PricingContext();
 
-        Assert.Equal(0m, ctx.CartTotal);
-        Assert.Equal(0, ctx.ItemCount);
-        Assert.Equal("Standard", ctx.CustomerTier);
-        Assert.False(ctx.IsHoliday);
-        Assert.Equal("", ctx.PromoCode);
-        Assert.NotNull(ctx.Variables);
+        ScenarioExpect.Equal(0m, ctx.CartTotal);
+        ScenarioExpect.Equal(0, ctx.ItemCount);
+        ScenarioExpect.Equal("Standard", ctx.CustomerTier);
+        ScenarioExpect.False(ctx.IsHoliday);
+        ScenarioExpect.Equal("", ctx.PromoCode);
+        ScenarioExpect.NotNull(ctx.Variables);
     }
 
+    [Scenario("CreatePricingInterpreter Numeric Literals")]
     [Fact]
     public void CreatePricingInterpreter_Numeric_Literals()
     {
@@ -28,9 +31,10 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("number", "42.5"),
             ctx);
 
-        Assert.Equal(42.5m, result);
+        ScenarioExpect.Equal(42.5m, result);
     }
 
+    [Scenario("CreatePricingInterpreter Percent Literals")]
     [Fact]
     public void CreatePricingInterpreter_Percent_Literals()
     {
@@ -41,9 +45,10 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("percent", "15%"),
             ctx);
 
-        Assert.Equal(0.15m, result);
+        ScenarioExpect.Equal(0.15m, result);
     }
 
+    [Scenario("CreatePricingInterpreter Var CartTotal")]
     [Fact]
     public void CreatePricingInterpreter_Var_CartTotal()
     {
@@ -54,9 +59,10 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("var", "cart_total"),
             ctx);
 
-        Assert.Equal(100m, result);
+        ScenarioExpect.Equal(100m, result);
     }
 
+    [Scenario("CreatePricingInterpreter Var TierDiscount Gold")]
     [Fact]
     public void CreatePricingInterpreter_Var_TierDiscount_Gold()
     {
@@ -67,9 +73,10 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("var", "tier_discount"),
             ctx);
 
-        Assert.Equal(0.10m, result);
+        ScenarioExpect.Equal(0.10m, result);
     }
 
+    [Scenario("CreatePricingInterpreter Var TierDiscount Platinum")]
     [Fact]
     public void CreatePricingInterpreter_Var_TierDiscount_Platinum()
     {
@@ -80,9 +87,10 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("var", "tier_discount"),
             ctx);
 
-        Assert.Equal(0.15m, result);
+        ScenarioExpect.Equal(0.15m, result);
     }
 
+    [Scenario("CreatePricingInterpreter Var TierDiscount Diamond")]
     [Fact]
     public void CreatePricingInterpreter_Var_TierDiscount_Diamond()
     {
@@ -93,9 +101,10 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("var", "tier_discount"),
             ctx);
 
-        Assert.Equal(0.20m, result);
+        ScenarioExpect.Equal(0.20m, result);
     }
 
+    [Scenario("CreatePricingInterpreter Var CustomVariable")]
     [Fact]
     public void CreatePricingInterpreter_Var_CustomVariable()
     {
@@ -106,9 +115,10 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("var", "custom"),
             ctx);
 
-        Assert.Equal(99m, result);
+        ScenarioExpect.Equal(99m, result);
     }
 
+    [Scenario("TierDiscountRule Gold Customer")]
     [Fact]
     public void TierDiscountRule_Gold_Customer()
     {
@@ -117,9 +127,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(TierDiscountRule, ctx);
 
-        Assert.Equal(15m, result); // 150 * 0.10 = 15
+        ScenarioExpect.Equal(15m, result); // 150 * 0.10 = 15
     }
 
+    [Scenario("ThresholdDiscountRule Below Threshold")]
     [Fact]
     public void ThresholdDiscountRule_Below_Threshold()
     {
@@ -128,9 +139,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(ThresholdDiscountRule, ctx);
 
-        Assert.Equal(0m, result);
+        ScenarioExpect.Equal(0m, result);
     }
 
+    [Scenario("ThresholdDiscountRule Above Threshold")]
     [Fact]
     public void ThresholdDiscountRule_Above_Threshold()
     {
@@ -139,9 +151,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(ThresholdDiscountRule, ctx);
 
-        Assert.Equal(5m, result);
+        ScenarioExpect.Equal(5m, result);
     }
 
+    [Scenario("HolidayDiscountRule Below Cap")]
     [Fact]
     public void HolidayDiscountRule_Below_Cap()
     {
@@ -150,9 +163,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(HolidayDiscountRule, ctx);
 
-        Assert.Equal(12m, result); // 80 * 0.15 = 12
+        ScenarioExpect.Equal(12m, result); // 80 * 0.15 = 12
     }
 
+    [Scenario("HolidayDiscountRule Capped At 20")]
     [Fact]
     public void HolidayDiscountRule_Capped_At_20()
     {
@@ -161,9 +175,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(HolidayDiscountRule, ctx);
 
-        Assert.Equal(20m, result); // 200 * 0.15 = 30, but capped at 20
+        ScenarioExpect.Equal(20m, result); // 200 * 0.15 = 30, but capped at 20
     }
 
+    [Scenario("CreateEligibilityInterpreter Tier Check")]
     [Fact]
     public void CreateEligibilityInterpreter_Tier_Check()
     {
@@ -179,10 +194,11 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("tier", "Gold"),
             standardCtx);
 
-        Assert.True(goldResult);
-        Assert.False(standardResult);
+        ScenarioExpect.True(goldResult);
+        ScenarioExpect.False(standardResult);
     }
 
+    [Scenario("CreateEligibilityInterpreter CartOver Check")]
     [Fact]
     public void CreateEligibilityInterpreter_CartOver_Check()
     {
@@ -198,10 +214,11 @@ public sealed class InterpreterDemoTests
             PatternKit.Behavioral.Interpreter.ExpressionExtensions.Terminal("cartOver", "100"),
             lowCart);
 
-        Assert.True(highResult);
-        Assert.False(lowResult);
+        ScenarioExpect.True(highResult);
+        ScenarioExpect.False(lowResult);
     }
 
+    [Scenario("VipEligibilityRule Gold High Cart")]
     [Fact]
     public void VipEligibilityRule_Gold_High_Cart()
     {
@@ -210,9 +227,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(VipEligibilityRule, ctx);
 
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 
+    [Scenario("VipEligibilityRule Standard High Cart")]
     [Fact]
     public void VipEligibilityRule_Standard_High_Cart()
     {
@@ -221,9 +239,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(VipEligibilityRule, ctx);
 
-        Assert.False(result);
+        ScenarioExpect.False(result);
     }
 
+    [Scenario("VipEligibilityRule Gold Low Cart")]
     [Fact]
     public void VipEligibilityRule_Gold_Low_Cart()
     {
@@ -232,9 +251,10 @@ public sealed class InterpreterDemoTests
 
         var result = interpreter.Interpret(VipEligibilityRule, ctx);
 
-        Assert.False(result);
+        ScenarioExpect.False(result);
     }
 
+    [Scenario("CreateAsyncPricingInterpreter PromoCode Lookup")]
     [Fact]
     public async Task CreateAsyncPricingInterpreter_PromoCode_Lookup()
     {
@@ -248,9 +268,10 @@ public sealed class InterpreterDemoTests
 
         var result = await interpreter.InterpretAsync(promoRule, ctx);
 
-        Assert.Equal(25m, result); // 100 * 0.25 = 25
+        ScenarioExpect.Equal(25m, result); // 100 * 0.25 = 25
     }
 
+    [Scenario("CreateAsyncPricingInterpreter Unknown PromoCode")]
     [Fact]
     public async Task CreateAsyncPricingInterpreter_Unknown_PromoCode()
     {
@@ -263,15 +284,17 @@ public sealed class InterpreterDemoTests
 
         var result = await interpreter.InterpretAsync(promoRule, ctx);
 
-        Assert.Equal(0m, result);
+        ScenarioExpect.Equal(0m, result);
     }
 
+    [Scenario("RunAsync Executes Without Errors")]
     [Fact]
     public async Task RunAsync_Executes_Without_Errors()
     {
         await PatternKit.Examples.InterpreterDemo.InterpreterDemo.RunAsync();
     }
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/IteratorDemo/IteratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/IteratorDemo/IteratorDemoTests.cs
@@ -1,62 +1,69 @@
 using PatternKit.Examples.IteratorDemo;
 using static PatternKit.Examples.IteratorDemo.IteratorDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.IteratorDemoTests;
 
 public sealed class IteratorDemoTests
 {
+    [Scenario("SensorReading Record Works")]
     [Fact]
     public void SensorReading_Record_Works()
     {
         var reading = new SensorReading("sensor-001", "temperature", 25.5, DateTime.UtcNow);
 
-        Assert.Equal("sensor-001", reading.SensorId);
-        Assert.Equal("temperature", reading.Type);
-        Assert.Equal(25.5, reading.Value);
+        ScenarioExpect.Equal("sensor-001", reading.SensorId);
+        ScenarioExpect.Equal("temperature", reading.Type);
+        ScenarioExpect.Equal(25.5, reading.Value);
     }
 
+    [Scenario("ProcessedReading Record Works")]
     [Fact]
     public void ProcessedReading_Record_Works()
     {
         var reading = new ProcessedReading("sensor-001", "temperature", 25.5, 0.5, "normal");
 
-        Assert.Equal("sensor-001", reading.SensorId);
-        Assert.Equal("temperature", reading.Type);
-        Assert.Equal(25.5, reading.Value);
-        Assert.Equal(0.5, reading.NormalizedValue);
-        Assert.Equal("normal", reading.Status);
+        ScenarioExpect.Equal("sensor-001", reading.SensorId);
+        ScenarioExpect.Equal("temperature", reading.Type);
+        ScenarioExpect.Equal(25.5, reading.Value);
+        ScenarioExpect.Equal(0.5, reading.NormalizedValue);
+        ScenarioExpect.Equal("normal", reading.Status);
     }
 
+    [Scenario("Alert Record Works")]
     [Fact]
     public void Alert_Record_Works()
     {
         var alert = new Alert("sensor-001", "High temp", "critical", DateTime.UtcNow);
 
-        Assert.Equal("sensor-001", alert.SensorId);
-        Assert.Equal("High temp", alert.Message);
-        Assert.Equal("critical", alert.Severity);
+        ScenarioExpect.Equal("sensor-001", alert.SensorId);
+        ScenarioExpect.Equal("High temp", alert.Message);
+        ScenarioExpect.Equal("critical", alert.Severity);
     }
 
+    [Scenario("AggregatedStats Record Works")]
     [Fact]
     public void AggregatedStats_Record_Works()
     {
         var stats = new AggregatedStats("temperature", 20.0, 45.0, 32.5, 100);
 
-        Assert.Equal("temperature", stats.Type);
-        Assert.Equal(20.0, stats.Min);
-        Assert.Equal(45.0, stats.Max);
-        Assert.Equal(32.5, stats.Average);
-        Assert.Equal(100, stats.Count);
+        ScenarioExpect.Equal("temperature", stats.Type);
+        ScenarioExpect.Equal(20.0, stats.Min);
+        ScenarioExpect.Equal(45.0, stats.Max);
+        ScenarioExpect.Equal(32.5, stats.Average);
+        ScenarioExpect.Equal(100, stats.Count);
     }
 
+    [Scenario("GenerateSensorReadings Creates Specified Count")]
     [Fact]
     public void GenerateSensorReadings_Creates_Specified_Count()
     {
         var readings = GenerateSensorReadings(10).ToList();
 
-        Assert.Equal(10, readings.Count);
+        ScenarioExpect.Equal(10, readings.Count);
     }
 
+    [Scenario("GenerateSensorReadings Creates Valid Readings")]
     [Fact]
     public void GenerateSensorReadings_Creates_Valid_Readings()
     {
@@ -64,109 +71,122 @@ public sealed class IteratorDemoTests
 
         foreach (var reading in readings)
         {
-            Assert.NotNull(reading.SensorId);
-            Assert.NotNull(reading.Type);
-            Assert.True(reading.Value > 0);
-            Assert.Contains(reading.Type, new[] { "temperature", "humidity", "pressure" });
+            ScenarioExpect.NotNull(reading.SensorId);
+            ScenarioExpect.NotNull(reading.Type);
+            ScenarioExpect.True(reading.Value > 0);
+            ScenarioExpect.Contains(reading.Type, new[] { "temperature", "humidity", "pressure" });
         }
     }
 
+    [Scenario("IsValidReading Returns True For Valid")]
     [Fact]
     public void IsValidReading_Returns_True_For_Valid()
     {
         var reading = new SensorReading("sensor-001", "temperature", 25.0, DateTime.UtcNow);
 
-        Assert.True(IsValidReading(reading));
+        ScenarioExpect.True(IsValidReading(reading));
     }
 
+    [Scenario("IsValidReading Returns False For Zero")]
     [Fact]
     public void IsValidReading_Returns_False_For_Zero()
     {
         var reading = new SensorReading("sensor-001", "temperature", 0, DateTime.UtcNow);
 
-        Assert.False(IsValidReading(reading));
+        ScenarioExpect.False(IsValidReading(reading));
     }
 
+    [Scenario("IsValidReading Returns False For High Value")]
     [Fact]
     public void IsValidReading_Returns_False_For_High_Value()
     {
         var reading = new SensorReading("sensor-001", "temperature", 15000, DateTime.UtcNow);
 
-        Assert.False(IsValidReading(reading));
+        ScenarioExpect.False(IsValidReading(reading));
     }
 
+    [Scenario("NormalizeValue Temperature")]
     [Fact]
     public void NormalizeValue_Temperature()
     {
         var normalized = NormalizeValue("temperature", 35);
 
-        Assert.Equal(0.5, normalized); // (35 - 20) / 30 = 0.5
+        ScenarioExpect.Equal(0.5, normalized); // (35 - 20) / 30 = 0.5
     }
 
+    [Scenario("NormalizeValue Humidity")]
     [Fact]
     public void NormalizeValue_Humidity()
     {
         var normalized = NormalizeValue("humidity", 50);
 
-        Assert.Equal(0.5, normalized); // 50 / 100 = 0.5
+        ScenarioExpect.Equal(0.5, normalized); // 50 / 100 = 0.5
     }
 
+    [Scenario("NormalizeValue Pressure")]
     [Fact]
     public void NormalizeValue_Pressure()
     {
         var normalized = NormalizeValue("pressure", 1010);
 
-        Assert.Equal(0.5, normalized); // (1010 - 980) / 60 = 0.5
+        ScenarioExpect.Equal(0.5, normalized); // (1010 - 980) / 60 = 0.5
     }
 
+    [Scenario("DetermineStatus Temperature Critical")]
     [Fact]
     public void DetermineStatus_Temperature_Critical()
     {
         var status = DetermineStatus("temperature", 50);
 
-        Assert.Equal("critical", status);
+        ScenarioExpect.Equal("critical", status);
     }
 
+    [Scenario("DetermineStatus Temperature Warning")]
     [Fact]
     public void DetermineStatus_Temperature_Warning()
     {
         var status = DetermineStatus("temperature", 40);
 
-        Assert.Equal("warning", status);
+        ScenarioExpect.Equal("warning", status);
     }
 
+    [Scenario("DetermineStatus Temperature Normal")]
     [Fact]
     public void DetermineStatus_Temperature_Normal()
     {
         var status = DetermineStatus("temperature", 25);
 
-        Assert.Equal("normal", status);
+        ScenarioExpect.Equal("normal", status);
     }
 
+    [Scenario("DetermineStatus Humidity Critical")]
     [Fact]
     public void DetermineStatus_Humidity_Critical()
     {
         var status = DetermineStatus("humidity", 90);
 
-        Assert.Equal("critical", status);
+        ScenarioExpect.Equal("critical", status);
     }
 
+    [Scenario("DetermineStatus Humidity Warning")]
     [Fact]
     public void DetermineStatus_Humidity_Warning()
     {
         var status = DetermineStatus("humidity", 75);
 
-        Assert.Equal("warning", status);
+        ScenarioExpect.Equal("warning", status);
     }
 
+    [Scenario("DetermineStatus Pressure Warning")]
     [Fact]
     public void DetermineStatus_Pressure_Warning()
     {
         var status = DetermineStatus("pressure", 1035);
 
-        Assert.Equal("warning", status);
+        ScenarioExpect.Equal("warning", status);
     }
 
+    [Scenario("ProcessReading Creates ProcessedReading")]
     [Fact]
     public void ProcessReading_Creates_ProcessedReading()
     {
@@ -174,13 +194,14 @@ public sealed class IteratorDemoTests
 
         var processed = ProcessReading(reading);
 
-        Assert.Equal("sensor-001", processed.SensorId);
-        Assert.Equal("temperature", processed.Type);
-        Assert.Equal(35, processed.Value);
-        Assert.Equal(0.5, processed.NormalizedValue);
-        Assert.Equal("normal", processed.Status);
+        ScenarioExpect.Equal("sensor-001", processed.SensorId);
+        ScenarioExpect.Equal("temperature", processed.Type);
+        ScenarioExpect.Equal(35, processed.Value);
+        ScenarioExpect.Equal(0.5, processed.NormalizedValue);
+        ScenarioExpect.Equal("normal", processed.Status);
     }
 
+    [Scenario("CreateAlert From ProcessedReading")]
     [Fact]
     public void CreateAlert_From_ProcessedReading()
     {
@@ -188,11 +209,12 @@ public sealed class IteratorDemoTests
 
         var alert = CreateAlert(processed);
 
-        Assert.Equal("sensor-001", alert.SensorId);
-        Assert.Equal("critical", alert.Severity);
-        Assert.Contains("TEMPERATURE", alert.Message);
+        ScenarioExpect.Equal("sensor-001", alert.SensorId);
+        ScenarioExpect.Equal("critical", alert.Severity);
+        ScenarioExpect.Contains("TEMPERATURE", alert.Message);
     }
 
+    [Scenario("CreateProcessingPipeline Filters And Transforms")]
     [Fact]
     public void CreateProcessingPipeline_Filters_And_Transforms()
     {
@@ -206,11 +228,12 @@ public sealed class IteratorDemoTests
         var pipeline = CreateProcessingPipeline(readings);
         var results = pipeline.ToList();
 
-        Assert.Single(results);
-        Assert.Equal("s2", results[0].SensorId);
-        Assert.Equal("critical", results[0].Status);
+        ScenarioExpect.Single(results);
+        ScenarioExpect.Equal("s2", results[0].SensorId);
+        ScenarioExpect.Equal("critical", results[0].Status);
     }
 
+    [Scenario("CreateSharedPipeline Creates SharedFlow")]
     [Fact]
     public void CreateSharedPipeline_Creates_SharedFlow()
     {
@@ -218,9 +241,10 @@ public sealed class IteratorDemoTests
 
         var shared = CreateSharedPipeline(readings);
 
-        Assert.NotNull(shared);
+        ScenarioExpect.NotNull(shared);
     }
 
+    [Scenario("CreateSharedPipeline Forks Work Independently")]
     [Fact]
     public void CreateSharedPipeline_Forks_Work_Independently()
     {
@@ -231,9 +255,10 @@ public sealed class IteratorDemoTests
         var fork1 = shared.Fork().ToList();
         var fork2 = shared.Fork().ToList();
 
-        Assert.Equal(fork1.Count, fork2.Count);
+        ScenarioExpect.Equal(fork1.Count, fork2.Count);
     }
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/MediatorDemo/MediatorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/MediatorDemo/MediatorDemoTests.cs
@@ -150,6 +150,7 @@ public sealed class MediatorDemoTests(ITestOutputHelper output) : TinyBddXunitBa
             })
             .AssertPassed();
 
+    [Scenario("LoggingBehavior Runs Before And After")]
     [Fact]
     public Task LoggingBehavior_Runs_Before_And_After()
         => Given("a mediator with logging whole behavior", () =>
@@ -180,6 +181,7 @@ public sealed class MediatorDemoTests(ITestOutputHelper output) : TinyBddXunitBa
             .Then("log contains before and after", t => t.Item2.Contains("before") && t.Item2.Contains("after"))
             .AssertPassed();
 
+    [Scenario("ExceptionBehavior Catches And Logs")]
     [Fact]
     public Task ExceptionBehavior_Catches_And_Logs()
         => Given("a mediator with exception-catching whole behavior", () =>
@@ -219,6 +221,7 @@ public sealed class MediatorDemoTests(ITestOutputHelper output) : TinyBddXunitBa
             .Then("log contains caught", log => log.Exists(l => l.StartsWith("caught:")))
             .AssertPassed();
 
+    [Scenario("ValidationBehavior ShortCircuits On Invalid")]
     [Fact]
     public Task ValidationBehavior_ShortCircuits_On_Invalid()
         => Given("a mediator with validation pre behavior", () =>
@@ -250,6 +253,7 @@ public sealed class MediatorDemoTests(ITestOutputHelper output) : TinyBddXunitBa
             .Then("throws ArgumentException", ex => ex is ArgumentException)
             .AssertPassed();
 
+    [Scenario("MultipleBehaviors Compose In Order")]
     [Fact]
     public Task MultipleBehaviors_Compose_In_Order()
         => Given("a mediator with multiple behaviors", () =>

--- a/test/PatternKit.Examples.Tests/Messaging/BackplaneFacadeDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/BackplaneFacadeDemoTests.cs
@@ -1,11 +1,13 @@
 using PatternKit.Examples.Messaging;
 using PatternKit.Messaging;
 using PatternKit.Messaging.Reliability;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class BackplaneFacadeDemoTests
 {
+    [Scenario("BackplaneHostBuilder ConfiguresNativeMessagingPlatformSurface")]
     [Fact]
     public async Task BackplaneHostBuilder_ConfiguresNativeMessagingPlatformSurface()
     {
@@ -32,82 +34,87 @@ public sealed class BackplaneFacadeDemoTests
                 .WithCorrelationId("corr-builder")
                 .WithIdempotencyKey("idem-builder"));
 
-        Assert.Same(outbox, host.Outbox);
-        Assert.Same(idempotency, host.IdempotencyStore);
-        Assert.Single(host.Endpoints);
-        Assert.Equal("orders.standard", host.Endpoints[0].Name);
-        Assert.Single(host.Endpoints[0].Handlers);
-        Assert.Equal(new BackplaneOrderAccepted("order-builder", "orders.standard", "corr-builder"), response);
-        Assert.Contains(transport.DeliveryLog, static entry => entry.Contains("orders.standard->orders.standard", StringComparison.Ordinal));
+        ScenarioExpect.Same(outbox, host.Outbox);
+        ScenarioExpect.Same(idempotency, host.IdempotencyStore);
+        ScenarioExpect.Single(host.Endpoints);
+        ScenarioExpect.Equal("orders.standard", host.Endpoints[0].Name);
+        ScenarioExpect.Single(host.Endpoints[0].Handlers);
+        ScenarioExpect.Equal(new BackplaneOrderAccepted("order-builder", "orders.standard", "corr-builder"), response);
+        ScenarioExpect.Contains(transport.DeliveryLog, static entry => entry.Contains("orders.standard->orders.standard", StringComparison.Ordinal));
     }
 
+    [Scenario("RunAsync RoutesRequestsAndPublishesEventsThroughBackplane")]
     [Fact]
     public async Task RunAsync_RoutesRequestsAndPublishesEventsThroughBackplane()
     {
         var summary = await BackplaneFacadeDemo.RunAsync();
 
-        Assert.Equal(4, summary.Accepted.Count);
-        Assert.Equal("orders.standard", summary.Accepted[0].Endpoint);
-        Assert.Equal("orders.standard", summary.Accepted[1].Endpoint);
-        Assert.Equal("orders.priority", summary.Accepted[2].Endpoint);
-        Assert.Equal("orders.standard", summary.Accepted[3].Endpoint);
+        ScenarioExpect.Equal(4, summary.Accepted.Count);
+        ScenarioExpect.Equal("orders.standard", summary.Accepted[0].Endpoint);
+        ScenarioExpect.Equal("orders.standard", summary.Accepted[1].Endpoint);
+        ScenarioExpect.Equal("orders.priority", summary.Accepted[2].Endpoint);
+        ScenarioExpect.Equal("orders.standard", summary.Accepted[3].Endpoint);
 
-        Assert.Equal("orders.standard", summary.Endpoints["order-standard"]);
-        Assert.Equal("orders.priority", summary.Endpoints["order-vip"]);
-        Assert.Equal("orders.standard", summary.Endpoints["order-declined"]);
+        ScenarioExpect.Equal("orders.standard", summary.Endpoints["order-standard"]);
+        ScenarioExpect.Equal("orders.priority", summary.Endpoints["order-vip"]);
+        ScenarioExpect.Equal("orders.standard", summary.Endpoints["order-declined"]);
     }
 
+    [Scenario("RunAsync ReplaysDuplicateRequestWithoutRepeatingSideEffects")]
     [Fact]
     public async Task RunAsync_ReplaysDuplicateRequestWithoutRepeatingSideEffects()
     {
         var summary = await BackplaneFacadeDemo.RunAsync();
 
-        Assert.Equal("corr-order-standard", summary.Accepted[0].CorrelationId);
-        Assert.Equal(summary.Accepted[0], summary.Accepted[1]);
-        Assert.Single(summary.Audit, static entry => entry == "orders:accepted:order-standard:orders.standard");
-        Assert.Single(summary.Outbox, static record =>
+        ScenarioExpect.Equal("corr-order-standard", summary.Accepted[0].CorrelationId);
+        ScenarioExpect.Equal(summary.Accepted[0], summary.Accepted[1]);
+        ScenarioExpect.Single(summary.Audit, static entry => entry == "orders:accepted:order-standard:orders.standard");
+        ScenarioExpect.Single(summary.Outbox, static record =>
             record.Address == "orders.submitted"
             && record.CorrelationId == "corr-order-standard");
     }
 
+    [Scenario("RunAsync FansOutEventsToIndependentServices")]
     [Fact]
     public async Task RunAsync_FansOutEventsToIndependentServices()
     {
         var summary = await BackplaneFacadeDemo.RunAsync();
 
-        Assert.Contains(summary.Audit, static entry => entry == "billing:received:order-standard");
-        Assert.Contains(summary.Audit, static entry => entry == "audit:order-submitted:order-standard:corr-order-standard");
-        Assert.Contains(summary.Audit, static entry => entry == "fulfillment:scheduled:order-standard");
-        Assert.Contains(summary.Audit, static entry => entry == "notification:order-standard:shipment-scheduled");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "billing:received:order-standard");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "audit:order-submitted:order-standard:corr-order-standard");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "fulfillment:scheduled:order-standard");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "notification:order-standard:shipment-scheduled");
 
-        Assert.Contains(summary.DeliveryLog, static entry => entry == "orders.submitted->billing-service:BackplaneOrderSubmitted");
-        Assert.Contains(summary.DeliveryLog, static entry => entry == "orders.submitted->audit-service:BackplaneOrderSubmitted");
+        ScenarioExpect.Contains(summary.DeliveryLog, static entry => entry == "orders.submitted->billing-service:BackplaneOrderSubmitted");
+        ScenarioExpect.Contains(summary.DeliveryLog, static entry => entry == "orders.submitted->audit-service:BackplaneOrderSubmitted");
     }
 
+    [Scenario("RunAsync UsesOutboxBeforeTransportDispatch")]
     [Fact]
     public async Task RunAsync_UsesOutboxBeforeTransportDispatch()
     {
         var summary = await BackplaneFacadeDemo.RunAsync();
 
-        Assert.All(summary.Outbox, static record => Assert.True(record.Dispatched));
-        Assert.Equal(8, summary.Outbox.Count);
-        Assert.Equal(3, summary.Outbox.Count(static record => record.Address == "orders.submitted"));
-        Assert.Equal(2, summary.Outbox.Count(static record => record.Address == "payments.captured"));
-        Assert.Equal(1, summary.Outbox.Count(static record => record.Address == "payments.declined"));
-        Assert.Equal(2, summary.Outbox.Count(static record => record.Address == "shipments.scheduled"));
-        Assert.All(summary.Outbox, static record => Assert.InRange(record.Delivered, 1, int.MaxValue));
+        ScenarioExpect.All(summary.Outbox, static record => ScenarioExpect.True(record.Dispatched));
+        ScenarioExpect.Equal(8, summary.Outbox.Count);
+        ScenarioExpect.Equal(3, summary.Outbox.Count(static record => record.Address == "orders.submitted"));
+        ScenarioExpect.Equal(2, summary.Outbox.Count(static record => record.Address == "payments.captured"));
+        ScenarioExpect.Equal(1, summary.Outbox.Count(static record => record.Address == "payments.declined"));
+        ScenarioExpect.Equal(2, summary.Outbox.Count(static record => record.Address == "shipments.scheduled"));
+        ScenarioExpect.All(summary.Outbox, static record => ScenarioExpect.InRange(record.Delivered, 1, int.MaxValue));
     }
 
+    [Scenario("RunAsync PreservesCorrelationAcrossServices")]
     [Fact]
     public async Task RunAsync_PreservesCorrelationAcrossServices()
     {
         var summary = await BackplaneFacadeDemo.RunAsync();
 
-        Assert.Contains(summary.Notifications, static notification =>
+        ScenarioExpect.Contains(summary.Notifications, static notification =>
             notification is { OrderId: "order-standard", Kind: "shipment-scheduled", CorrelationId: "corr-order-standard" });
-        Assert.Contains(summary.Notifications, static notification =>
+        ScenarioExpect.Contains(summary.Notifications, static notification =>
             notification is { OrderId: "order-vip", Kind: "shipment-scheduled", CorrelationId: "corr-order-vip" });
-        Assert.Contains(summary.Notifications, static notification =>
+        ScenarioExpect.Contains(summary.Notifications, static notification =>
             notification is { OrderId: "order-declined", Kind: "payment-declined", CorrelationId: "corr-order-declined" });
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/BackplaneTestcontainerE2ETests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/BackplaneTestcontainerE2ETests.cs
@@ -13,11 +13,13 @@ using PatternKit.Messaging.Reliability;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Testcontainers.RabbitMq;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class BackplaneTestcontainerE2ETests
 {
+    [Scenario("RabbitMqBackplane RunsRequestReplyAndPublishSubscribeThroughContainer")]
     [Fact]
     [Trait("Category", "E2E")]
     public async Task RabbitMqBackplane_RunsRequestReplyAndPublishSubscribeThroughContainer()
@@ -34,6 +36,7 @@ public sealed class BackplaneTestcontainerE2ETests
         await AssertBackplaneAsync(transport);
     }
 
+    [Scenario("MqttBackplane RunsRequestReplyAndPublishSubscribeThroughContainer")]
     [Fact]
     [Trait("Category", "E2E")]
     public async Task MqttBackplane_RunsRequestReplyAndPublishSubscribeThroughContainer()
@@ -105,14 +108,14 @@ public sealed class BackplaneTestcontainerE2ETests
 
         var notification = await observed.Task.WaitAsync(TimeSpan.FromSeconds(20));
 
-        Assert.Equal(new BackplaneOrderAccepted("container-order", "orders.standard", "corr-container-order"), accepted);
-        Assert.Equal(new CustomerNotification("container-order", "order-submitted", "corr-container-order"), notification);
-        Assert.Single(outbox.Records);
-        Assert.Equal("orders.submitted", outbox.Records[0].Address);
-        Assert.True(outbox.Records[0].Dispatched);
-        Assert.Equal(1, outbox.Records[0].Delivered);
-        Assert.True(idempotency.TryGet("idem-container-order", out var claim));
-        Assert.Equal(IdempotencyEntryStatus.Completed, claim!.Status);
+        ScenarioExpect.Equal(new BackplaneOrderAccepted("container-order", "orders.standard", "corr-container-order"), accepted);
+        ScenarioExpect.Equal(new CustomerNotification("container-order", "order-submitted", "corr-container-order"), notification);
+        ScenarioExpect.Single(outbox.Records);
+        ScenarioExpect.Equal("orders.submitted", outbox.Records[0].Address);
+        ScenarioExpect.True(outbox.Records[0].Dispatched);
+        ScenarioExpect.Equal(1, outbox.Records[0].Delivered);
+        ScenarioExpect.True(idempotency.TryGet("idem-container-order", out var claim));
+        ScenarioExpect.Equal(IdempotencyEntryStatus.Completed, claim!.Status);
     }
 }
 

--- a/test/PatternKit.Examples.Tests/Messaging/ContentRouterGeneratorExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ContentRouterGeneratorExampleTests.cs
@@ -1,15 +1,17 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class ContentRouterGeneratorExampleTests
 {
+    [Scenario("Run RoutesGeneratedContentRouter")]
     [Theory]
     [InlineData("wholesale", "wholesale")]
     [InlineData("retail", "retail")]
     [InlineData("unknown", "default")]
     public void Run_RoutesGeneratedContentRouter(string channel, string expected)
     {
-        Assert.Equal(expected, ContentRouterGeneratorExample.Run(channel));
+        ScenarioExpect.Equal(expected, ContentRouterGeneratorExample.Run(channel));
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/DispatcherExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/DispatcherExampleTests.cs
@@ -11,6 +11,7 @@ namespace PatternKit.Examples.Tests.Messaging;
 [Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
 public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    [Scenario("DispatcherUsageExamples RunWithoutThrowing")]
     [Fact]
     public async Task DispatcherUsageExamples_RunWithoutThrowing()
     {
@@ -20,6 +21,7 @@ public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXu
         await DispatcherUsageExamples.PipelineExample();
     }
 
+    [Scenario("CommandHandlers ReturnExpectedResponsesAndLogOperations")]
     [Fact]
     public async Task CommandHandlers_ReturnExpectedResponsesAndLogOperations()
     {
@@ -34,14 +36,15 @@ public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXu
             default);
         var paymentSuccess = await paymentHandler.Handle(new ProcessPaymentCommand(order.Id, order.Total), default);
 
-        Assert.Equal("Ada", customer.Name);
-        Assert.Equal(100m, order.Total);
-        Assert.True(paymentSuccess);
-        Assert.Contains(logger.GetLogs(), log => log.Contains("Creating customer", StringComparison.Ordinal));
-        Assert.Contains(logger.GetLogs(), log => log.Contains("Placing order", StringComparison.Ordinal));
-        Assert.Contains(logger.GetLogs(), log => log.Contains("Processing payment", StringComparison.Ordinal));
+        ScenarioExpect.Equal("Ada", customer.Name);
+        ScenarioExpect.Equal(100m, order.Total);
+        ScenarioExpect.True(paymentSuccess);
+        ScenarioExpect.Contains(logger.GetLogs(), log => log.Contains("Creating customer", StringComparison.Ordinal));
+        ScenarioExpect.Contains(logger.GetLogs(), log => log.Contains("Placing order", StringComparison.Ordinal));
+        ScenarioExpect.Contains(logger.GetLogs(), log => log.Contains("Processing payment", StringComparison.Ordinal));
     }
 
+    [Scenario("QueryAndStreamHandlers ReadFromRepositories")]
     [Fact]
     public async Task QueryAndStreamHandlers_ReadFromRepositories()
     {
@@ -59,13 +62,14 @@ public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXu
             productResults.Add(product);
         }
 
-        Assert.NotNull(customer);
-        Assert.Equal("Ada", customer.Name);
-        Assert.Single(customerOrders);
-        Assert.Equal(2, productResults.Count);
-        Assert.All(productResults, product => Assert.Contains("o", product.Name, StringComparison.OrdinalIgnoreCase));
+        ScenarioExpect.NotNull(customer);
+        ScenarioExpect.Equal("Ada", customer.Name);
+        ScenarioExpect.Single(customerOrders);
+        ScenarioExpect.Equal(2, productResults.Count);
+        ScenarioExpect.All(productResults, product => ScenarioExpect.Contains("o", product.Name, StringComparison.OrdinalIgnoreCase));
     }
 
+    [Scenario("NotificationHandlers LogMessages")]
     [Fact]
     public async Task NotificationHandlers_LogMessages()
     {
@@ -77,9 +81,10 @@ public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXu
         await new SendOrderConfirmationHandler(logger).Handle(new OrderPlacedEvent(5, 1, 125m), default);
         await new RecordPaymentAuditHandler(logger).Handle(new PaymentProcessedEvent(5, 125m, true), default);
 
-        Assert.Equal(5, logger.GetLogs().Count);
+        ScenarioExpect.Equal(5, logger.GetLogs().Count);
     }
 
+    [Scenario("PipelineBehaviors InvokeNextAndLogCrossCuttingSteps")]
     [Fact]
     public async Task PipelineBehaviors_InvokeNextAndLogCrossCuttingSteps()
     {
@@ -96,16 +101,17 @@ public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXu
         var transacted = await new TransactionBehavior<CreateCustomerCommand, Customer>(logger)
             .Handle(request, default, () => ValueTask.FromResult(expected));
 
-        Assert.Same(expected, logged);
-        Assert.Same(expected, validated);
-        Assert.Same(expected, measured);
-        Assert.Same(expected, transacted);
-        Assert.Contains(logger.GetLogs(), log => log.Contains("[Logging]", StringComparison.Ordinal));
-        Assert.Contains(logger.GetLogs(), log => log.Contains("[Validation]", StringComparison.Ordinal));
-        Assert.Contains(logger.GetLogs(), log => log.Contains("[Performance]", StringComparison.Ordinal));
-        Assert.Contains(logger.GetLogs(), log => log.Contains("[Transaction] Committing", StringComparison.Ordinal));
+        ScenarioExpect.Same(expected, logged);
+        ScenarioExpect.Same(expected, validated);
+        ScenarioExpect.Same(expected, measured);
+        ScenarioExpect.Same(expected, transacted);
+        ScenarioExpect.Contains(logger.GetLogs(), log => log.Contains("[Logging]", StringComparison.Ordinal));
+        ScenarioExpect.Contains(logger.GetLogs(), log => log.Contains("[Validation]", StringComparison.Ordinal));
+        ScenarioExpect.Contains(logger.GetLogs(), log => log.Contains("[Performance]", StringComparison.Ordinal));
+        ScenarioExpect.Contains(logger.GetLogs(), log => log.Contains("[Transaction] Committing", StringComparison.Ordinal));
     }
 
+    [Scenario("ServiceCollectionExtensions RegisterGeneratedDispatcherAndHandlers")]
     [Fact]
     public void ServiceCollectionExtensions_RegisterGeneratedDispatcherAndHandlers()
     {
@@ -121,11 +127,11 @@ public sealed class DispatcherExampleTests(ITestOutputHelper output) : TinyBddXu
 
         using var provider = services.BuildServiceProvider();
 
-        Assert.NotNull(provider.GetRequiredService<ProductionDispatcher>());
-        Assert.NotNull(provider.GetRequiredService<ICommandHandler<CreateCustomerCommand, Customer>>());
-        Assert.NotEmpty(provider.GetServices<INotificationHandler<CustomerCreatedEvent>>());
-        Assert.NotNull(provider.GetRequiredService<IStreamHandler<SearchProductsQuery, ProductSearchResult>>());
-        Assert.NotNull(provider.GetRequiredService<IPipelineBehavior<CreateCustomerCommand, Customer>>());
+        ScenarioExpect.NotNull(provider.GetRequiredService<ProductionDispatcher>());
+        ScenarioExpect.NotNull(provider.GetRequiredService<ICommandHandler<CreateCustomerCommand, Customer>>());
+        ScenarioExpect.NotEmpty(provider.GetServices<INotificationHandler<CustomerCreatedEvent>>());
+        ScenarioExpect.NotNull(provider.GetRequiredService<IStreamHandler<SearchProductsQuery, ProductSearchResult>>());
+        ScenarioExpect.NotNull(provider.GetRequiredService<IPipelineBehavior<CreateCustomerCommand, Customer>>());
     }
 
     [Scenario("Comprehensive mediator demo runs a production-style CQRS and notification workflow")]

--- a/test/PatternKit.Examples.Tests/Messaging/MailboxExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/MailboxExampleTests.cs
@@ -1,14 +1,16 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class MailboxExampleTests
 {
+    [Scenario("RunAsync ProcessesMessagesInOrder")]
     [Fact]
     public async Task RunAsync_ProcessesMessagesInOrder()
     {
         var processed = await MailboxExample.RunAsync();
 
-        Assert.Equal(["batch-42:prepare", "batch-42:ship"], processed);
+        ScenarioExpect.Equal(["batch-42:prepare", "batch-42:ship"], processed);
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/MessageEnvelopeExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/MessageEnvelopeExampleTests.cs
@@ -1,21 +1,23 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class MessageEnvelopeExampleTests
 {
+    [Scenario("Run ReturnsExpectedEnvelopeAndContextMetadata")]
     [Fact]
     public void Run_ReturnsExpectedEnvelopeAndContextMetadata()
     {
         var summary = MessageEnvelopeExample.Run();
 
-        Assert.Equal("order-42", summary.OrderId);
-        Assert.Equal("msg-100", summary.MessageId);
-        Assert.Equal("order-42", summary.CorrelationId);
-        Assert.Equal("checkout-7", summary.CausationId);
-        Assert.Equal("order-42:accepted", summary.IdempotencyKey);
-        Assert.Equal("application/vnd.patternkit.order+json", summary.ContentType);
-        Assert.Equal("billing", summary.Route);
-        Assert.Equal(1, summary.Attempt);
+        ScenarioExpect.Equal("order-42", summary.OrderId);
+        ScenarioExpect.Equal("msg-100", summary.MessageId);
+        ScenarioExpect.Equal("order-42", summary.CorrelationId);
+        ScenarioExpect.Equal("checkout-7", summary.CausationId);
+        ScenarioExpect.Equal("order-42:accepted", summary.IdempotencyKey);
+        ScenarioExpect.Equal("application/vnd.patternkit.order+json", summary.ContentType);
+        ScenarioExpect.Equal("billing", summary.Route);
+        ScenarioExpect.Equal(1, summary.Attempt);
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/MessageRoutingExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/MessageRoutingExampleTests.cs
@@ -1,18 +1,20 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class MessageRoutingExampleTests
 {
+    [Scenario("Run ComposesEnterpriseRoutingPrimitives")]
     [Fact]
     public void Run_ComposesEnterpriseRoutingPrimitives()
     {
         var summary = MessageRoutingExample.Run();
 
-        Assert.Equal("priority", summary.Route);
-        Assert.Equal(["audit", "billing"], summary.Recipients);
-        Assert.Equal(2, summary.SplitCount);
-        Assert.Equal(100m, summary.AggregatedTotal);
-        Assert.Equal("msg-order-42", summary.CausationId);
+        ScenarioExpect.Equal("priority", summary.Route);
+        ScenarioExpect.Equal(["audit", "billing"], summary.Recipients);
+        ScenarioExpect.Equal(2, summary.SplitCount);
+        ScenarioExpect.Equal(100m, summary.AggregatedTotal);
+        ScenarioExpect.Equal("msg-order-42", summary.CausationId);
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/ReliabilityExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ReliabilityExampleTests.cs
@@ -1,14 +1,16 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class ReliabilityExampleTests
 {
+    [Scenario("RunAsync DispatchesOneOutboxMessageForDuplicateInput")]
     [Fact]
     public async Task RunAsync_DispatchesOneOutboxMessageForDuplicateInput()
     {
         var dispatched = await ReliabilityExample.RunAsync();
 
-        Assert.Equal(["order-42"], dispatched);
+        ScenarioExpect.Equal(["order-42"], dispatched);
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class ResilientCheckoutDemoTests
 {
+    [Scenario("Run CompletesPrimaryCardRoute")]
     [Fact]
     public void Run_CompletesPrimaryCardRoute()
     {
@@ -12,18 +14,19 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.True(result.Succeeded);
-        Assert.False(result.ManualReview);
-        Assert.Equal("primary-card", result.FinalRoute);
-        Assert.Single(result.Attempts);
-        Assert.StartsWith("primarywarehouse-order-primary-", result.ReservationId, StringComparison.Ordinal);
-        Assert.StartsWith("card-order-primary-", result.PaymentId, StringComparison.Ordinal);
-        Assert.StartsWith("primarywarehouse-ship-order-primary-", result.ShipmentId, StringComparison.Ordinal);
-        Assert.Contains("validate:ok", result.Audit);
-        Assert.Empty(services.Inventory.ReleasedReservations);
-        Assert.Empty(services.Payments.RefundedPayments);
+        ScenarioExpect.True(result.Succeeded);
+        ScenarioExpect.False(result.ManualReview);
+        ScenarioExpect.Equal("primary-card", result.FinalRoute);
+        ScenarioExpect.Single(result.Attempts);
+        ScenarioExpect.StartsWith("primarywarehouse-order-primary-", result.ReservationId, StringComparison.Ordinal);
+        ScenarioExpect.StartsWith("card-order-primary-", result.PaymentId, StringComparison.Ordinal);
+        ScenarioExpect.StartsWith("primarywarehouse-ship-order-primary-", result.ShipmentId, StringComparison.Ordinal);
+        ScenarioExpect.Contains("validate:ok", result.Audit);
+        ScenarioExpect.Empty(services.Inventory.ReleasedReservations);
+        ScenarioExpect.Empty(services.Payments.RefundedPayments);
     }
 
+    [Scenario("Run RollsBackPrimaryReservationAndRetriesDropshipWhenInventoryUnavailable")]
     [Fact]
     public void Run_RollsBackPrimaryReservationAndRetriesDropshipWhenInventoryUnavailable()
     {
@@ -35,15 +38,16 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.True(result.Succeeded);
-        Assert.Equal("dropship-card", result.FinalRoute);
-        Assert.Equal(["primary-card", "dropship-card"], result.Attempts.Select(static attempt => attempt.Route));
-        Assert.Equal(CheckoutFailureKind.InventoryUnavailable, result.Attempts[0].FailureKind);
-        Assert.StartsWith("dropship-order-dropship-", result.ReservationId, StringComparison.Ordinal);
-        Assert.Empty(services.Inventory.ReleasedReservations);
-        Assert.Contains("route:primary-card:failed:InventoryUnavailable", result.Audit);
+        ScenarioExpect.True(result.Succeeded);
+        ScenarioExpect.Equal("dropship-card", result.FinalRoute);
+        ScenarioExpect.Equal(["primary-card", "dropship-card"], result.Attempts.Select(static attempt => attempt.Route));
+        ScenarioExpect.Equal(CheckoutFailureKind.InventoryUnavailable, result.Attempts[0].FailureKind);
+        ScenarioExpect.StartsWith("dropship-order-dropship-", result.ReservationId, StringComparison.Ordinal);
+        ScenarioExpect.Empty(services.Inventory.ReleasedReservations);
+        ScenarioExpect.Contains("route:primary-card:failed:InventoryUnavailable", result.Audit);
     }
 
+    [Scenario("Run RefundsCardAndRetriesGiftCardWhenPaymentDeclines")]
     [Fact]
     public void Run_RefundsCardAndRetriesGiftCardWhenPaymentDeclines()
     {
@@ -55,16 +59,17 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.True(result.Succeeded);
-        Assert.Equal("primary-gift-card", result.FinalRoute);
-        Assert.Equal(["primary-card", "primary-gift-card"], result.Attempts.Select(static attempt => attempt.Route));
-        Assert.Equal(CheckoutFailureKind.PaymentDeclined, result.Attempts[0].FailureKind);
-        Assert.Single(services.Inventory.ReleasedReservations);
-        Assert.Empty(services.Payments.RefundedPayments);
-        Assert.StartsWith("giftcard-order-gift-", result.PaymentId, StringComparison.Ordinal);
-        Assert.Contains(result.Audit, static entry => entry.StartsWith("inventory:released:", StringComparison.Ordinal));
+        ScenarioExpect.True(result.Succeeded);
+        ScenarioExpect.Equal("primary-gift-card", result.FinalRoute);
+        ScenarioExpect.Equal(["primary-card", "primary-gift-card"], result.Attempts.Select(static attempt => attempt.Route));
+        ScenarioExpect.Equal(CheckoutFailureKind.PaymentDeclined, result.Attempts[0].FailureKind);
+        ScenarioExpect.Single(services.Inventory.ReleasedReservations);
+        ScenarioExpect.Empty(services.Payments.RefundedPayments);
+        ScenarioExpect.StartsWith("giftcard-order-gift-", result.PaymentId, StringComparison.Ordinal);
+        ScenarioExpect.Contains(result.Audit, static entry => entry.StartsWith("inventory:released:", StringComparison.Ordinal));
     }
 
+    [Scenario("Run SendsFraudHoldToManualReviewWithoutSideEffects")]
     [Fact]
     public void Run_SendsFraudHoldToManualReviewWithoutSideEffects()
     {
@@ -73,17 +78,18 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.False(result.Succeeded);
-        Assert.True(result.ManualReview);
-        Assert.Equal("manual-review", result.FinalRoute);
-        Assert.Null(result.ReservationId);
-        Assert.Null(result.PaymentId);
-        Assert.Null(result.ShipmentId);
-        Assert.Contains("manual-review:queued", result.Audit);
-        Assert.Empty(services.Inventory.ReleasedReservations);
-        Assert.Empty(services.Payments.RefundedPayments);
+        ScenarioExpect.False(result.Succeeded);
+        ScenarioExpect.True(result.ManualReview);
+        ScenarioExpect.Equal("manual-review", result.FinalRoute);
+        ScenarioExpect.Null(result.ReservationId);
+        ScenarioExpect.Null(result.PaymentId);
+        ScenarioExpect.Null(result.ShipmentId);
+        ScenarioExpect.Contains("manual-review:queued", result.Audit);
+        ScenarioExpect.Empty(services.Inventory.ReleasedReservations);
+        ScenarioExpect.Empty(services.Payments.RefundedPayments);
     }
 
+    [Scenario("Run SendsUnrecoverableFailureToManualReview")]
     [Fact]
     public void Run_SendsUnrecoverableFailureToManualReview()
     {
@@ -95,12 +101,13 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.False(result.Succeeded);
-        Assert.True(result.ManualReview);
-        Assert.Equal("manual-review", result.FinalRoute);
-        Assert.Equal(["primary-card", "dropship-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
+        ScenarioExpect.False(result.Succeeded);
+        ScenarioExpect.True(result.ManualReview);
+        ScenarioExpect.Equal("manual-review", result.FinalRoute);
+        ScenarioExpect.Equal(["primary-card", "dropship-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
     }
 
+    [Scenario("Run UsesPreferredGiftCardWhenBalanceCoversTotal")]
     [Fact]
     public void Run_UsesPreferredGiftCardWhenBalanceCoversTotal()
     {
@@ -112,15 +119,16 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.True(result.Succeeded);
-        Assert.False(result.ManualReview);
-        Assert.Equal("primary-gift-card", result.FinalRoute);
-        Assert.Single(result.Attempts);
-        Assert.StartsWith("giftcard-order-preferred-gift-", result.PaymentId, StringComparison.Ordinal);
-        Assert.Empty(services.Inventory.ReleasedReservations);
-        Assert.Empty(services.Payments.RefundedPayments);
+        ScenarioExpect.True(result.Succeeded);
+        ScenarioExpect.False(result.ManualReview);
+        ScenarioExpect.Equal("primary-gift-card", result.FinalRoute);
+        ScenarioExpect.Single(result.Attempts);
+        ScenarioExpect.StartsWith("giftcard-order-preferred-gift-", result.PaymentId, StringComparison.Ordinal);
+        ScenarioExpect.Empty(services.Inventory.ReleasedReservations);
+        ScenarioExpect.Empty(services.Payments.RefundedPayments);
     }
 
+    [Scenario("Run EmptyCartValidationFailureEscalatesToManualReview")]
     [Fact]
     public void Run_EmptyCartValidationFailureEscalatesToManualReview()
     {
@@ -132,17 +140,18 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.False(result.Succeeded);
-        Assert.True(result.ManualReview);
-        Assert.Equal("manual-review", result.FinalRoute);
-        Assert.Equal(["primary-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
-        Assert.Equal(CheckoutFailureKind.ValidationFailed, result.Attempts[0].FailureKind);
-        Assert.Contains("cart-empty", result.Attempts[0].Message, StringComparison.Ordinal);
-        Assert.Null(result.ReservationId);
-        Assert.Null(result.PaymentId);
-        Assert.Null(result.ShipmentId);
+        ScenarioExpect.False(result.Succeeded);
+        ScenarioExpect.True(result.ManualReview);
+        ScenarioExpect.Equal("manual-review", result.FinalRoute);
+        ScenarioExpect.Equal(["primary-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
+        ScenarioExpect.Equal(CheckoutFailureKind.ValidationFailed, result.Attempts[0].FailureKind);
+        ScenarioExpect.Contains("cart-empty", result.Attempts[0].Message, StringComparison.Ordinal);
+        ScenarioExpect.Null(result.ReservationId);
+        ScenarioExpect.Null(result.PaymentId);
+        ScenarioExpect.Null(result.ShipmentId);
     }
 
+    [Scenario("Run CardDeclineWithoutGiftCardFallbackEscalatesToManualReviewAndReleasesInventory")]
     [Fact]
     public void Run_CardDeclineWithoutGiftCardFallbackEscalatesToManualReviewAndReleasesInventory()
     {
@@ -154,14 +163,14 @@ public sealed class ResilientCheckoutDemoTests
 
         var result = ResilientCheckoutDemo.Run(request, services);
 
-        Assert.False(result.Succeeded);
-        Assert.True(result.ManualReview);
-        Assert.Equal("manual-review", result.FinalRoute);
-        Assert.Equal(["primary-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
-        Assert.Equal(CheckoutFailureKind.PaymentDeclined, result.Attempts[0].FailureKind);
-        Assert.Single(services.Inventory.ReleasedReservations);
-        Assert.Empty(services.Payments.RefundedPayments);
-        Assert.Contains(result.Audit, static entry => entry.StartsWith("inventory:released:", StringComparison.Ordinal));
+        ScenarioExpect.False(result.Succeeded);
+        ScenarioExpect.True(result.ManualReview);
+        ScenarioExpect.Equal("manual-review", result.FinalRoute);
+        ScenarioExpect.Equal(["primary-card", "manual-review"], result.Attempts.Select(static attempt => attempt.Route));
+        ScenarioExpect.Equal(CheckoutFailureKind.PaymentDeclined, result.Attempts[0].FailureKind);
+        ScenarioExpect.Single(services.Inventory.ReleasedReservations);
+        ScenarioExpect.Empty(services.Payments.RefundedPayments);
+        ScenarioExpect.Contains(result.Audit, static entry => entry.StartsWith("inventory:released:", StringComparison.Ordinal));
     }
 
     private static CheckoutRequest CreateRequest(string orderId, decimal total, decimal giftCardBalance = 0m)

--- a/test/PatternKit.Examples.Tests/Messaging/RoutingSlipExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/RoutingSlipExampleTests.cs
@@ -1,16 +1,18 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class RoutingSlipExampleTests
 {
+    [Scenario("Run UsesGeneratedRoutingSlipFactory")]
     [Fact]
     public void Run_UsesGeneratedRoutingSlipFactory()
     {
         var summary = RoutingSlipExample.Run();
 
-        Assert.Equal("validated,reserved,shipped", summary.Status);
-        Assert.Equal(["validate", "reserve-inventory", "ship"], summary.Steps);
-        Assert.Equal("3", summary.RoutingIndex);
+        ScenarioExpect.Equal("validated,reserved,shipped", summary.Status);
+        ScenarioExpect.Equal(["validate", "reserve-inventory", "ship"], summary.Steps);
+        ScenarioExpect.Equal("3", summary.RoutingIndex);
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/SagaExampleTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/SagaExampleTests.cs
@@ -1,17 +1,19 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class SagaExampleTests
 {
+    [Scenario("Run UsesGeneratedSagaFactory")]
     [Fact]
     public void Run_UsesGeneratedSagaFactory()
     {
         var summary = SagaExample.Run();
 
-        Assert.Equal("order-42", summary.OrderId);
-        Assert.True(summary.Submitted);
-        Assert.True(summary.Paid);
-        Assert.True(summary.Completed);
+        ScenarioExpect.Equal("order-42", summary.OrderId);
+        ScenarioExpect.True(summary.Submitted);
+        ScenarioExpect.True(summary.Paid);
+        ScenarioExpect.True(summary.Completed);
     }
 }

--- a/test/PatternKit.Examples.Tests/Messaging/ServiceCollaborationMailboxDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/Messaging/ServiceCollaborationMailboxDemoTests.cs
@@ -1,28 +1,30 @@
 using PatternKit.Examples.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.Messaging;
 
 public sealed class ServiceCollaborationMailboxDemoTests
 {
+    [Scenario("RunAsync CoordinatesServicesAndCompensatesDeclinedPayment")]
     [Fact]
     public async Task RunAsync_CoordinatesServicesAndCompensatesDeclinedPayment()
     {
         var summary = await ServiceCollaborationMailboxDemo.RunAsync();
 
-        Assert.Contains(summary.Audit, static entry => entry == "inventory:reserved:order-ok:res-order-ok");
-        Assert.Contains(summary.Audit, static entry => entry == "payment:captured:order-ok");
-        Assert.Contains(summary.Audit, static entry => entry == "shipping:scheduled:order-ok");
-        Assert.Contains(summary.Audit, static entry => entry == "notification:order-ok:fulfilled");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "inventory:reserved:order-ok:res-order-ok");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "payment:captured:order-ok");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "shipping:scheduled:order-ok");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "notification:order-ok:fulfilled");
 
-        Assert.Contains(summary.Audit, static entry => entry == "inventory:reserved:order-declined:res-order-declined");
-        Assert.Contains(summary.Audit, static entry => entry == "payment:declined:order-declined");
-        Assert.Contains(summary.Audit, static entry => entry == "inventory:released:order-declined:res-order-declined");
-        Assert.Contains(summary.Audit, static entry => entry == "notification:order-declined:payment-declined");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "inventory:reserved:order-declined:res-order-declined");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "payment:declined:order-declined");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "inventory:released:order-declined:res-order-declined");
+        ScenarioExpect.Contains(summary.Audit, static entry => entry == "notification:order-declined:payment-declined");
 
-        Assert.Equal(["order-ok"], summary.OpenReservations);
-        Assert.Contains(summary.Notifications, static notification =>
+        ScenarioExpect.Equal(["order-ok"], summary.OpenReservations);
+        ScenarioExpect.Contains(summary.Notifications, static notification =>
             notification is { OrderId: "order-ok", Status: "fulfilled", CorrelationId: "checkout-ok" });
-        Assert.Contains(summary.Notifications, static notification =>
+        ScenarioExpect.Contains(summary.Notifications, static notification =>
             notification is { OrderId: "order-declined", Status: "payment-declined", CorrelationId: "checkout-declined" });
     }
 }

--- a/test/PatternKit.Examples.Tests/ObserverDemo/EventHubTests.cs
+++ b/test/PatternKit.Examples.Tests/ObserverDemo/EventHubTests.cs
@@ -1,17 +1,20 @@
 using PatternKit.Examples.ObserverDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.ObserverDemoTests;
 
 public sealed class EventHubTests
 {
+    [Scenario("CreateDefault Returns NonNull")]
     [Fact]
     public void CreateDefault_Returns_NonNull()
     {
         var hub = EventHub<int>.CreateDefault();
 
-        Assert.NotNull(hub);
+        ScenarioExpect.NotNull(hub);
     }
 
+    [Scenario("Publish Invokes Subscriber")]
     [Fact]
     public void Publish_Invokes_Subscriber()
     {
@@ -21,10 +24,11 @@ public sealed class EventHubTests
 
         hub.Publish(42);
 
-        Assert.Single(received);
-        Assert.Equal(42, received[0]);
+        ScenarioExpect.Single(received);
+        ScenarioExpect.Equal(42, received[0]);
     }
 
+    [Scenario("Publish Invokes Multiple Subscribers")]
     [Fact]
     public void Publish_Invokes_Multiple_Subscribers()
     {
@@ -36,12 +40,13 @@ public sealed class EventHubTests
 
         hub.Publish("hello");
 
-        Assert.Single(log1);
-        Assert.Single(log2);
-        Assert.Equal("hello", log1[0]);
-        Assert.Equal("hello", log2[0]);
+        ScenarioExpect.Single(log1);
+        ScenarioExpect.Single(log2);
+        ScenarioExpect.Equal("hello", log1[0]);
+        ScenarioExpect.Equal("hello", log2[0]);
     }
 
+    [Scenario("Dispose Removes Subscription")]
     [Fact]
     public void Dispose_Removes_Subscription()
     {
@@ -53,10 +58,11 @@ public sealed class EventHubTests
         sub.Dispose();
         hub.Publish(2);
 
-        Assert.Single(received);
-        Assert.Equal(1, received[0]);
+        ScenarioExpect.Single(received);
+        ScenarioExpect.Equal(1, received[0]);
     }
 
+    [Scenario("On With Predicate Filters Events")]
     [Fact]
     public void On_With_Predicate_Filters_Events()
     {
@@ -69,11 +75,12 @@ public sealed class EventHubTests
         hub.Publish(8);
         hub.Publish(20);
 
-        Assert.Equal(2, received.Count);
-        Assert.Equal(15, received[0]);
-        Assert.Equal(20, received[1]);
+        ScenarioExpect.Equal(2, received.Count);
+        ScenarioExpect.Equal(15, received[0]);
+        ScenarioExpect.Equal(20, received[1]);
     }
 
+    [Scenario("Multiple Subscriptions With Different Predicates")]
     [Fact]
     public void Multiple_Subscriptions_With_Different_Predicates()
     {
@@ -87,22 +94,24 @@ public sealed class EventHubTests
         hub.Publish(3);
         hub.Publish(4);
 
-        Assert.Equal(2, evens.Count); // -2 and 4
-        Assert.Equal(2, positives.Count); // 3 and 4
+        ScenarioExpect.Equal(2, evens.Count); // -2 and 4
+        ScenarioExpect.Equal(2, positives.Count); // 3 and 4
     }
 }
 
 public sealed class UserEventTests
 {
+    [Scenario("UserEvent Record Works")]
     [Fact]
     public void UserEvent_Record_Works()
     {
         var evt = new UserEvent(123, "login");
 
-        Assert.Equal(123, evt.Id);
-        Assert.Equal("login", evt.Action);
+        ScenarioExpect.Equal(123, evt.Id);
+        ScenarioExpect.Equal("login", evt.Action);
     }
 
+    [Scenario("EventHub With UserEvent")]
     [Fact]
     public void EventHub_With_UserEvent()
     {
@@ -113,11 +122,12 @@ public sealed class UserEventTests
         hub.Publish(new UserEvent(1, "login"));
         hub.Publish(new UserEvent(2, "logout"));
 
-        Assert.Equal(2, received.Count);
-        Assert.Equal("login", received[0].Action);
-        Assert.Equal("logout", received[1].Action);
+        ScenarioExpect.Equal(2, received.Count);
+        ScenarioExpect.Equal("login", received[0].Action);
+        ScenarioExpect.Equal("logout", received[1].Action);
     }
 
+    [Scenario("EventHub UserEvent Filtered By Action")]
     [Fact]
     public void EventHub_UserEvent_Filtered_By_Action()
     {
@@ -129,10 +139,11 @@ public sealed class UserEventTests
         hub.Publish(new UserEvent(2, "logout"));
         hub.Publish(new UserEvent(3, "login"));
 
-        Assert.Equal(2, logins.Count);
-        Assert.All(logins, e => Assert.Equal("login", e.Action));
+        ScenarioExpect.Equal(2, logins.Count);
+        ScenarioExpect.All(logins, e => ScenarioExpect.Equal("login", e.Action));
     }
 
+    [Scenario("EventHub UserEvent Filtered By Id")]
     [Fact]
     public void EventHub_UserEvent_Filtered_By_Id()
     {
@@ -144,7 +155,7 @@ public sealed class UserEventTests
         hub.Publish(new UserEvent(2, "login"));
         hub.Publish(new UserEvent(1, "logout"));
 
-        Assert.Equal(2, user1Events.Count);
-        Assert.All(user1Events, e => Assert.Equal(1, e.Id));
+        ScenarioExpect.Equal(2, user1Events.Count);
+        ScenarioExpect.All(user1Events, e => ScenarioExpect.Equal(1, e.Id));
     }
 }

--- a/test/PatternKit.Examples.Tests/ObserverGeneratorDemo/ObserverGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/ObserverGeneratorDemo/ObserverGeneratorDemoTests.cs
@@ -9,6 +9,7 @@ namespace PatternKit.Examples.Tests.ObserverGeneratorDemo;
 [Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
 public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    [Scenario("TemperatureChanged PublishesToSubscribersInOrder")]
     [Fact]
     public void TemperatureChanged_PublishesToSubscribersInOrder()
     {
@@ -20,9 +21,10 @@ public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyB
 
         changed.Publish(new TemperatureReading("sensor-a", 21.5, DateTime.UtcNow));
 
-        Assert.Equal(["first:sensor-a:21.5", "second:sensor-a:21.5"], received);
+        ScenarioExpect.Equal(["first:sensor-a:21.5", "second:sensor-a:21.5"], received);
     }
 
+    [Scenario("TemperatureChanged DisposedSubscription IsNotInvoked")]
     [Fact]
     public void TemperatureChanged_DisposedSubscription_IsNotInvoked()
     {
@@ -34,9 +36,10 @@ public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyB
         subscription.Dispose();
         changed.Publish(new TemperatureReading("sensor-a", 21, DateTime.UtcNow));
 
-        Assert.Equal(1, count);
+        ScenarioExpect.Equal(1, count);
     }
 
+    [Scenario("TemperatureAlertRaised StopPolicy DoesNotStopSubsequentGeneratedSubscribers")]
     [Fact]
     public void TemperatureAlertRaised_StopPolicy_DoesNotStopSubsequentGeneratedSubscribers()
     {
@@ -47,9 +50,10 @@ public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyB
 
         alertRaised.Publish(new TemperatureAlert("sensor-a", 30, 25));
 
-        Assert.True(handled);
+        ScenarioExpect.True(handled);
     }
 
+    [Scenario("NotificationPublished AwaitsAsyncSubscribers")]
     [Fact]
     public async Task NotificationPublished_AwaitsAsyncSubscribers()
     {
@@ -64,9 +68,10 @@ public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyB
 
         await published.PublishAsync(new Notification("user-1", "hello", 1));
 
-        Assert.Equal(["user-1"], received);
+        ScenarioExpect.Equal(["user-1"], received);
     }
 
+    [Scenario("NotificationSent ContinuesAfterSubscriberExceptions")]
     [Fact]
     public void NotificationSent_ContinuesAfterSubscriberExceptions()
     {
@@ -78,9 +83,10 @@ public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyB
 
         sent.Publish(new NotificationResult(true, "Email"));
 
-        Assert.True(handled);
+        ScenarioExpect.True(handled);
     }
 
+    [Scenario("NotificationSystem SendsThroughRegisteredAsyncHandlers")]
     [Fact]
     public async Task NotificationSystem_SendsThroughRegisteredAsyncHandlers()
     {
@@ -96,9 +102,9 @@ public sealed class ObserverGeneratorDemoTests(ITestOutputHelper output) : TinyB
 
         await system.SendAsync(new Notification("user-1", "hello", 1));
 
-        var result = Assert.Single(results);
-        Assert.True(result.Success);
-        Assert.Equal("Push", result.Channel);
+        var result = ScenarioExpect.Single(results);
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.Equal("Push", result.Channel);
     }
 
     [Scenario("Temperature monitor publishes readings, alerts, subscriber failures, and lifecycle disposal")]

--- a/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
+++ b/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
@@ -42,6 +42,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="..\ScenarioExpect.cs" Link="ScenarioExpect.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
       <Folder Include="FlyweightDemo\" />
       <Folder Include="Strategies\" />
     </ItemGroup>

--- a/test/PatternKit.Examples.Tests/PatternShowcase/PatternShowcaseTests.cs
+++ b/test/PatternKit.Examples.Tests/PatternShowcase/PatternShowcaseTests.cs
@@ -142,14 +142,16 @@ public sealed class PatternShowcaseTests(ITestOutputHelper output) : TinyBddXuni
 
 public sealed class PatternShowcaseUnitTests
 {
+    [Scenario("Build ReturnsNonNull")]
     [Fact]
     public void Build_ReturnsNonNull()
     {
         var facade = Showcase.Build();
 
-        Assert.NotNull(facade);
+        ScenarioExpect.NotNull(facade);
     }
 
+    [Scenario("SandboxGateway ChargeAsync Completes")]
     [Fact]
     public void SandboxGateway_ChargeAsync_Completes()
     {
@@ -157,9 +159,10 @@ public sealed class PatternShowcaseUnitTests
 
         var task = gateway.ChargeAsync(100m, CancellationToken.None);
 
-        Assert.True(task.IsCompleted);
+        ScenarioExpect.True(task.IsCompleted);
     }
 
+    [Scenario("SandboxGateway RefundAsync Completes")]
     [Fact]
     public void SandboxGateway_RefundAsync_Completes()
     {
@@ -167,9 +170,10 @@ public sealed class PatternShowcaseUnitTests
 
         var task = gateway.RefundAsync(100m, CancellationToken.None);
 
-        Assert.True(task.IsCompleted);
+        ScenarioExpect.True(task.IsCompleted);
     }
 
+    [Scenario("StripeGateway ChargeAsync Completes")]
     [Fact]
     public void StripeGateway_ChargeAsync_Completes()
     {
@@ -177,9 +181,10 @@ public sealed class PatternShowcaseUnitTests
 
         var task = gateway.ChargeAsync(100m, CancellationToken.None);
 
-        Assert.True(task.IsCompleted);
+        ScenarioExpect.True(task.IsCompleted);
     }
 
+    [Scenario("StripeGateway RefundAsync Completes")]
     [Fact]
     public void StripeGateway_RefundAsync_Completes()
     {
@@ -187,71 +192,78 @@ public sealed class PatternShowcaseUnitTests
 
         var task = gateway.RefundAsync(100m, CancellationToken.None);
 
-        Assert.True(task.IsCompleted);
+        ScenarioExpect.True(task.IsCompleted);
     }
 
+    [Scenario("OrderDto Record Works")]
     [Fact]
     public void OrderDto_Record_Works()
     {
         var dto = new Showcase.OrderDto("ORD-1", "C-1", "card",
             [new Showcase.OrderItemDto("SKU", "Name", 10m, 1)]);
 
-        Assert.Equal("ORD-1", dto.OrderId);
-        Assert.Equal("C-1", dto.CustomerId);
-        Assert.Equal("card", dto.PaymentKind);
-        Assert.Single(dto.Items);
+        ScenarioExpect.Equal("ORD-1", dto.OrderId);
+        ScenarioExpect.Equal("C-1", dto.CustomerId);
+        ScenarioExpect.Equal("card", dto.PaymentKind);
+        ScenarioExpect.Single(dto.Items);
     }
 
+    [Scenario("OrderItemDto Record Works")]
     [Fact]
     public void OrderItemDto_Record_Works()
     {
         var item = new Showcase.OrderItemDto("SKU-1", "Widget", 25.99m, 3, "Electronics");
 
-        Assert.Equal("SKU-1", item.Sku);
-        Assert.Equal("Widget", item.Name);
-        Assert.Equal(25.99m, item.Price);
-        Assert.Equal(3, item.Qty);
-        Assert.Equal("Electronics", item.Category);
+        ScenarioExpect.Equal("SKU-1", item.Sku);
+        ScenarioExpect.Equal("Widget", item.Name);
+        ScenarioExpect.Equal(25.99m, item.Price);
+        ScenarioExpect.Equal(3, item.Qty);
+        ScenarioExpect.Equal("Electronics", item.Category);
     }
 
+    [Scenario("OrderItemDto DefaultCategory IsNull")]
     [Fact]
     public void OrderItemDto_DefaultCategory_IsNull()
     {
         var item = new Showcase.OrderItemDto("SKU-1", "Widget", 25.99m, 3);
 
-        Assert.Null(item.Category);
+        ScenarioExpect.Null(item.Category);
     }
 
+    [Scenario("Cash Record Works")]
     [Fact]
     public void Cash_Record_Works()
     {
         var cash = new Showcase.Cash(50.00m);
 
-        Assert.Equal(50.00m, cash.Amount);
+        ScenarioExpect.Equal(50.00m, cash.Amount);
     }
 
+    [Scenario("Card Record Works")]
     [Fact]
     public void Card_Record_Works()
     {
         var card = new Showcase.Card("VISA", "4242", 100.00m);
 
-        Assert.Equal("VISA", card.Brand);
-        Assert.Equal("4242", card.Last4);
-        Assert.Equal(100.00m, card.Amount);
+        ScenarioExpect.Equal("VISA", card.Brand);
+        ScenarioExpect.Equal("4242", card.Last4);
+        ScenarioExpect.Equal(100.00m, card.Amount);
     }
 
+    [Scenario("OrderItem Record Works")]
     [Fact]
     public void OrderItem_Record_Works()
     {
         var item = new Showcase.OrderItem("SKU-1", "Widget", 10m, 5, "Promo");
 
-        Assert.Equal("SKU-1", item.Sku);
-        Assert.Equal("Widget", item.Name);
-        Assert.Equal(10m, item.UnitPrice);
-        Assert.Equal(5, item.Quantity);
-        Assert.Equal("Promo", item.Category);
+        ScenarioExpect.Equal("SKU-1", item.Sku);
+        ScenarioExpect.Equal("Widget", item.Name);
+        ScenarioExpect.Equal(10m, item.UnitPrice);
+        ScenarioExpect.Equal(5, item.Quantity);
+        ScenarioExpect.Equal("Promo", item.Category);
     }
 
+    [Scenario("OrderContext Total Computation")]
     [Fact]
     public void OrderContext_Total_Computation()
     {
@@ -272,24 +284,26 @@ public sealed class PatternShowcaseUnitTests
         ctx.Discount = 10m;
         ctx.Fees = 5m;
 
-        Assert.Equal(95m, ctx.Total); // 100 - 10 + 5 = 95
+        ScenarioExpect.Equal(95m, ctx.Total); // 100 - 10 + 5 = 95
     }
 
+    [Scenario("OrderPlaced Record Works")]
     [Fact]
     public void OrderPlaced_Record_Works()
     {
         var evt = new Showcase.OrderPlaced("ORD-123");
 
-        Assert.Equal("ORD-123", evt.OrderId);
+        ScenarioExpect.Equal("ORD-123", evt.OrderId);
     }
 
+    [Scenario("GenerateReceipt Record Works")]
     [Fact]
     public void GenerateReceipt_Record_Works()
     {
         var cmd = new Showcase.GenerateReceipt("ORD-456", 123.45m);
 
-        Assert.Equal("ORD-456", cmd.OrderId);
-        Assert.Equal(123.45m, cmd.Total);
+        ScenarioExpect.Equal("ORD-456", cmd.OrderId);
+        ScenarioExpect.Equal(123.45m, cmd.Total);
     }
 }
 

--- a/test/PatternKit.Examples.Tests/PointOfSale/DemoTests.cs
+++ b/test/PatternKit.Examples.Tests/PointOfSale/DemoTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Examples.PointOfSale;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.PointOfSaleDemoTests;
 
 public sealed class DemoTests
 {
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {
@@ -13,6 +15,7 @@ public sealed class DemoTests
 
 public sealed class DemoScenarioTests
 {
+    [Scenario("SimpleBusiness Scenario Works")]
     [Fact]
     public void SimpleBusiness_Scenario_Works()
     {
@@ -21,11 +24,12 @@ public sealed class DemoScenarioTests
 
         var receipt = processor.Execute(order);
 
-        Assert.NotNull(receipt);
-        Assert.True(receipt.TaxAmount > 0);
-        Assert.Equal("ORD-001", receipt.OrderId);
+        ScenarioExpect.NotNull(receipt);
+        ScenarioExpect.True(receipt.TaxAmount > 0);
+        ScenarioExpect.Equal("ORD-001", receipt.OrderId);
     }
 
+    [Scenario("RetailStore Scenario Works")]
     [Fact]
     public void RetailStore_Scenario_Works()
     {
@@ -34,10 +38,11 @@ public sealed class DemoScenarioTests
 
         var receipt = processor.Execute(order);
 
-        Assert.NotNull(receipt);
-        Assert.True(receipt.TaxAmount > 0);
+        ScenarioExpect.NotNull(receipt);
+        ScenarioExpect.True(receipt.TaxAmount > 0);
     }
 
+    [Scenario("Ecommerce Scenario With Promotions")]
     [Fact]
     public void Ecommerce_Scenario_With_Promotions()
     {
@@ -59,9 +64,10 @@ public sealed class DemoScenarioTests
         var processor = PaymentProcessorDemo.CreateEcommerceProcessor(promotions);
         var receipt = processor.Execute(order);
 
-        Assert.NotNull(receipt);
+        ScenarioExpect.NotNull(receipt);
     }
 
+    [Scenario("EmployeePurchase Gets Discount")]
     [Fact]
     public void EmployeePurchase_Gets_Discount()
     {
@@ -92,10 +98,11 @@ public sealed class DemoScenarioTests
         var processor = PaymentProcessorDemo.CreateCashRegisterProcessor();
         var receipt = processor.Execute(order);
 
-        Assert.NotNull(receipt);
-        Assert.True(receipt.DiscountAmount > 0); // Employee discount should apply
+        ScenarioExpect.NotNull(receipt);
+        ScenarioExpect.True(receipt.DiscountAmount > 0); // Employee discount should apply
     }
 
+    [Scenario("BirthdaySpecial Scenario")]
     [Fact]
     public void BirthdaySpecial_Scenario()
     {
@@ -128,9 +135,10 @@ public sealed class DemoScenarioTests
         var processor = PaymentProcessorDemo.CreateBirthdaySpecialProcessor(order);
         var receipt = processor.Execute(order);
 
-        Assert.NotNull(receipt);
+        ScenarioExpect.NotNull(receipt);
     }
 
+    [Scenario("InternationalStore With NickelRounding")]
     [Fact]
     public void InternationalStore_With_NickelRounding()
     {
@@ -168,7 +176,7 @@ public sealed class DemoScenarioTests
         var processor = PaymentProcessorDemo.CreateCashRegisterProcessor();
         var receipt = processor.Execute(order);
 
-        Assert.NotNull(receipt);
+        ScenarioExpect.NotNull(receipt);
     }
 
     private static PurchaseOrder CreateBasicOrder(string orderId, string customerId, string? loyaltyTier)

--- a/test/PatternKit.Examples.Tests/PrototypeDemo/PrototypeDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/PrototypeDemo/PrototypeDemoTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Examples.PrototypeDemo;
 using static PatternKit.Examples.PrototypeDemo.PrototypeDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.PrototypeDemoTests;
 
 public sealed class PrototypeDemoTests
 {
+    [Scenario("CharacterStats Clone Creates Independent Copy")]
     [Fact]
     public void CharacterStats_Clone_Creates_Independent_Copy()
     {
@@ -19,13 +21,14 @@ public sealed class PrototypeDemoTests
 
         var clone = original.Clone();
 
-        Assert.NotSame(original, clone);
-        Assert.Equal(original.Health, clone.Health);
+        ScenarioExpect.NotSame(original, clone);
+        ScenarioExpect.Equal(original.Health, clone.Health);
 
         clone.Health = 200;
-        Assert.Equal(100, original.Health);
+        ScenarioExpect.Equal(100, original.Health);
     }
 
+    [Scenario("Equipment Clone Creates Independent Copy")]
     [Fact]
     public void Equipment_Clone_Creates_Independent_Copy()
     {
@@ -38,15 +41,16 @@ public sealed class PrototypeDemoTests
 
         var clone = original.Clone();
 
-        Assert.NotSame(original, clone);
-        Assert.NotSame(original.Accessories, clone.Accessories);
-        Assert.Equal(original.Weapon, clone.Weapon);
-        Assert.Equal(original.Accessories.Count, clone.Accessories.Count);
+        ScenarioExpect.NotSame(original, clone);
+        ScenarioExpect.NotSame(original.Accessories, clone.Accessories);
+        ScenarioExpect.Equal(original.Weapon, clone.Weapon);
+        ScenarioExpect.Equal(original.Accessories.Count, clone.Accessories.Count);
 
         clone.Accessories.Add("Cape");
-        Assert.Equal(2, original.Accessories.Count);
+        ScenarioExpect.Equal(2, original.Accessories.Count);
     }
 
+    [Scenario("GameCharacter DeepClone Creates Independent Copy")]
     [Fact]
     public void GameCharacter_DeepClone_Creates_Independent_Copy()
     {
@@ -54,53 +58,57 @@ public sealed class PrototypeDemoTests
 
         var clone = GameCharacter.DeepClone(original);
 
-        Assert.NotSame(original, clone);
-        Assert.NotEqual(original.Id, clone.Id);
-        Assert.NotSame(original.Stats, clone.Stats);
-        Assert.NotSame(original.Equipment, clone.Equipment);
-        Assert.NotSame(original.Abilities, clone.Abilities);
-        Assert.NotSame(original.Resistances, clone.Resistances);
+        ScenarioExpect.NotSame(original, clone);
+        ScenarioExpect.NotEqual(original.Id, clone.Id);
+        ScenarioExpect.NotSame(original.Stats, clone.Stats);
+        ScenarioExpect.NotSame(original.Equipment, clone.Equipment);
+        ScenarioExpect.NotSame(original.Abilities, clone.Abilities);
+        ScenarioExpect.NotSame(original.Resistances, clone.Resistances);
     }
 
+    [Scenario("CreateWarriorPrototype Has Correct Stats")]
     [Fact]
     public void CreateWarriorPrototype_Has_Correct_Stats()
     {
         var warrior = CreateWarriorPrototype();
 
-        Assert.Equal("Warrior", warrior.Name);
-        Assert.Equal("Warrior", warrior.Class);
-        Assert.Equal(150, warrior.Stats.Health);
-        Assert.Equal(30, warrior.Stats.Mana);
-        Assert.Equal(15, warrior.Stats.Strength);
-        Assert.Equal("Iron Sword", warrior.Equipment.Weapon);
+        ScenarioExpect.Equal("Warrior", warrior.Name);
+        ScenarioExpect.Equal("Warrior", warrior.Class);
+        ScenarioExpect.Equal(150, warrior.Stats.Health);
+        ScenarioExpect.Equal(30, warrior.Stats.Mana);
+        ScenarioExpect.Equal(15, warrior.Stats.Strength);
+        ScenarioExpect.Equal("Iron Sword", warrior.Equipment.Weapon);
     }
 
+    [Scenario("CreateMagePrototype Has Correct Stats")]
     [Fact]
     public void CreateMagePrototype_Has_Correct_Stats()
     {
         var mage = CreateMagePrototype();
 
-        Assert.Equal("Mage", mage.Name);
-        Assert.Equal("Mage", mage.Class);
-        Assert.Equal(80, mage.Stats.Health);
-        Assert.Equal(150, mage.Stats.Mana);
-        Assert.Equal(18, mage.Stats.Intelligence);
-        Assert.Equal("Oak Staff", mage.Equipment.Weapon);
+        ScenarioExpect.Equal("Mage", mage.Name);
+        ScenarioExpect.Equal("Mage", mage.Class);
+        ScenarioExpect.Equal(80, mage.Stats.Health);
+        ScenarioExpect.Equal(150, mage.Stats.Mana);
+        ScenarioExpect.Equal(18, mage.Stats.Intelligence);
+        ScenarioExpect.Equal("Oak Staff", mage.Equipment.Weapon);
     }
 
+    [Scenario("CreateRoguePrototype Has Correct Stats")]
     [Fact]
     public void CreateRoguePrototype_Has_Correct_Stats()
     {
         var rogue = CreateRoguePrototype();
 
-        Assert.Equal("Rogue", rogue.Name);
-        Assert.Equal("Rogue", rogue.Class);
-        Assert.Equal(100, rogue.Stats.Health);
-        Assert.Equal(16, rogue.Stats.Agility);
-        Assert.Equal("Twin Daggers", rogue.Equipment.Weapon);
-        Assert.Equal(50, rogue.Resistances["Poison"]);
+        ScenarioExpect.Equal("Rogue", rogue.Name);
+        ScenarioExpect.Equal("Rogue", rogue.Class);
+        ScenarioExpect.Equal(100, rogue.Stats.Health);
+        ScenarioExpect.Equal(16, rogue.Stats.Agility);
+        ScenarioExpect.Equal("Twin Daggers", rogue.Equipment.Weapon);
+        ScenarioExpect.Equal(50, rogue.Resistances["Poison"]);
     }
 
+    [Scenario("CreateCharacterFactory Clones Warrior")]
     [Fact]
     public void CreateCharacterFactory_Clones_Warrior()
     {
@@ -108,10 +116,11 @@ public sealed class PrototypeDemoTests
 
         var warrior = factory.Create("warrior");
 
-        Assert.Equal("Warrior", warrior.Name);
-        Assert.Equal("Warrior", warrior.Class);
+        ScenarioExpect.Equal("Warrior", warrior.Name);
+        ScenarioExpect.Equal("Warrior", warrior.Class);
     }
 
+    [Scenario("CreateCharacterFactory Clones Mage")]
     [Fact]
     public void CreateCharacterFactory_Clones_Mage()
     {
@@ -119,10 +128,11 @@ public sealed class PrototypeDemoTests
 
         var mage = factory.Create("mage");
 
-        Assert.Equal("Mage", mage.Name);
-        Assert.Equal("Mage", mage.Class);
+        ScenarioExpect.Equal("Mage", mage.Name);
+        ScenarioExpect.Equal("Mage", mage.Class);
     }
 
+    [Scenario("CreateCharacterFactory Clones Rogue")]
     [Fact]
     public void CreateCharacterFactory_Clones_Rogue()
     {
@@ -130,10 +140,11 @@ public sealed class PrototypeDemoTests
 
         var rogue = factory.Create("rogue");
 
-        Assert.Equal("Rogue", rogue.Name);
-        Assert.Equal("Rogue", rogue.Class);
+        ScenarioExpect.Equal("Rogue", rogue.Name);
+        ScenarioExpect.Equal("Rogue", rogue.Class);
     }
 
+    [Scenario("CreateCharacterFactory Clones EliteWarrior")]
     [Fact]
     public void CreateCharacterFactory_Clones_EliteWarrior()
     {
@@ -141,11 +152,12 @@ public sealed class PrototypeDemoTests
 
         var elite = factory.Create("elite-warrior");
 
-        Assert.Equal("Elite Warrior", elite.Name);
-        Assert.Equal(10, elite.Level);
-        Assert.Equal(300, elite.Stats.Health); // 150 * 2
+        ScenarioExpect.Equal("Elite Warrior", elite.Name);
+        ScenarioExpect.Equal(10, elite.Level);
+        ScenarioExpect.Equal(300, elite.Stats.Health); // 150 * 2
     }
 
+    [Scenario("CreateCharacterFactory Clones EliteMage")]
     [Fact]
     public void CreateCharacterFactory_Clones_EliteMage()
     {
@@ -153,11 +165,12 @@ public sealed class PrototypeDemoTests
 
         var elite = factory.Create("elite-mage");
 
-        Assert.Equal("Archmage", elite.Name);
-        Assert.Equal(15, elite.Level);
-        Assert.Equal(450, elite.Stats.Mana); // 150 * 3
+        ScenarioExpect.Equal("Archmage", elite.Name);
+        ScenarioExpect.Equal(15, elite.Level);
+        ScenarioExpect.Equal(450, elite.Stats.Mana); // 150 * 3
     }
 
+    [Scenario("CreateCharacterFactory Clones Boss")]
     [Fact]
     public void CreateCharacterFactory_Clones_Boss()
     {
@@ -165,14 +178,15 @@ public sealed class PrototypeDemoTests
 
         var boss = factory.Create("boss-dragon-knight");
 
-        Assert.Equal("Dragon Knight", boss.Name);
-        Assert.Equal(50, boss.Level);
-        Assert.Equal(5000, boss.Stats.Health);
-        Assert.Equal(80, boss.Stats.Strength);
-        Assert.Equal("Dragonbone Greatsword", boss.Equipment.Weapon);
-        Assert.Equal(100, boss.Resistances["Fire"]);
+        ScenarioExpect.Equal("Dragon Knight", boss.Name);
+        ScenarioExpect.Equal(50, boss.Level);
+        ScenarioExpect.Equal(5000, boss.Stats.Health);
+        ScenarioExpect.Equal(80, boss.Stats.Strength);
+        ScenarioExpect.Equal("Dragonbone Greatsword", boss.Equipment.Weapon);
+        ScenarioExpect.Equal(100, boss.Resistances["Fire"]);
     }
 
+    [Scenario("CreateCharacterFactory With Mutation")]
     [Fact]
     public void CreateCharacterFactory_With_Mutation()
     {
@@ -184,10 +198,11 @@ public sealed class PrototypeDemoTests
             c.Level = 25;
         });
 
-        Assert.Equal("Sir Galahad", custom.Name);
-        Assert.Equal(25, custom.Level);
+        ScenarioExpect.Equal("Sir Galahad", custom.Name);
+        ScenarioExpect.Equal(25, custom.Level);
     }
 
+    [Scenario("CreateCharacterFactory Default Returns Warrior")]
     [Fact]
     public void CreateCharacterFactory_Default_Returns_Warrior()
     {
@@ -195,9 +210,10 @@ public sealed class PrototypeDemoTests
 
         var unknown = factory.Create("unknown-key");
 
-        Assert.Equal("Warrior", unknown.Class);
+        ScenarioExpect.Equal("Warrior", unknown.Class);
     }
 
+    [Scenario("CreateNpcSpawner Creates Clones")]
     [Fact]
     public void CreateNpcSpawner_Creates_Clones()
     {
@@ -215,11 +231,12 @@ public sealed class PrototypeDemoTests
         var spawn1 = spawner.Create();
         var spawn2 = spawner.Create();
 
-        Assert.NotSame(spawn1, spawn2);
-        Assert.Equal("Goblin", spawn1.Name);
-        Assert.Equal("Goblin", spawn2.Name);
+        ScenarioExpect.NotSame(spawn1, spawn2);
+        ScenarioExpect.Equal("Goblin", spawn1.Name);
+        ScenarioExpect.Equal("Goblin", spawn2.Name);
     }
 
+    [Scenario("CreateNpcSpawner With Mutation")]
     [Fact]
     public void CreateNpcSpawner_With_Mutation()
     {
@@ -236,9 +253,10 @@ public sealed class PrototypeDemoTests
 
         var spawn = spawner.Create(g => g.Name = "Elite Goblin");
 
-        Assert.Equal("Elite Goblin", spawn.Name);
+        ScenarioExpect.Equal("Elite Goblin", spawn.Name);
     }
 
+    [Scenario("GameCharacter ToString Works")]
     [Fact]
     public void GameCharacter_ToString_Works()
     {
@@ -246,11 +264,12 @@ public sealed class PrototypeDemoTests
 
         var str = warrior.ToString();
 
-        Assert.Contains("Warrior", str);
-        Assert.Contains("HP:150", str);
-        Assert.Contains("STR:15", str);
+        ScenarioExpect.Contains("Warrior", str);
+        ScenarioExpect.Contains("HP:150", str);
+        ScenarioExpect.Contains("STR:15", str);
     }
 
+    [Scenario("Run Executes Without Errors")]
     [Fact]
     public void Run_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/ProxyGeneratorDemo/ProxyGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/ProxyGeneratorDemo/ProxyGeneratorDemoTests.cs
@@ -10,6 +10,7 @@ namespace PatternKit.Examples.Tests.ProxyGeneratorDemo;
 [Collection(PatternKit.Examples.Tests.ConsoleTestCollection.Name)]
 public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    [Scenario("RealPaymentService StoresSuccessfulTransactions")]
     [Fact]
     public void RealPaymentService_StoresSuccessfulTransactions()
     {
@@ -18,14 +19,15 @@ public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddX
         var result = service.ProcessPayment(CreateRequest("cust-1", 42m));
         var history = service.GetTransactionHistory("cust-1");
 
-        Assert.True(result.Success);
-        Assert.StartsWith("TXN-", result.TransactionId);
-        var transaction = Assert.Single(history);
-        Assert.Equal("cust-1", transaction.CustomerId);
-        Assert.Equal(42m, transaction.Amount);
-        Assert.Equal("USD", transaction.Currency);
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.StartsWith("TXN-", result.TransactionId);
+        var transaction = ScenarioExpect.Single(history);
+        ScenarioExpect.Equal("cust-1", transaction.CustomerId);
+        ScenarioExpect.Equal(42m, transaction.Amount);
+        ScenarioExpect.Equal("USD", transaction.Currency);
     }
 
+    [Scenario("RealPaymentService AsyncPayment StoresTransaction")]
     [Fact]
     public async Task RealPaymentService_AsyncPayment_StoresTransaction()
     {
@@ -33,11 +35,12 @@ public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddX
 
         var result = await service.ProcessPaymentAsync(CreateRequest("cust-async", 75m));
 
-        Assert.True(result.Success);
-        Assert.Contains("async", result.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Single(service.GetTransactionHistory("cust-async"));
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.Contains("async", result.Message, StringComparison.OrdinalIgnoreCase);
+        ScenarioExpect.Single(service.GetTransactionHistory("cust-async"));
     }
 
+    [Scenario("GeneratedProxy WithInterceptors InvokesInnerService")]
     [Fact]
     public void GeneratedProxy_WithInterceptors_InvokesInnerService()
     {
@@ -49,12 +52,13 @@ public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddX
         var result = proxy.ProcessPayment(CreateRequest("cust-proxy", 100m));
         var history = proxy.GetTransactionHistory("cust-proxy");
 
-        Assert.True(result.Success);
-        Assert.Single(history);
-        Assert.Contains(nameof(IPaymentService.ProcessPayment), timing.GetTimings().Keys);
-        Assert.Contains(nameof(IPaymentService.GetTransactionHistory), timing.GetTimings().Keys);
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.Single(history);
+        ScenarioExpect.Contains(nameof(IPaymentService.ProcessPayment), timing.GetTimings().Keys);
+        ScenarioExpect.Contains(nameof(IPaymentService.GetTransactionHistory), timing.GetTimings().Keys);
     }
 
+    [Scenario("GeneratedProxy WithAuthenticationInterceptor RejectsInvalidToken")]
     [Fact]
     public void GeneratedProxy_WithAuthenticationInterceptor_RejectsInvalidToken()
     {
@@ -71,9 +75,10 @@ public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddX
             AuthToken = "bad-token"
         };
 
-        Assert.Throws<UnauthorizedAccessException>(() => proxy.ProcessPayment(request));
+        ScenarioExpect.Throws<UnauthorizedAccessException>(() => proxy.ProcessPayment(request));
     }
 
+    [Scenario("GeneratedProxy AsyncInterceptors InvokeInnerService")]
     [Fact]
     public async Task GeneratedProxy_AsyncInterceptors_InvokeInnerService()
     {
@@ -84,10 +89,11 @@ public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddX
 
         var result = await proxy.ProcessPaymentAsync(CreateRequest("cust-proxy-async", 55m));
 
-        Assert.True(result.Success);
-        Assert.Contains(nameof(IPaymentService.ProcessPaymentAsync), timing.GetTimings().Keys);
+        ScenarioExpect.True(result.Success);
+        ScenarioExpect.Contains(nameof(IPaymentService.ProcessPaymentAsync), timing.GetTimings().Keys);
     }
 
+    [Scenario("CachingInterceptor RecordsTransactionHistoryResults")]
     [Fact]
     public void CachingInterceptor_RecordsTransactionHistoryResults()
     {
@@ -98,11 +104,11 @@ public sealed class ProxyGeneratorDemoTests(ITestOutputHelper output) : TinyBddX
         _ = proxy.GetTransactionHistory("cust-cache");
 
         var stats = cache.GetStats();
-        Assert.Equal(1, stats.Count);
-        Assert.Equal(0, stats.Expired);
+        ScenarioExpect.Equal(1, stats.Count);
+        ScenarioExpect.Equal(0, stats.Expired);
 
         cache.ClearCache();
-        Assert.Equal(0, cache.GetStats().Count);
+        ScenarioExpect.Equal(0, cache.GetStats().Count);
     }
 
     [Scenario("Comprehensive proxy demo runs the generated proxy pipeline")]

--- a/test/PatternKit.Examples.Tests/SingletonGeneratorDemo/SingletonGeneratorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/SingletonGeneratorDemo/SingletonGeneratorDemoTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Examples.SingletonGeneratorDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.SingletonGeneratorDemo;
 
 public class SingletonGeneratorDemoTests
 {
+    [Scenario("AppClock ReturnsSameInstance")]
     [Fact]
     public void AppClock_ReturnsSameInstance()
     {
@@ -11,10 +13,11 @@ public class SingletonGeneratorDemoTests
         var clock1 = AppClock.Instance;
         var clock2 = AppClock.Instance;
 
-        // Assert
-        Assert.Same(clock1, clock2);
+        // Then
+        ScenarioExpect.Same(clock1, clock2);
     }
 
+    [Scenario("AppClock ProvidesCurrentTime")]
     [Fact]
     public void AppClock_ProvidesCurrentTime()
     {
@@ -23,10 +26,11 @@ public class SingletonGeneratorDemoTests
         var clockTime = AppClock.Instance.UtcNow;
         var after = DateTime.UtcNow;
 
-        // Assert
-        Assert.InRange(clockTime, before, after);
+        // Then
+        ScenarioExpect.InRange(clockTime, before, after);
     }
 
+    [Scenario("AppClock ProvidesUnixTimestamp")]
     [Fact]
     public void AppClock_ProvidesUnixTimestamp()
     {
@@ -37,11 +41,12 @@ public class SingletonGeneratorDemoTests
         var timestamp = AppClock.Instance.UnixTimestamp;
         var afterTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-        // Assert
-        Assert.True(timestamp > 0);
-        Assert.InRange(timestamp, beforeTimestamp, afterTimestamp);
+        // Then
+        ScenarioExpect.True(timestamp > 0);
+        ScenarioExpect.InRange(timestamp, beforeTimestamp, afterTimestamp);
     }
 
+    [Scenario("AppClock ProvidesLocalTimeAndCurrentDate")]
     [Fact]
     public void AppClock_ProvidesLocalTimeAndCurrentDate()
     {
@@ -50,10 +55,11 @@ public class SingletonGeneratorDemoTests
         var after = DateTimeOffset.Now.AddSeconds(1);
         var today = AppClock.Instance.Today;
 
-        Assert.InRange(now, before, after);
-        Assert.InRange(today.DayNumber, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)).DayNumber, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).DayNumber);
+        ScenarioExpect.InRange(now, before, after);
+        ScenarioExpect.InRange(today.DayNumber, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)).DayNumber, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).DayNumber);
     }
 
+    [Scenario("ConfigManager ReturnsSameInstance")]
     [Fact]
     public void ConfigManager_ReturnsSameInstance()
     {
@@ -61,34 +67,37 @@ public class SingletonGeneratorDemoTests
         var config1 = ConfigManager.Instance;
         var config2 = ConfigManager.Instance;
 
-        // Assert
-        Assert.Same(config1, config2);
+        // Then
+        ScenarioExpect.Same(config1, config2);
     }
 
+    [Scenario("ConfigManager HasDefaultValues")]
     [Fact]
     public void ConfigManager_HasDefaultValues()
     {
         // Act
         var config = ConfigManager.Instance;
 
-        // Assert
-        Assert.NotNull(config.AppName);
-        Assert.NotNull(config.Environment);
-        Assert.NotNull(config.ConnectionString);
-        Assert.False(config.DebugLogging);
-        Assert.Contains($"App={config.AppName}", config.ToString(), StringComparison.Ordinal);
+        // Then
+        ScenarioExpect.NotNull(config.AppName);
+        ScenarioExpect.NotNull(config.Environment);
+        ScenarioExpect.NotNull(config.ConnectionString);
+        ScenarioExpect.False(config.DebugLogging);
+        ScenarioExpect.Contains($"App={config.AppName}", config.ToString(), StringComparison.Ordinal);
     }
 
+    [Scenario("ConfigManager LoadedAtIsInPast")]
     [Fact]
     public void ConfigManager_LoadedAtIsInPast()
     {
         // Act
         var config = ConfigManager.Instance;
 
-        // Assert
-        Assert.True(config.LoadedAt <= DateTime.UtcNow);
+        // Then
+        ScenarioExpect.True(config.LoadedAt <= DateTime.UtcNow);
     }
 
+    [Scenario("ServiceRegistry ReturnsSameInstance")]
     [Fact]
     public void ServiceRegistry_ReturnsSameInstance()
     {
@@ -96,10 +105,11 @@ public class SingletonGeneratorDemoTests
         var registry1 = ServiceRegistry.Instance;
         var registry2 = ServiceRegistry.Instance;
 
-        // Assert
-        Assert.Same(registry1, registry2);
+        // Then
+        ScenarioExpect.Same(registry1, registry2);
     }
 
+    [Scenario("ServiceRegistry RegisterAndResolve")]
     [Fact]
     public void ServiceRegistry_RegisterAndResolve()
     {
@@ -112,10 +122,11 @@ public class SingletonGeneratorDemoTests
         registry.Register<ITestService>(service);
         var resolved = registry.Resolve<ITestService>();
 
-        // Assert
-        Assert.Same(service, resolved);
+        // Then
+        ScenarioExpect.Same(service, resolved);
     }
 
+    [Scenario("ServiceRegistry RegisterFactory")]
     [Fact]
     public void ServiceRegistry_RegisterFactory()
     {
@@ -134,11 +145,12 @@ public class SingletonGeneratorDemoTests
         var first = registry.Resolve<ITestService>();
         var second = registry.Resolve<ITestService>();
 
-        // Assert
-        Assert.Same(first, second); // Factory result is cached
-        Assert.Equal(1, callCount); // Factory only called once
+        // Then
+        ScenarioExpect.Same(first, second); // Factory result is cached
+        ScenarioExpect.Equal(1, callCount); // Factory only called once
     }
 
+    [Scenario("ServiceRegistry TryResolve ReturnsNullWhenNotFound")]
     [Fact]
     public void ServiceRegistry_TryResolve_ReturnsNullWhenNotFound()
     {
@@ -149,10 +161,11 @@ public class SingletonGeneratorDemoTests
         // Act
         var result = registry.TryResolve<IUnregisteredService>();
 
-        // Assert
-        Assert.Null(result);
+        // Then
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("ServiceRegistry Resolve ThrowsWhenNotFound")]
     [Fact]
     public void ServiceRegistry_Resolve_ThrowsWhenNotFound()
     {
@@ -160,11 +173,12 @@ public class SingletonGeneratorDemoTests
         var registry = ServiceRegistry.Instance;
         registry.Clear();
 
-        // Act & Assert
-        Assert.Throws<InvalidOperationException>(() =>
+        // Act and verify
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             registry.Resolve<IUnregisteredService>());
     }
 
+    [Scenario("ServiceRegistry IsRegistered")]
     [Fact]
     public void ServiceRegistry_IsRegistered()
     {
@@ -173,11 +187,12 @@ public class SingletonGeneratorDemoTests
         registry.Clear();
         registry.Register<ITestService>(new TestService("test"));
 
-        // Assert
-        Assert.True(registry.IsRegistered<ITestService>());
-        Assert.False(registry.IsRegistered<IUnregisteredService>());
+        // Then
+        ScenarioExpect.True(registry.IsRegistered<ITestService>());
+        ScenarioExpect.False(registry.IsRegistered<IUnregisteredService>());
     }
 
+    [Scenario("ServiceRegistry ThreadSafe ParallelAccess")]
     [Fact]
     public void ServiceRegistry_ThreadSafe_ParallelAccess()
     {
@@ -200,11 +215,11 @@ public class SingletonGeneratorDemoTests
             results[i] = registry.Resolve<ITestService>();
         });
 
-        // Assert - all should get the same instance
+        // Then - all should get the same instance
         var first = results[0];
-        Assert.All(results, r => Assert.Same(first, r));
+        ScenarioExpect.All(results, r => ScenarioExpect.Same(first, r));
         // Factory is invoked exactly once due to Lazy<T> ensuring single execution
-        Assert.Equal(1, creationCount);
+        ScenarioExpect.Equal(1, creationCount);
     }
 
     // Test service interface

--- a/test/PatternKit.Examples.Tests/TemplateDemo/TemplateDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/TemplateDemo/TemplateDemoTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Examples.TemplateDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.TemplateDemo;
 
 public sealed class TemplateDemoTests
 {
+    [Scenario("DataProcessor Execute Counts Words")]
     [Fact]
     public void DataProcessor_Execute_Counts_Words()
     {
@@ -11,9 +13,10 @@ public sealed class TemplateDemoTests
 
         var result = processor.Execute("The quick brown fox");
 
-        Assert.Equal(4, result);
+        ScenarioExpect.Equal(4, result);
     }
 
+    [Scenario("DataProcessor Execute Handles Multiple Spaces")]
     [Fact]
     public void DataProcessor_Execute_Handles_Multiple_Spaces()
     {
@@ -21,9 +24,10 @@ public sealed class TemplateDemoTests
 
         var result = processor.Execute("One   two    three");
 
-        Assert.Equal(3, result);
+        ScenarioExpect.Equal(3, result);
     }
 
+    [Scenario("DataProcessor Execute Empty String")]
     [Fact]
     public void DataProcessor_Execute_Empty_String()
     {
@@ -31,9 +35,10 @@ public sealed class TemplateDemoTests
 
         var result = processor.Execute("");
 
-        Assert.Equal(0, result);
+        ScenarioExpect.Equal(0, result);
     }
 
+    [Scenario("TemplateMethodDemo Run Executes Without Errors")]
     [Fact]
     public void TemplateMethodDemo_Run_Executes_Without_Errors()
     {
@@ -43,6 +48,7 @@ public sealed class TemplateDemoTests
 
 public sealed class TemplateFluentDemoTests
 {
+    [Scenario("TemplateFluentDemo Run Executes Without Errors")]
     [Fact]
     public void TemplateFluentDemo_Run_Executes_Without_Errors()
     {
@@ -52,6 +58,7 @@ public sealed class TemplateFluentDemoTests
 
 public sealed class AsyncDataPipelineTests
 {
+    [Scenario("AsyncDataPipeline ExecuteAsync Processes Request")]
     [Fact]
     public async Task AsyncDataPipeline_ExecuteAsync_Processes_Request()
     {
@@ -59,9 +66,10 @@ public sealed class AsyncDataPipelineTests
 
         var result = await pipeline.ExecuteAsync(42);
 
-        Assert.Equal("PAYLOAD:42", result);
+        ScenarioExpect.Equal("PAYLOAD:42", result);
     }
 
+    [Scenario("AsyncDataPipeline ExecuteAsync Cancellation")]
     [Fact]
     public async Task AsyncDataPipeline_ExecuteAsync_Cancellation()
     {
@@ -69,13 +77,14 @@ public sealed class AsyncDataPipelineTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+        await ScenarioExpect.ThrowsAnyAsync<OperationCanceledException>(
             () => pipeline.ExecuteAsync(1, cts.Token));
     }
 }
 
 public sealed class TemplateAsyncFluentDemoTests
 {
+    [Scenario("TemplateAsyncFluentDemo RunAsync Executes Without Errors")]
     [Fact]
     public async Task TemplateAsyncFluentDemo_RunAsync_Executes_Without_Errors()
     {

--- a/test/PatternKit.Examples.Tests/TemplateMethodGeneratorDemo/OrderProcessingDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/TemplateMethodGeneratorDemo/OrderProcessingDemoTests.cs
@@ -13,13 +13,13 @@ public sealed partial class OrderProcessingDemoTests(ITestOutputHelper output) :
     {
         var log = await PatternKit.Examples.TemplateMethodGeneratorDemo.OrderProcessingDemo.RunAsync();
 
-        Assert.True(log.Any(l => l.Contains("Starting order processing")), "Should start with BeforeAll hook");
-        Assert.True(log.Any(l => l.Contains("Payment authorized")), "Should authorize payment");
-        Assert.True(log.Any(l => l.Contains("Inventory reserved")), "Should reserve inventory");
-        Assert.True(log.Any(l => l.Contains("Order confirmed")), "Should confirm order");
-        Assert.True(log.Any(l => l.Contains("Notification sent")), "Should send notification");
-        Assert.True(log.Any(l => l.Contains("Order processing completed successfully")), "Should end with AfterAll hook");
-        Assert.True(log.Any(l => l.Contains("ready for fulfillment")), "Order should be ready for fulfillment");
+        ScenarioExpect.True(log.Any(l => l.Contains("Starting order processing")), "Should start with BeforeAll hook");
+        ScenarioExpect.True(log.Any(l => l.Contains("Payment authorized")), "Should authorize payment");
+        ScenarioExpect.True(log.Any(l => l.Contains("Inventory reserved")), "Should reserve inventory");
+        ScenarioExpect.True(log.Any(l => l.Contains("Order confirmed")), "Should confirm order");
+        ScenarioExpect.True(log.Any(l => l.Contains("Notification sent")), "Should send notification");
+        ScenarioExpect.True(log.Any(l => l.Contains("Order processing completed successfully")), "Should end with AfterAll hook");
+        ScenarioExpect.True(log.Any(l => l.Contains("ready for fulfillment")), "Order should be ready for fulfillment");
     }
 
     [Scenario("Invalid payment amount triggers error handling")]
@@ -28,11 +28,11 @@ public sealed partial class OrderProcessingDemoTests(ITestOutputHelper output) :
     {
         var log = await PatternKit.Examples.TemplateMethodGeneratorDemo.OrderProcessingDemo.RunWithInvalidAmountAsync();
 
-        Assert.True(log.Any(l => l.Contains("Authorizing payment")), "Should attempt payment authorization");
-        Assert.True(log.Any(l => l.Contains("ERROR: Invalid payment amount")), "Payment authorization should fail");
-        Assert.True(log.Any(l => l.Contains("Order processing failed")), "Should invoke OnError hook");
-        Assert.False(log.Any(l => l.Contains("Inventory reserved")), "Should not reserve inventory");
-        Assert.False(log.Any(l => l.Contains("Order confirmed")), "Should not confirm order");
+        ScenarioExpect.True(log.Any(l => l.Contains("Authorizing payment")), "Should attempt payment authorization");
+        ScenarioExpect.True(log.Any(l => l.Contains("ERROR: Invalid payment amount")), "Payment authorization should fail");
+        ScenarioExpect.True(log.Any(l => l.Contains("Order processing failed")), "Should invoke OnError hook");
+        ScenarioExpect.False(log.Any(l => l.Contains("Inventory reserved")), "Should not reserve inventory");
+        ScenarioExpect.False(log.Any(l => l.Contains("Order confirmed")), "Should not confirm order");
     }
 
     [Scenario("Cancellation is supported in async workflow")]
@@ -46,7 +46,7 @@ public sealed partial class OrderProcessingDemoTests(ITestOutputHelper output) :
 
         // Either cancellation happened or workflow completed (race condition)
         var result = log.Any(l => l.Contains("cancelled")) || log.Any(l => l.Contains("completed"));
-        Assert.True(result, "Should handle cancellation or complete");
+        ScenarioExpect.True(result, "Should handle cancellation or complete");
     }
 
     [Scenario("Mixed sync and async steps work together")]
@@ -59,8 +59,8 @@ public sealed partial class OrderProcessingDemoTests(ITestOutputHelper output) :
                            log.Any(l => l.Contains("Notification sent"));
         var hasSyncSteps = log.Any(l => l.Contains("Order confirmed"));
 
-        Assert.True(hasAsyncSteps, "Should have async steps");
-        Assert.True(hasSyncSteps, "Should have sync steps");
+        ScenarioExpect.True(hasAsyncSteps, "Should have async steps");
+        ScenarioExpect.True(hasSyncSteps, "Should have sync steps");
     }
 
     [Scenario("Error handling includes compensating actions")]
@@ -69,9 +69,9 @@ public sealed partial class OrderProcessingDemoTests(ITestOutputHelper output) :
     {
         var log = await PatternKit.Examples.TemplateMethodGeneratorDemo.OrderProcessingDemo.RunWithInvalidAmountAsync();
 
-        Assert.True(log.Any(l => l.Contains("Order processing failed")), "OnError hook should be invoked");
+        ScenarioExpect.True(log.Any(l => l.Contains("Order processing failed")), "OnError hook should be invoked");
         // In this case, inventory wasn't reserved yet, so only payment rollback would be mentioned
         var hasCompensationMention = log.Any(l => l.Contains("Rolling back")) || !log.Any(l => l.Contains("Inventory reserved"));
-        Assert.True(hasCompensationMention, "Should mention rollback actions or not have reserved inventory");
+        ScenarioExpect.True(hasCompensationMention, "Should mention rollback actions or not have reserved inventory");
     }
 }

--- a/test/PatternKit.Examples.Tests/VisitorDemo/VisitorDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/VisitorDemo/VisitorDemoTests.cs
@@ -1,70 +1,78 @@
 using PatternKit.Examples.VisitorDemo;
+using TinyBDD;
 
 namespace PatternKit.Examples.Tests.VisitorDemoTests;
 
 public sealed class TenderRecordTests
 {
+    [Scenario("Cash Record Works")]
     [Fact]
     public void Cash_Record_Works()
     {
         var cash = new Cash(10.50m);
 
-        Assert.Equal(10.50m, cash.Value);
-        Assert.Equal(10.50m, cash.Amount);
+        ScenarioExpect.Equal(10.50m, cash.Value);
+        ScenarioExpect.Equal(10.50m, cash.Amount);
     }
 
+    [Scenario("Card Record Works")]
     [Fact]
     public void Card_Record_Works()
     {
         var card = new Card("VISA", "4242", 25.75m);
 
-        Assert.Equal("VISA", card.Brand);
-        Assert.Equal("4242", card.Last4);
-        Assert.Equal(25.75m, card.Value);
-        Assert.Equal(25.75m, card.Amount);
+        ScenarioExpect.Equal("VISA", card.Brand);
+        ScenarioExpect.Equal("4242", card.Last4);
+        ScenarioExpect.Equal(25.75m, card.Value);
+        ScenarioExpect.Equal(25.75m, card.Amount);
     }
 
+    [Scenario("GiftCard Record Works")]
     [Fact]
     public void GiftCard_Record_Works()
     {
         var gift = new GiftCard("GFT-123", 15.00m);
 
-        Assert.Equal("GFT-123", gift.Code);
-        Assert.Equal(15.00m, gift.Value);
-        Assert.Equal(15.00m, gift.Amount);
+        ScenarioExpect.Equal("GFT-123", gift.Code);
+        ScenarioExpect.Equal(15.00m, gift.Value);
+        ScenarioExpect.Equal(15.00m, gift.Amount);
     }
 
+    [Scenario("StoreCredit Record Works")]
     [Fact]
     public void StoreCredit_Record_Works()
     {
         var credit = new StoreCredit("CUST-456", 5.25m);
 
-        Assert.Equal("CUST-456", credit.CustomerId);
-        Assert.Equal(5.25m, credit.Value);
-        Assert.Equal(5.25m, credit.Amount);
+        ScenarioExpect.Equal("CUST-456", credit.CustomerId);
+        ScenarioExpect.Equal(5.25m, credit.Value);
+        ScenarioExpect.Equal(5.25m, credit.Amount);
     }
 
+    [Scenario("Unknown Record Works")]
     [Fact]
     public void Unknown_Record_Works()
     {
         var unknown = new Unknown("PromoVoucher", 2.00m);
 
-        Assert.Equal("PromoVoucher", unknown.Description);
-        Assert.Equal(2.00m, unknown.Value);
-        Assert.Equal(2.00m, unknown.Amount);
+        ScenarioExpect.Equal("PromoVoucher", unknown.Description);
+        ScenarioExpect.Equal(2.00m, unknown.Value);
+        ScenarioExpect.Equal(2.00m, unknown.Amount);
     }
 }
 
 public sealed class ReceiptRenderingTests
 {
+    [Scenario("CreateRenderer Returns NonNull")]
     [Fact]
     public void CreateRenderer_Returns_NonNull()
     {
         var renderer = ReceiptRendering.CreateRenderer();
 
-        Assert.NotNull(renderer);
+        ScenarioExpect.NotNull(renderer);
     }
 
+    [Scenario("Renderer Formats Cash")]
     [Fact]
     public void Renderer_Formats_Cash()
     {
@@ -73,10 +81,11 @@ public sealed class ReceiptRenderingTests
 
         var line = renderer.Dispatch(cash);
 
-        Assert.Contains("Cash", line);
-        Assert.Contains("10.00", line);
+        ScenarioExpect.Contains("Cash", line);
+        ScenarioExpect.Contains("10.00", line);
     }
 
+    [Scenario("Renderer Formats Card")]
     [Fact]
     public void Renderer_Formats_Card()
     {
@@ -85,11 +94,12 @@ public sealed class ReceiptRenderingTests
 
         var line = renderer.Dispatch(card);
 
-        Assert.Contains("VISA", line);
-        Assert.Contains("4242", line);
-        Assert.Contains("15.75", line);
+        ScenarioExpect.Contains("VISA", line);
+        ScenarioExpect.Contains("4242", line);
+        ScenarioExpect.Contains("15.75", line);
     }
 
+    [Scenario("Renderer Formats GiftCard")]
     [Fact]
     public void Renderer_Formats_GiftCard()
     {
@@ -98,11 +108,12 @@ public sealed class ReceiptRenderingTests
 
         var line = renderer.Dispatch(gift);
 
-        Assert.Contains("GiftCard", line);
-        Assert.Contains("GFT-001", line);
-        Assert.Contains("5.00", line);
+        ScenarioExpect.Contains("GiftCard", line);
+        ScenarioExpect.Contains("GFT-001", line);
+        ScenarioExpect.Contains("5.00", line);
     }
 
+    [Scenario("Renderer Formats StoreCredit")]
     [Fact]
     public void Renderer_Formats_StoreCredit()
     {
@@ -111,11 +122,12 @@ public sealed class ReceiptRenderingTests
 
         var line = renderer.Dispatch(credit);
 
-        Assert.Contains("StoreCredit", line);
-        Assert.Contains("C123", line);
-        Assert.Contains("3.25", line);
+        ScenarioExpect.Contains("StoreCredit", line);
+        ScenarioExpect.Contains("C123", line);
+        ScenarioExpect.Contains("3.25", line);
     }
 
+    [Scenario("Renderer Formats Unknown With Default")]
     [Fact]
     public void Renderer_Formats_Unknown_With_Default()
     {
@@ -124,13 +136,14 @@ public sealed class ReceiptRenderingTests
 
         var line = renderer.Dispatch(unknown);
 
-        Assert.Contains("Other", line);
-        Assert.Contains("2.00", line);
+        ScenarioExpect.Contains("Other", line);
+        ScenarioExpect.Contains("2.00", line);
     }
 }
 
 public sealed class CountersHandlerTests
 {
+    [Scenario("Cash Increments CashCount")]
     [Fact]
     public void Cash_Increments_CashCount()
     {
@@ -138,10 +151,11 @@ public sealed class CountersHandlerTests
 
         handler.Cash(new Cash(10.00m));
 
-        Assert.Equal(1, handler.CashCount);
-        Assert.Equal(10.00m, handler.Total);
+        ScenarioExpect.Equal(1, handler.CashCount);
+        ScenarioExpect.Equal(10.00m, handler.Total);
     }
 
+    [Scenario("Card Increments CardCount")]
     [Fact]
     public void Card_Increments_CardCount()
     {
@@ -149,10 +163,11 @@ public sealed class CountersHandlerTests
 
         handler.Card(new Card("MC", "1234", 20.00m));
 
-        Assert.Equal(1, handler.CardCount);
-        Assert.Equal(20.00m, handler.Total);
+        ScenarioExpect.Equal(1, handler.CardCount);
+        ScenarioExpect.Equal(20.00m, handler.Total);
     }
 
+    [Scenario("Gift Increments GiftCount")]
     [Fact]
     public void Gift_Increments_GiftCount()
     {
@@ -160,10 +175,11 @@ public sealed class CountersHandlerTests
 
         handler.Gift(new GiftCard("G-001", 5.00m));
 
-        Assert.Equal(1, handler.GiftCount);
-        Assert.Equal(5.00m, handler.Total);
+        ScenarioExpect.Equal(1, handler.GiftCount);
+        ScenarioExpect.Equal(5.00m, handler.Total);
     }
 
+    [Scenario("Credit Increments CreditCount")]
     [Fact]
     public void Credit_Increments_CreditCount()
     {
@@ -171,10 +187,11 @@ public sealed class CountersHandlerTests
 
         handler.Credit(new StoreCredit("C-001", 3.00m));
 
-        Assert.Equal(1, handler.CreditCount);
-        Assert.Equal(3.00m, handler.Total);
+        ScenarioExpect.Equal(1, handler.CreditCount);
+        ScenarioExpect.Equal(3.00m, handler.Total);
     }
 
+    [Scenario("Fallback Increments FallbackCount")]
     [Fact]
     public void Fallback_Increments_FallbackCount()
     {
@@ -183,10 +200,11 @@ public sealed class CountersHandlerTests
 
         handler.Fallback(unknown);
 
-        Assert.Equal(1, handler.FallbackCount);
-        Assert.Equal(1.50m, handler.Total);
+        ScenarioExpect.Equal(1, handler.FallbackCount);
+        ScenarioExpect.Equal(1.50m, handler.Total);
     }
 
+    [Scenario("Multiple Tenders Accumulate Correctly")]
     [Fact]
     public void Multiple_Tenders_Accumulate_Correctly()
     {
@@ -197,26 +215,28 @@ public sealed class CountersHandlerTests
         handler.Card(new Card("VISA", "1111", 20.00m));
         handler.Gift(new GiftCard("G1", 7.50m));
 
-        Assert.Equal(2, handler.CashCount);
-        Assert.Equal(1, handler.CardCount);
-        Assert.Equal(1, handler.GiftCount);
-        Assert.Equal(0, handler.CreditCount);
-        Assert.Equal(0, handler.FallbackCount);
-        Assert.Equal(42.50m, handler.Total);
+        ScenarioExpect.Equal(2, handler.CashCount);
+        ScenarioExpect.Equal(1, handler.CardCount);
+        ScenarioExpect.Equal(1, handler.GiftCount);
+        ScenarioExpect.Equal(0, handler.CreditCount);
+        ScenarioExpect.Equal(0, handler.FallbackCount);
+        ScenarioExpect.Equal(42.50m, handler.Total);
     }
 }
 
 public sealed class RoutingTests
 {
+    [Scenario("CreateRouter Returns NonNull")]
     [Fact]
     public void CreateRouter_Returns_NonNull()
     {
         var handler = new CountersHandler();
         var router = Routing.CreateRouter(handler);
 
-        Assert.NotNull(router);
+        ScenarioExpect.NotNull(router);
     }
 
+    [Scenario("Router Dispatches Cash")]
     [Fact]
     public void Router_Dispatches_Cash()
     {
@@ -225,9 +245,10 @@ public sealed class RoutingTests
 
         router.Dispatch(new Cash(10.00m));
 
-        Assert.Equal(1, handler.CashCount);
+        ScenarioExpect.Equal(1, handler.CashCount);
     }
 
+    [Scenario("Router Dispatches Card")]
     [Fact]
     public void Router_Dispatches_Card()
     {
@@ -236,9 +257,10 @@ public sealed class RoutingTests
 
         router.Dispatch(new Card("AMEX", "0000", 50.00m));
 
-        Assert.Equal(1, handler.CardCount);
+        ScenarioExpect.Equal(1, handler.CardCount);
     }
 
+    [Scenario("Router Dispatches GiftCard")]
     [Fact]
     public void Router_Dispatches_GiftCard()
     {
@@ -247,9 +269,10 @@ public sealed class RoutingTests
 
         router.Dispatch(new GiftCard("G2", 25.00m));
 
-        Assert.Equal(1, handler.GiftCount);
+        ScenarioExpect.Equal(1, handler.GiftCount);
     }
 
+    [Scenario("Router Dispatches StoreCredit")]
     [Fact]
     public void Router_Dispatches_StoreCredit()
     {
@@ -258,9 +281,10 @@ public sealed class RoutingTests
 
         router.Dispatch(new StoreCredit("C2", 15.00m));
 
-        Assert.Equal(1, handler.CreditCount);
+        ScenarioExpect.Equal(1, handler.CreditCount);
     }
 
+    [Scenario("Router Dispatches Unknown To Fallback")]
     [Fact]
     public void Router_Dispatches_Unknown_To_Fallback()
     {
@@ -269,9 +293,10 @@ public sealed class RoutingTests
 
         router.Dispatch(new Unknown("External", 5.00m));
 
-        Assert.Equal(1, handler.FallbackCount);
+        ScenarioExpect.Equal(1, handler.FallbackCount);
     }
 
+    [Scenario("Router Dispatches Multiple Tenders")]
     [Fact]
     public void Router_Dispatches_Multiple_Tenders()
     {
@@ -291,49 +316,52 @@ public sealed class RoutingTests
             router.Dispatch(t);
         }
 
-        Assert.Equal(1, handler.CashCount);
-        Assert.Equal(1, handler.CardCount);
-        Assert.Equal(1, handler.GiftCount);
-        Assert.Equal(1, handler.CreditCount);
-        Assert.Equal(1, handler.FallbackCount);
-        Assert.Equal(36.00m, handler.Total);
+        ScenarioExpect.Equal(1, handler.CashCount);
+        ScenarioExpect.Equal(1, handler.CardCount);
+        ScenarioExpect.Equal(1, handler.GiftCount);
+        ScenarioExpect.Equal(1, handler.CreditCount);
+        ScenarioExpect.Equal(1, handler.FallbackCount);
+        ScenarioExpect.Equal(36.00m, handler.Total);
     }
 }
 
 public sealed class DemoTests
 {
+    [Scenario("Run Returns Receipt And Counters")]
     [Fact]
     public void Run_Returns_Receipt_And_Counters()
     {
         var (receipt, counters) = Demo.Run();
 
-        Assert.NotNull(receipt);
-        Assert.NotNull(counters);
-        Assert.Equal(5, receipt.Length);
+        ScenarioExpect.NotNull(receipt);
+        ScenarioExpect.NotNull(counters);
+        ScenarioExpect.Equal(5, receipt.Length);
     }
 
+    [Scenario("Run Counters Match Expected")]
     [Fact]
     public void Run_Counters_Match_Expected()
     {
         var (_, counters) = Demo.Run();
 
-        Assert.Equal(1, counters.CashCount);
-        Assert.Equal(1, counters.CardCount);
-        Assert.Equal(1, counters.GiftCount);
-        Assert.Equal(1, counters.CreditCount);
-        Assert.Equal(1, counters.FallbackCount);
-        Assert.Equal(36.00m, counters.Total);
+        ScenarioExpect.Equal(1, counters.CashCount);
+        ScenarioExpect.Equal(1, counters.CardCount);
+        ScenarioExpect.Equal(1, counters.GiftCount);
+        ScenarioExpect.Equal(1, counters.CreditCount);
+        ScenarioExpect.Equal(1, counters.FallbackCount);
+        ScenarioExpect.Equal(36.00m, counters.Total);
     }
 
+    [Scenario("Run Receipt Contains All Tender Types")]
     [Fact]
     public void Run_Receipt_Contains_All_Tender_Types()
     {
         var (receipt, _) = Demo.Run();
 
-        Assert.Contains(receipt, r => r.Contains("Cash"));
-        Assert.Contains(receipt, r => r.Contains("VISA"));
-        Assert.Contains(receipt, r => r.Contains("GiftCard"));
-        Assert.Contains(receipt, r => r.Contains("StoreCredit"));
-        Assert.Contains(receipt, r => r.Contains("Other"));
+        ScenarioExpect.Contains(receipt, r => r.Contains("Cash"));
+        ScenarioExpect.Contains(receipt, r => r.Contains("VISA"));
+        ScenarioExpect.Contains(receipt, r => r.Contains("GiftCard"));
+        ScenarioExpect.Contains(receipt, r => r.Contains("StoreCredit"));
+        ScenarioExpect.Contains(receipt, r => r.Contains("Other"));
     }
 }

--- a/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
@@ -17,6 +17,7 @@ using PatternKit.Generators.State;
 using PatternKit.Generators.Template;
 using PatternKit.Generators.Visitors;
 using PatternKit.Generators;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -100,6 +101,7 @@ public sealed class AbstractionsAttributeCoverageTests
         { typeof(GenerateVisitorAttribute), AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, false, false }
     };
 
+    [Scenario("AttributeUsage Is Declared As Expected")]
     [Theory]
     [MemberData(nameof(AttributeUsageCases))]
     public void AttributeUsage_Is_Declared_As_Expected(
@@ -108,14 +110,15 @@ public sealed class AbstractionsAttributeCoverageTests
         bool allowMultiple,
         bool inherited)
     {
-        var usage = Assert.Single(attributeType.GetCustomAttributes(typeof(AttributeUsageAttribute), false)
+        var usage = ScenarioExpect.Single(attributeType.GetCustomAttributes(typeof(AttributeUsageAttribute), false)
             .Cast<AttributeUsageAttribute>());
 
-        Assert.Equal(validOn, usage.ValidOn);
-        Assert.Equal(allowMultiple, usage.AllowMultiple);
-        Assert.Equal(inherited, usage.Inherited);
+        ScenarioExpect.Equal(validOn, usage.ValidOn);
+        ScenarioExpect.Equal(allowMultiple, usage.AllowMultiple);
+        ScenarioExpect.Equal(inherited, usage.Inherited);
     }
 
+    [Scenario("Adapter Attributes Expose Defaults And Configuration")]
     [Fact]
     public void Adapter_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -130,16 +133,17 @@ public sealed class AbstractionsAttributeCoverageTests
         };
         var map = new AdapterMapAttribute { TargetMember = nameof(IDisposable.Dispose) };
 
-        Assert.Equal(typeof(IDisposable), generator.Target);
-        Assert.Equal(typeof(string), generator.Adaptee);
-        Assert.Equal("StringDisposableAdapter", generator.AdapterTypeName);
-        Assert.Equal(AdapterMissingMapPolicy.ThrowingStub, generator.MissingMap);
-        Assert.False(generator.Sealed);
-        Assert.Equal("Demo.Adapters", generator.Namespace);
-        Assert.Equal(nameof(IDisposable.Dispose), map.TargetMember);
+        ScenarioExpect.Equal(typeof(IDisposable), generator.Target);
+        ScenarioExpect.Equal(typeof(string), generator.Adaptee);
+        ScenarioExpect.Equal("StringDisposableAdapter", generator.AdapterTypeName);
+        ScenarioExpect.Equal(AdapterMissingMapPolicy.ThrowingStub, generator.MissingMap);
+        ScenarioExpect.False(generator.Sealed);
+        ScenarioExpect.Equal("Demo.Adapters", generator.Namespace);
+        ScenarioExpect.Equal(nameof(IDisposable.Dispose), map.TargetMember);
         AssertEnumValues(AdapterMissingMapPolicy.Error, AdapterMissingMapPolicy.ThrowingStub, AdapterMissingMapPolicy.Ignore);
     }
 
+    [Scenario("Bridge Attributes Expose Defaults And Configuration")]
     [Fact]
     public void Bridge_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -151,14 +155,15 @@ public sealed class AbstractionsAttributeCoverageTests
             DefaultTypeName = "FileBackend"
         };
 
-        Assert.Equal("StorageBackend", implementor.ImplementorTypeName);
-        Assert.Equal(typeof(IDisposable), abstraction.ImplementorType);
-        Assert.Equal("Backend", abstraction.ImplementorPropertyName);
-        Assert.True(abstraction.GenerateDefault);
-        Assert.Equal("FileBackend", abstraction.DefaultTypeName);
-        Assert.IsType<BridgeIgnoreAttribute>(new BridgeIgnoreAttribute());
+        ScenarioExpect.Equal("StorageBackend", implementor.ImplementorTypeName);
+        ScenarioExpect.Equal(typeof(IDisposable), abstraction.ImplementorType);
+        ScenarioExpect.Equal("Backend", abstraction.ImplementorPropertyName);
+        ScenarioExpect.True(abstraction.GenerateDefault);
+        ScenarioExpect.Equal("FileBackend", abstraction.DefaultTypeName);
+        ScenarioExpect.IsType<BridgeIgnoreAttribute>(new BridgeIgnoreAttribute());
     }
 
+    [Scenario("Chain And Command Attributes Expose Defaults And Configuration")]
     [Fact]
     public void Chain_And_Command_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -178,24 +183,25 @@ public sealed class AbstractionsAttributeCoverageTests
         };
         var commandHandler = new CommandHandlerAttribute { CommandType = typeof(string) };
 
-        Assert.Equal(ChainModel.Pipeline, chain.Model);
-        Assert.Equal("Run", chain.HandleMethodName);
-        Assert.Equal("TryRun", chain.TryHandleMethodName);
-        Assert.Equal(7, handler.Order);
-        Assert.Equal("Audit", handler.Name);
-        Assert.Equal("SubmitOrder", command.CommandTypeName);
-        Assert.False(command.GenerateAsync);
-        Assert.True(command.ForceAsync);
-        Assert.True(command.GenerateUndo);
-        Assert.Equal(typeof(string), commandHandler.CommandType);
-        Assert.IsType<ChainDefaultAttribute>(new ChainDefaultAttribute());
-        Assert.IsType<ChainTerminalAttribute>(new ChainTerminalAttribute());
-        Assert.IsType<CommandHostAttribute>(new CommandHostAttribute());
-        Assert.IsType<CommandCaseAttribute>(new CommandCaseAttribute());
-        Assert.IsType<CommandUndoAttribute>(new CommandUndoAttribute());
+        ScenarioExpect.Equal(ChainModel.Pipeline, chain.Model);
+        ScenarioExpect.Equal("Run", chain.HandleMethodName);
+        ScenarioExpect.Equal("TryRun", chain.TryHandleMethodName);
+        ScenarioExpect.Equal(7, handler.Order);
+        ScenarioExpect.Equal("Audit", handler.Name);
+        ScenarioExpect.Equal("SubmitOrder", command.CommandTypeName);
+        ScenarioExpect.False(command.GenerateAsync);
+        ScenarioExpect.True(command.ForceAsync);
+        ScenarioExpect.True(command.GenerateUndo);
+        ScenarioExpect.Equal(typeof(string), commandHandler.CommandType);
+        ScenarioExpect.IsType<ChainDefaultAttribute>(new ChainDefaultAttribute());
+        ScenarioExpect.IsType<ChainTerminalAttribute>(new ChainTerminalAttribute());
+        ScenarioExpect.IsType<CommandHostAttribute>(new CommandHostAttribute());
+        ScenarioExpect.IsType<CommandCaseAttribute>(new CommandCaseAttribute());
+        ScenarioExpect.IsType<CommandUndoAttribute>(new CommandUndoAttribute());
         AssertEnumValues(ChainModel.Responsibility, ChainModel.Pipeline);
     }
 
+    [Scenario("Composite Composer And Decorator Attributes Expose Defaults And Configuration")]
     [Fact]
     public void Composite_Composer_And_Decorator_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -225,32 +231,33 @@ public sealed class AbstractionsAttributeCoverageTests
             ForceAsync = true
         };
 
-        Assert.Equal("NodeBase", composite.ComponentBaseName);
-        Assert.Equal("BranchBase", composite.CompositeBaseName);
-        Assert.Equal("Items", composite.ChildrenPropertyName);
-        Assert.Equal(CompositeChildrenStorage.ImmutableArray, composite.Storage);
-        Assert.True(composite.GenerateTraversalHelpers);
-        Assert.Equal("Run", composer.InvokeMethodName);
-        Assert.Equal("RunAsync", composer.InvokeAsyncMethodName);
-        Assert.True(composer.GenerateAsync);
-        Assert.True(composer.ForceAsync);
-        Assert.Equal(ComposerWrapOrder.InnerFirst, composer.WrapOrder);
-        Assert.Equal(12, step.Order);
-        Assert.Equal("Validate", step.Name);
-        Assert.Equal("StorageDecorator", decorator.BaseTypeName);
-        Assert.Equal("StorageDecorators", decorator.HelpersTypeName);
-        Assert.Equal(DecoratorCompositionMode.PipelineNextStyle, decorator.Composition);
-        Assert.True(decorator.GenerateAsync);
-        Assert.True(decorator.ForceAsync);
-        Assert.IsType<CompositeIgnoreAttribute>(new CompositeIgnoreAttribute());
-        Assert.IsType<ComposeTerminalAttribute>(new ComposeTerminalAttribute());
-        Assert.IsType<ComposeIgnoreAttribute>(new ComposeIgnoreAttribute());
-        Assert.IsType<DecoratorIgnoreAttribute>(new DecoratorIgnoreAttribute());
+        ScenarioExpect.Equal("NodeBase", composite.ComponentBaseName);
+        ScenarioExpect.Equal("BranchBase", composite.CompositeBaseName);
+        ScenarioExpect.Equal("Items", composite.ChildrenPropertyName);
+        ScenarioExpect.Equal(CompositeChildrenStorage.ImmutableArray, composite.Storage);
+        ScenarioExpect.True(composite.GenerateTraversalHelpers);
+        ScenarioExpect.Equal("Run", composer.InvokeMethodName);
+        ScenarioExpect.Equal("RunAsync", composer.InvokeAsyncMethodName);
+        ScenarioExpect.True(composer.GenerateAsync);
+        ScenarioExpect.True(composer.ForceAsync);
+        ScenarioExpect.Equal(ComposerWrapOrder.InnerFirst, composer.WrapOrder);
+        ScenarioExpect.Equal(12, step.Order);
+        ScenarioExpect.Equal("Validate", step.Name);
+        ScenarioExpect.Equal("StorageDecorator", decorator.BaseTypeName);
+        ScenarioExpect.Equal("StorageDecorators", decorator.HelpersTypeName);
+        ScenarioExpect.Equal(DecoratorCompositionMode.PipelineNextStyle, decorator.Composition);
+        ScenarioExpect.True(decorator.GenerateAsync);
+        ScenarioExpect.True(decorator.ForceAsync);
+        ScenarioExpect.IsType<CompositeIgnoreAttribute>(new CompositeIgnoreAttribute());
+        ScenarioExpect.IsType<ComposeTerminalAttribute>(new ComposeTerminalAttribute());
+        ScenarioExpect.IsType<ComposeIgnoreAttribute>(new ComposeIgnoreAttribute());
+        ScenarioExpect.IsType<DecoratorIgnoreAttribute>(new DecoratorIgnoreAttribute());
         AssertEnumValues(CompositeChildrenStorage.List, CompositeChildrenStorage.ImmutableArray);
         AssertEnumValues(ComposerWrapOrder.OuterFirst, ComposerWrapOrder.InnerFirst);
         AssertEnumValues(DecoratorCompositionMode.None, DecoratorCompositionMode.HelpersOnly, DecoratorCompositionMode.PipelineNextStyle);
     }
 
+    [Scenario("Facade Attributes Expose Defaults And Configuration")]
     [Fact]
     public void Facade_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -269,21 +276,22 @@ public sealed class AbstractionsAttributeCoverageTests
         var expose = new FacadeExposeAttribute { MethodName = "Checkout" };
         var map = new FacadeMapAttribute { MemberName = "GetInvoice" };
 
-        Assert.Equal("BillingFacade", facade.FacadeTypeName);
-        Assert.False(facade.GenerateAsync);
-        Assert.True(facade.ForceAsync);
-        Assert.Equal(FacadeMissingMapPolicy.Stub, facade.MissingMap);
-        Assert.Equal("Billing.Client", facade.TargetTypeName);
-        Assert.Equal(["CreateInvoice"], facade.Include);
-        Assert.Equal(["DeleteInvoice"], facade.Exclude);
-        Assert.Equal("Billing", facade.MemberPrefix);
-        Assert.Equal("_billing", facade.FieldName);
-        Assert.Equal("Checkout", expose.MethodName);
-        Assert.Equal("GetInvoice", map.MemberName);
-        Assert.IsType<FacadeIgnoreAttribute>(new FacadeIgnoreAttribute());
+        ScenarioExpect.Equal("BillingFacade", facade.FacadeTypeName);
+        ScenarioExpect.False(facade.GenerateAsync);
+        ScenarioExpect.True(facade.ForceAsync);
+        ScenarioExpect.Equal(FacadeMissingMapPolicy.Stub, facade.MissingMap);
+        ScenarioExpect.Equal("Billing.Client", facade.TargetTypeName);
+        ScenarioExpect.Equal(["CreateInvoice"], facade.Include);
+        ScenarioExpect.Equal(["DeleteInvoice"], facade.Exclude);
+        ScenarioExpect.Equal("Billing", facade.MemberPrefix);
+        ScenarioExpect.Equal("_billing", facade.FieldName);
+        ScenarioExpect.Equal("Checkout", expose.MethodName);
+        ScenarioExpect.Equal("GetInvoice", map.MemberName);
+        ScenarioExpect.IsType<FacadeIgnoreAttribute>(new FacadeIgnoreAttribute());
         AssertEnumValues(FacadeMissingMapPolicy.Error, FacadeMissingMapPolicy.Stub, FacadeMissingMapPolicy.Ignore);
     }
 
+    [Scenario("Flyweight Iterator And Messaging Attributes Expose Defaults And Configuration")]
     [Fact]
     public void Flyweight_Iterator_And_Messaging_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -326,56 +334,57 @@ public sealed class AbstractionsAttributeCoverageTests
         };
         var route = new ContentRouteAttribute("priority", 4, "IsPriority");
 
-        Assert.Equal(typeof(string), flyweight.KeyType);
-        Assert.Equal("SymbolCache", flyweight.CacheTypeName);
-        Assert.Equal(128, flyweight.Capacity);
-        Assert.Equal(FlyweightEviction.Lru, flyweight.Eviction);
-        Assert.Equal(FlyweightThreadingPolicy.Concurrent, flyweight.Threading);
-        Assert.False(flyweight.GenerateTryGet);
-        Assert.False(iterator.GenerateEnumerator);
-        Assert.False(iterator.GenerateTryMoveNext);
-        Assert.Equal("Demo.Dispatching", dispatcher.Namespace);
-        Assert.Equal("DemoDispatcher", dispatcher.Name);
-        Assert.True(dispatcher.IncludeObjectOverloads);
-        Assert.False(dispatcher.IncludeStreaming);
-        Assert.Equal(GeneratedVisibility.Internal, dispatcher.Visibility);
-        Assert.Equal(typeof(string), routingSlip.PayloadType);
-        Assert.Equal("Build", routingSlip.FactoryName);
-        Assert.Equal("BuildAsync", routingSlip.AsyncFactoryName);
-        Assert.Equal("validate", routingStep.Name);
-        Assert.Equal(10, routingStep.Order);
-        Assert.Equal(typeof(int), saga.StateType);
-        Assert.Equal("BuildSaga", saga.FactoryName);
-        Assert.Equal("BuildSagaAsync", saga.AsyncFactoryName);
-        Assert.Equal(typeof(decimal), sagaStep.MessageType);
-        Assert.Equal(11, sagaStep.Order);
-        Assert.Equal(typeof(string), router.PayloadType);
-        Assert.Equal(typeof(int), router.ResultType);
-        Assert.Equal("BuildRouter", router.FactoryName);
-        Assert.Equal("priority", route.Name);
-        Assert.Equal(4, route.Order);
-        Assert.Equal("IsPriority", route.PredicateMethodName);
-        Assert.Throws<ArgumentNullException>(() => new GenerateRoutingSlipAttribute(null!));
-        Assert.Throws<ArgumentException>(() => new RoutingSlipStepAttribute("", 1));
-        Assert.Throws<ArgumentNullException>(() => new GenerateSagaAttribute(null!));
-        Assert.Throws<ArgumentNullException>(() => new SagaStepAttribute(null!, 1));
-        Assert.Throws<ArgumentNullException>(() => new GenerateContentRouterAttribute(null!, typeof(int)));
-        Assert.Throws<ArgumentNullException>(() => new GenerateContentRouterAttribute(typeof(string), null!));
-        Assert.Throws<ArgumentException>(() => new ContentRouteAttribute("", 1, "Predicate"));
-        Assert.Throws<ArgumentException>(() => new ContentRouteAttribute("name", 1, ""));
-        Assert.IsType<SagaCompleteWhenAttribute>(new SagaCompleteWhenAttribute());
-        Assert.IsType<ContentRouteDefaultAttribute>(new ContentRouteDefaultAttribute());
-        Assert.IsType<FlyweightFactoryAttribute>(new FlyweightFactoryAttribute());
-        Assert.IsType<IteratorStepAttribute>(new IteratorStepAttribute());
-        Assert.IsType<TraversalIteratorAttribute>(new TraversalIteratorAttribute());
-        Assert.IsType<DepthFirstAttribute>(new DepthFirstAttribute());
-        Assert.IsType<BreadthFirstAttribute>(new BreadthFirstAttribute());
-        Assert.IsType<TraversalChildrenAttribute>(new TraversalChildrenAttribute());
+        ScenarioExpect.Equal(typeof(string), flyweight.KeyType);
+        ScenarioExpect.Equal("SymbolCache", flyweight.CacheTypeName);
+        ScenarioExpect.Equal(128, flyweight.Capacity);
+        ScenarioExpect.Equal(FlyweightEviction.Lru, flyweight.Eviction);
+        ScenarioExpect.Equal(FlyweightThreadingPolicy.Concurrent, flyweight.Threading);
+        ScenarioExpect.False(flyweight.GenerateTryGet);
+        ScenarioExpect.False(iterator.GenerateEnumerator);
+        ScenarioExpect.False(iterator.GenerateTryMoveNext);
+        ScenarioExpect.Equal("Demo.Dispatching", dispatcher.Namespace);
+        ScenarioExpect.Equal("DemoDispatcher", dispatcher.Name);
+        ScenarioExpect.True(dispatcher.IncludeObjectOverloads);
+        ScenarioExpect.False(dispatcher.IncludeStreaming);
+        ScenarioExpect.Equal(GeneratedVisibility.Internal, dispatcher.Visibility);
+        ScenarioExpect.Equal(typeof(string), routingSlip.PayloadType);
+        ScenarioExpect.Equal("Build", routingSlip.FactoryName);
+        ScenarioExpect.Equal("BuildAsync", routingSlip.AsyncFactoryName);
+        ScenarioExpect.Equal("validate", routingStep.Name);
+        ScenarioExpect.Equal(10, routingStep.Order);
+        ScenarioExpect.Equal(typeof(int), saga.StateType);
+        ScenarioExpect.Equal("BuildSaga", saga.FactoryName);
+        ScenarioExpect.Equal("BuildSagaAsync", saga.AsyncFactoryName);
+        ScenarioExpect.Equal(typeof(decimal), sagaStep.MessageType);
+        ScenarioExpect.Equal(11, sagaStep.Order);
+        ScenarioExpect.Equal(typeof(string), router.PayloadType);
+        ScenarioExpect.Equal(typeof(int), router.ResultType);
+        ScenarioExpect.Equal("BuildRouter", router.FactoryName);
+        ScenarioExpect.Equal("priority", route.Name);
+        ScenarioExpect.Equal(4, route.Order);
+        ScenarioExpect.Equal("IsPriority", route.PredicateMethodName);
+        ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateRoutingSlipAttribute(null!));
+        ScenarioExpect.Throws<ArgumentException>(() => new RoutingSlipStepAttribute("", 1));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateSagaAttribute(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new SagaStepAttribute(null!, 1));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateContentRouterAttribute(null!, typeof(int)));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateContentRouterAttribute(typeof(string), null!));
+        ScenarioExpect.Throws<ArgumentException>(() => new ContentRouteAttribute("", 1, "Predicate"));
+        ScenarioExpect.Throws<ArgumentException>(() => new ContentRouteAttribute("name", 1, ""));
+        ScenarioExpect.IsType<SagaCompleteWhenAttribute>(new SagaCompleteWhenAttribute());
+        ScenarioExpect.IsType<ContentRouteDefaultAttribute>(new ContentRouteDefaultAttribute());
+        ScenarioExpect.IsType<FlyweightFactoryAttribute>(new FlyweightFactoryAttribute());
+        ScenarioExpect.IsType<IteratorStepAttribute>(new IteratorStepAttribute());
+        ScenarioExpect.IsType<TraversalIteratorAttribute>(new TraversalIteratorAttribute());
+        ScenarioExpect.IsType<DepthFirstAttribute>(new DepthFirstAttribute());
+        ScenarioExpect.IsType<BreadthFirstAttribute>(new BreadthFirstAttribute());
+        ScenarioExpect.IsType<TraversalChildrenAttribute>(new TraversalChildrenAttribute());
         AssertEnumValues(FlyweightEviction.None, FlyweightEviction.Lru);
         AssertEnumValues(FlyweightThreadingPolicy.SingleThreadedFast, FlyweightThreadingPolicy.Locking, FlyweightThreadingPolicy.Concurrent);
         AssertEnumValues(GeneratedVisibility.Public, GeneratedVisibility.Internal);
     }
 
+    [Scenario("Memento Prototype Observer Proxy And Singleton Attributes Expose Defaults And Configuration")]
     [Fact]
     public void Memento_Prototype_Observer_Proxy_And_Singleton_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -417,37 +426,37 @@ public sealed class AbstractionsAttributeCoverageTests
             InstancePropertyName = "Current"
         };
 
-        Assert.True(memento.GenerateCaretaker);
-        Assert.Equal(10, memento.Capacity);
-        Assert.Equal(MementoInclusionMode.ExplicitOnly, memento.InclusionMode);
-        Assert.False(memento.SkipDuplicates);
-        Assert.Equal(MementoCaptureStrategy.DeepCopy, mementoStrategy.Strategy);
-        Assert.Equal(PrototypeMode.DeepWhenPossible, prototype.Mode);
-        Assert.Equal("Copy", prototype.CloneMethodName);
-        Assert.True(prototype.IncludeExplicit);
-        Assert.Equal(PrototypeCloneStrategy.Clone, prototypeStrategy.Strategy);
-        Assert.Equal(typeof(string), observer.PayloadType);
-        Assert.Equal(ObserverThreadingPolicy.Concurrent, observer.Threading);
-        Assert.Equal(ObserverExceptionPolicy.Aggregate, observer.Exceptions);
-        Assert.Equal(ObserverOrderPolicy.Undefined, observer.Order);
-        Assert.False(observer.GenerateAsync);
-        Assert.True(observer.ForceAsync);
-        Assert.Equal("BillingProxy", proxy.ProxyTypeName);
-        Assert.Equal(ProxyInterceptorMode.Pipeline, proxy.InterceptorMode);
-        Assert.True(proxy.GenerateAsync);
-        Assert.True(proxy.ForceAsync);
-        Assert.Equal(ProxyExceptionPolicy.Swallow, proxy.Exceptions);
-        Assert.Equal(SingletonMode.Lazy, singleton.Mode);
-        Assert.Equal(SingletonThreading.SingleThreadedFast, singleton.Threading);
-        Assert.Equal("Current", singleton.InstancePropertyName);
-        Assert.IsType<MementoIgnoreAttribute>(new MementoIgnoreAttribute());
-        Assert.IsType<MementoIncludeAttribute>(new MementoIncludeAttribute());
-        Assert.IsType<ObserverHubAttribute>(new ObserverHubAttribute());
-        Assert.IsType<ObservedEventAttribute>(new ObservedEventAttribute());
-        Assert.IsType<PrototypeIgnoreAttribute>(new PrototypeIgnoreAttribute());
-        Assert.IsType<PrototypeIncludeAttribute>(new PrototypeIncludeAttribute());
-        Assert.IsType<ProxyIgnoreAttribute>(new ProxyIgnoreAttribute());
-        Assert.IsType<SingletonFactoryAttribute>(new SingletonFactoryAttribute());
+        ScenarioExpect.True(memento.GenerateCaretaker);
+        ScenarioExpect.Equal(10, memento.Capacity);
+        ScenarioExpect.Equal(MementoInclusionMode.ExplicitOnly, memento.InclusionMode);
+        ScenarioExpect.False(memento.SkipDuplicates);
+        ScenarioExpect.Equal(MementoCaptureStrategy.DeepCopy, mementoStrategy.Strategy);
+        ScenarioExpect.Equal(PrototypeMode.DeepWhenPossible, prototype.Mode);
+        ScenarioExpect.Equal("Copy", prototype.CloneMethodName);
+        ScenarioExpect.True(prototype.IncludeExplicit);
+        ScenarioExpect.Equal(PrototypeCloneStrategy.Clone, prototypeStrategy.Strategy);
+        ScenarioExpect.Equal(typeof(string), observer.PayloadType);
+        ScenarioExpect.Equal(ObserverThreadingPolicy.Concurrent, observer.Threading);
+        ScenarioExpect.Equal(ObserverExceptionPolicy.Aggregate, observer.Exceptions);
+        ScenarioExpect.Equal(ObserverOrderPolicy.Undefined, observer.Order);
+        ScenarioExpect.False(observer.GenerateAsync);
+        ScenarioExpect.True(observer.ForceAsync);
+        ScenarioExpect.Equal("BillingProxy", proxy.ProxyTypeName);
+        ScenarioExpect.Equal(ProxyInterceptorMode.Pipeline, proxy.InterceptorMode);
+        ScenarioExpect.True(proxy.GenerateAsync);
+        ScenarioExpect.True(proxy.ForceAsync);
+        ScenarioExpect.Equal(ProxyExceptionPolicy.Swallow, proxy.Exceptions);
+        ScenarioExpect.Equal(SingletonMode.Lazy, singleton.Mode);
+        ScenarioExpect.Equal(SingletonThreading.SingleThreadedFast, singleton.Threading);
+        ScenarioExpect.Equal("Current", singleton.InstancePropertyName);
+        ScenarioExpect.IsType<MementoIgnoreAttribute>(new MementoIgnoreAttribute());
+        ScenarioExpect.IsType<MementoIncludeAttribute>(new MementoIncludeAttribute());
+        ScenarioExpect.IsType<ObserverHubAttribute>(new ObserverHubAttribute());
+        ScenarioExpect.IsType<ObservedEventAttribute>(new ObservedEventAttribute());
+        ScenarioExpect.IsType<PrototypeIgnoreAttribute>(new PrototypeIgnoreAttribute());
+        ScenarioExpect.IsType<PrototypeIncludeAttribute>(new PrototypeIncludeAttribute());
+        ScenarioExpect.IsType<ProxyIgnoreAttribute>(new ProxyIgnoreAttribute());
+        ScenarioExpect.IsType<SingletonFactoryAttribute>(new SingletonFactoryAttribute());
         AssertEnumValues(MementoInclusionMode.IncludeAll, MementoInclusionMode.ExplicitOnly);
         AssertEnumValues(MementoCaptureStrategy.ByReference, MementoCaptureStrategy.Clone, MementoCaptureStrategy.DeepCopy, MementoCaptureStrategy.Custom);
         AssertEnumValues(PrototypeMode.ShallowWithWarnings, PrototypeMode.Shallow, PrototypeMode.DeepWhenPossible);
@@ -461,6 +470,7 @@ public sealed class AbstractionsAttributeCoverageTests
         AssertEnumValues(SingletonThreading.ThreadSafe, SingletonThreading.SingleThreadedFast);
     }
 
+    [Scenario("State And Template Attributes Expose Defaults And Configuration")]
     [Fact]
     public void State_And_Template_Attributes_Expose_Defaults_And_Configuration()
     {
@@ -505,38 +515,39 @@ public sealed class AbstractionsAttributeCoverageTests
             StepOrder = 3
         };
 
-        Assert.Equal(typeof(TestState), stateMachine.StateType);
-        Assert.Equal(typeof(TestTrigger), stateMachine.TriggerType);
-        Assert.Equal("Apply", stateMachine.FireMethodName);
-        Assert.Equal("ApplyAsync", stateMachine.FireAsyncMethodName);
-        Assert.Equal("CanApply", stateMachine.CanFireMethodName);
-        Assert.True(stateMachine.GenerateAsync);
-        Assert.True(stateMachine.ForceAsync);
-        Assert.Equal(StateMachineInvalidTriggerPolicy.ReturnFalse, stateMachine.InvalidTrigger);
-        Assert.Equal(StateMachineGuardFailurePolicy.Ignore, stateMachine.GuardFailure);
-        Assert.Equal(TestState.Draft, transition.From);
-        Assert.Equal(TestTrigger.Publish, transition.Trigger);
-        Assert.Equal(TestState.Published, transition.To);
-        Assert.Equal(TestState.Draft, guard.From);
-        Assert.Equal(TestTrigger.Publish, guard.Trigger);
-        Assert.Equal(TestState.Published, entry.State);
-        Assert.Equal(TestState.Draft, exit.State);
-        Assert.Equal("Run", template.ExecuteMethodName);
-        Assert.Equal("RunAsync", template.ExecuteAsyncMethodName);
-        Assert.True(template.GenerateAsync);
-        Assert.True(template.ForceAsync);
-        Assert.Equal(TemplateErrorPolicy.HandleAndContinue, template.ErrorPolicy);
-        Assert.Equal(3, step.Order);
-        Assert.Equal("Persist", step.Name);
-        Assert.True(step.Optional);
-        Assert.Equal(HookPoint.OnError, hook.HookPoint);
-        Assert.Equal(3, hook.StepOrder);
+        ScenarioExpect.Equal(typeof(TestState), stateMachine.StateType);
+        ScenarioExpect.Equal(typeof(TestTrigger), stateMachine.TriggerType);
+        ScenarioExpect.Equal("Apply", stateMachine.FireMethodName);
+        ScenarioExpect.Equal("ApplyAsync", stateMachine.FireAsyncMethodName);
+        ScenarioExpect.Equal("CanApply", stateMachine.CanFireMethodName);
+        ScenarioExpect.True(stateMachine.GenerateAsync);
+        ScenarioExpect.True(stateMachine.ForceAsync);
+        ScenarioExpect.Equal(StateMachineInvalidTriggerPolicy.ReturnFalse, stateMachine.InvalidTrigger);
+        ScenarioExpect.Equal(StateMachineGuardFailurePolicy.Ignore, stateMachine.GuardFailure);
+        ScenarioExpect.Equal(TestState.Draft, transition.From);
+        ScenarioExpect.Equal(TestTrigger.Publish, transition.Trigger);
+        ScenarioExpect.Equal(TestState.Published, transition.To);
+        ScenarioExpect.Equal(TestState.Draft, guard.From);
+        ScenarioExpect.Equal(TestTrigger.Publish, guard.Trigger);
+        ScenarioExpect.Equal(TestState.Published, entry.State);
+        ScenarioExpect.Equal(TestState.Draft, exit.State);
+        ScenarioExpect.Equal("Run", template.ExecuteMethodName);
+        ScenarioExpect.Equal("RunAsync", template.ExecuteAsyncMethodName);
+        ScenarioExpect.True(template.GenerateAsync);
+        ScenarioExpect.True(template.ForceAsync);
+        ScenarioExpect.Equal(TemplateErrorPolicy.HandleAndContinue, template.ErrorPolicy);
+        ScenarioExpect.Equal(3, step.Order);
+        ScenarioExpect.Equal("Persist", step.Name);
+        ScenarioExpect.True(step.Optional);
+        ScenarioExpect.Equal(HookPoint.OnError, hook.HookPoint);
+        ScenarioExpect.Equal(3, hook.StepOrder);
         AssertEnumValues(StateMachineInvalidTriggerPolicy.Throw, StateMachineInvalidTriggerPolicy.Ignore, StateMachineInvalidTriggerPolicy.ReturnFalse);
         AssertEnumValues(StateMachineGuardFailurePolicy.Throw, StateMachineGuardFailurePolicy.Ignore, StateMachineGuardFailurePolicy.ReturnFalse);
         AssertEnumValues(HookPoint.BeforeAll, HookPoint.AfterAll, HookPoint.OnError);
         AssertEnumValues(TemplateErrorPolicy.Rethrow, TemplateErrorPolicy.HandleAndContinue);
     }
 
+    [Scenario("Visitor Attribute Exposes Defaults And Configuration")]
     [Fact]
     public void Visitor_Attribute_Exposes_Defaults_And_Configuration()
     {
@@ -549,14 +560,14 @@ public sealed class AbstractionsAttributeCoverageTests
             AutoDiscoverDerivedTypes = false
         };
 
-        Assert.Null(defaults.VisitorInterfaceName);
-        Assert.True(defaults.GenerateAsync);
-        Assert.True(defaults.GenerateActions);
-        Assert.True(defaults.AutoDiscoverDerivedTypes);
-        Assert.Equal("IWorkflowNodeVisitor", configured.VisitorInterfaceName);
-        Assert.False(configured.GenerateAsync);
-        Assert.False(configured.GenerateActions);
-        Assert.False(configured.AutoDiscoverDerivedTypes);
+        ScenarioExpect.Null(defaults.VisitorInterfaceName);
+        ScenarioExpect.True(defaults.GenerateAsync);
+        ScenarioExpect.True(defaults.GenerateActions);
+        ScenarioExpect.True(defaults.AutoDiscoverDerivedTypes);
+        ScenarioExpect.Equal("IWorkflowNodeVisitor", configured.VisitorInterfaceName);
+        ScenarioExpect.False(configured.GenerateAsync);
+        ScenarioExpect.False(configured.GenerateActions);
+        ScenarioExpect.False(configured.AutoDiscoverDerivedTypes);
     }
 
     private static void AssertEnumValues<TEnum>(params TEnum[] values)
@@ -564,7 +575,7 @@ public sealed class AbstractionsAttributeCoverageTests
     {
         foreach (var value in values)
         {
-            Assert.True(Enum.IsDefined(value), $"{typeof(TEnum).Name}.{value} should be defined.");
+            ScenarioExpect.True(Enum.IsDefined(value), $"{typeof(TEnum).Name}.{value} should be defined.");
         }
     }
 }

--- a/test/PatternKit.Generators.Tests/AbstractionsTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsTests.cs
@@ -1,3 +1,5 @@
+using TinyBDD;
+
 namespace PatternKit.Generators.Tests;
 
 /// <summary>
@@ -8,39 +10,43 @@ public class AbstractionsTests
 {
     #region GenerateStrategyAttribute Tests
 
+    [Scenario("GenerateStrategyAttribute Action Constructor Sets Properties")]
     [Fact]
     public void GenerateStrategyAttribute_Action_Constructor_Sets_Properties()
     {
         var attr = new GenerateStrategyAttribute("TestStrategy", typeof(string), StrategyKind.Action);
 
-        Assert.Equal("TestStrategy", attr.Name);
-        Assert.Equal(typeof(string), attr.InType);
-        Assert.Null(attr.OutType);
-        Assert.Equal(StrategyKind.Action, attr.Kind);
+        ScenarioExpect.Equal("TestStrategy", attr.Name);
+        ScenarioExpect.Equal(typeof(string), attr.InType);
+        ScenarioExpect.Null(attr.OutType);
+        ScenarioExpect.Equal(StrategyKind.Action, attr.Kind);
     }
 
+    [Scenario("GenerateStrategyAttribute Result Constructor Sets Properties")]
     [Fact]
     public void GenerateStrategyAttribute_Result_Constructor_Sets_Properties()
     {
         var attr = new GenerateStrategyAttribute("TestStrategy", typeof(int), typeof(string), StrategyKind.Result);
 
-        Assert.Equal("TestStrategy", attr.Name);
-        Assert.Equal(typeof(int), attr.InType);
-        Assert.Equal(typeof(string), attr.OutType);
-        Assert.Equal(StrategyKind.Result, attr.Kind);
+        ScenarioExpect.Equal("TestStrategy", attr.Name);
+        ScenarioExpect.Equal(typeof(int), attr.InType);
+        ScenarioExpect.Equal(typeof(string), attr.OutType);
+        ScenarioExpect.Equal(StrategyKind.Result, attr.Kind);
     }
 
+    [Scenario("GenerateStrategyAttribute Try Constructor Sets Properties")]
     [Fact]
     public void GenerateStrategyAttribute_Try_Constructor_Sets_Properties()
     {
         var attr = new GenerateStrategyAttribute("Parser", typeof(string), typeof(int), StrategyKind.Try);
 
-        Assert.Equal("Parser", attr.Name);
-        Assert.Equal(typeof(string), attr.InType);
-        Assert.Equal(typeof(int), attr.OutType);
-        Assert.Equal(StrategyKind.Try, attr.Kind);
+        ScenarioExpect.Equal("Parser", attr.Name);
+        ScenarioExpect.Equal(typeof(string), attr.InType);
+        ScenarioExpect.Equal(typeof(int), attr.OutType);
+        ScenarioExpect.Equal(StrategyKind.Try, attr.Kind);
     }
 
+    [Scenario("GenerateStrategyAttribute Has Correct AttributeUsage")]
     [Fact]
     public void GenerateStrategyAttribute_Has_Correct_AttributeUsage()
     {
@@ -49,38 +55,41 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Class, usage.ValidOn);
-        Assert.True(usage.AllowMultiple);
-        Assert.False(usage.Inherited);
+        ScenarioExpect.Equal(AttributeTargets.Class, usage.ValidOn);
+        ScenarioExpect.True(usage.AllowMultiple);
+        ScenarioExpect.False(usage.Inherited);
     }
 
+    [Scenario("StrategyKind Enum Values Are Valid")]
     [Theory]
     [InlineData(StrategyKind.Action)]
     [InlineData(StrategyKind.Result)]
     [InlineData(StrategyKind.Try)]
     public void StrategyKind_Enum_Values_Are_Valid(StrategyKind kind)
     {
-        Assert.True(Enum.IsDefined(typeof(StrategyKind), kind));
+        ScenarioExpect.True(Enum.IsDefined(typeof(StrategyKind), kind));
     }
 
     #endregion
 
     #region GenerateBuilderAttribute Tests
 
+    [Scenario("GenerateBuilderAttribute Default Properties")]
     [Fact]
     public void GenerateBuilderAttribute_Default_Properties()
     {
         var attr = new Builders.GenerateBuilderAttribute();
 
-        Assert.Null(attr.BuilderTypeName);
-        Assert.Equal("New", attr.NewMethodName);
-        Assert.Equal("Build", attr.BuildMethodName);
-        Assert.Equal(Builders.BuilderModel.MutableInstance, attr.Model);
-        Assert.False(attr.GenerateBuilderMethods);
-        Assert.False(attr.ForceAsync);
-        Assert.False(attr.IncludeFields);
+        ScenarioExpect.Null(attr.BuilderTypeName);
+        ScenarioExpect.Equal("New", attr.NewMethodName);
+        ScenarioExpect.Equal("Build", attr.BuildMethodName);
+        ScenarioExpect.Equal(Builders.BuilderModel.MutableInstance, attr.Model);
+        ScenarioExpect.False(attr.GenerateBuilderMethods);
+        ScenarioExpect.False(attr.ForceAsync);
+        ScenarioExpect.False(attr.IncludeFields);
     }
 
+    [Scenario("GenerateBuilderAttribute Custom Properties")]
     [Fact]
     public void GenerateBuilderAttribute_Custom_Properties()
     {
@@ -95,15 +104,16 @@ public class AbstractionsTests
             IncludeFields = true
         };
 
-        Assert.Equal("PersonBuilder", attr.BuilderTypeName);
-        Assert.Equal("Create", attr.NewMethodName);
-        Assert.Equal("Construct", attr.BuildMethodName);
-        Assert.Equal(Builders.BuilderModel.StateProjection, attr.Model);
-        Assert.True(attr.GenerateBuilderMethods);
-        Assert.True(attr.ForceAsync);
-        Assert.True(attr.IncludeFields);
+        ScenarioExpect.Equal("PersonBuilder", attr.BuilderTypeName);
+        ScenarioExpect.Equal("Create", attr.NewMethodName);
+        ScenarioExpect.Equal("Construct", attr.BuildMethodName);
+        ScenarioExpect.Equal(Builders.BuilderModel.StateProjection, attr.Model);
+        ScenarioExpect.True(attr.GenerateBuilderMethods);
+        ScenarioExpect.True(attr.ForceAsync);
+        ScenarioExpect.True(attr.IncludeFields);
     }
 
+    [Scenario("GenerateBuilderAttribute Has Correct AttributeUsage")]
     [Fact]
     public void GenerateBuilderAttribute_Has_Correct_AttributeUsage()
     {
@@ -112,30 +122,33 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Class | AttributeTargets.Struct, usage.ValidOn);
-        Assert.False(usage.AllowMultiple);
-        Assert.False(usage.Inherited);
+        ScenarioExpect.Equal(AttributeTargets.Class | AttributeTargets.Struct, usage.ValidOn);
+        ScenarioExpect.False(usage.AllowMultiple);
+        ScenarioExpect.False(usage.Inherited);
     }
 
+    [Scenario("BuilderModel Enum Values Are Valid")]
     [Theory]
     [InlineData(Builders.BuilderModel.MutableInstance)]
     [InlineData(Builders.BuilderModel.StateProjection)]
     public void BuilderModel_Enum_Values_Are_Valid(Builders.BuilderModel model)
     {
-        Assert.True(Enum.IsDefined(typeof(Builders.BuilderModel), model));
+        ScenarioExpect.True(Enum.IsDefined(typeof(Builders.BuilderModel), model));
     }
 
     #endregion
 
     #region BuilderConstructorAttribute Tests
 
+    [Scenario("BuilderConstructorAttribute Can Be Created")]
     [Fact]
     public void BuilderConstructorAttribute_Can_Be_Created()
     {
         var attr = new Builders.BuilderConstructorAttribute();
-        Assert.NotNull(attr);
+        ScenarioExpect.NotNull(attr);
     }
 
+    [Scenario("BuilderConstructorAttribute Has Correct AttributeUsage")]
     [Fact]
     public void BuilderConstructorAttribute_Has_Correct_AttributeUsage()
     {
@@ -144,22 +157,24 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Constructor, usage.ValidOn);
-        Assert.False(usage.AllowMultiple);
-        Assert.False(usage.Inherited);
+        ScenarioExpect.Equal(AttributeTargets.Constructor, usage.ValidOn);
+        ScenarioExpect.False(usage.AllowMultiple);
+        ScenarioExpect.False(usage.Inherited);
     }
 
     #endregion
 
     #region BuilderIgnoreAttribute Tests
 
+    [Scenario("BuilderIgnoreAttribute Can Be Created")]
     [Fact]
     public void BuilderIgnoreAttribute_Can_Be_Created()
     {
         var attr = new Builders.BuilderIgnoreAttribute();
-        Assert.NotNull(attr);
+        ScenarioExpect.NotNull(attr);
     }
 
+    [Scenario("BuilderIgnoreAttribute Has Correct AttributeUsage")]
     [Fact]
     public void BuilderIgnoreAttribute_Has_Correct_AttributeUsage()
     {
@@ -168,23 +183,25 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Property | AttributeTargets.Field, usage.ValidOn);
-        Assert.False(usage.AllowMultiple);
-        Assert.False(usage.Inherited);
+        ScenarioExpect.Equal(AttributeTargets.Property | AttributeTargets.Field, usage.ValidOn);
+        ScenarioExpect.False(usage.AllowMultiple);
+        ScenarioExpect.False(usage.Inherited);
     }
 
     #endregion
 
     #region BuilderRequiredAttribute Tests
 
+    [Scenario("BuilderRequiredAttribute Default Properties")]
     [Fact]
     public void BuilderRequiredAttribute_Default_Properties()
     {
         var attr = new Builders.BuilderRequiredAttribute();
 
-        Assert.Null(attr.Message);
+        ScenarioExpect.Null(attr.Message);
     }
 
+    [Scenario("BuilderRequiredAttribute Custom Message")]
     [Fact]
     public void BuilderRequiredAttribute_Custom_Message()
     {
@@ -193,9 +210,10 @@ public class AbstractionsTests
             Message = "This field is required."
         };
 
-        Assert.Equal("This field is required.", attr.Message);
+        ScenarioExpect.Equal("This field is required.", attr.Message);
     }
 
+    [Scenario("BuilderRequiredAttribute Has Correct AttributeUsage")]
     [Fact]
     public void BuilderRequiredAttribute_Has_Correct_AttributeUsage()
     {
@@ -204,22 +222,24 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Property | AttributeTargets.Field, usage.ValidOn);
-        Assert.False(usage.AllowMultiple);
-        Assert.False(usage.Inherited);
+        ScenarioExpect.Equal(AttributeTargets.Property | AttributeTargets.Field, usage.ValidOn);
+        ScenarioExpect.False(usage.AllowMultiple);
+        ScenarioExpect.False(usage.Inherited);
     }
 
     #endregion
 
     #region BuilderProjectorAttribute Tests
 
+    [Scenario("BuilderProjectorAttribute Can Be Created")]
     [Fact]
     public void BuilderProjectorAttribute_Can_Be_Created()
     {
         var attr = new Builders.BuilderProjectorAttribute();
-        Assert.NotNull(attr);
+        ScenarioExpect.NotNull(attr);
     }
 
+    [Scenario("BuilderProjectorAttribute Has Correct AttributeUsage")]
     [Fact]
     public void BuilderProjectorAttribute_Has_Correct_AttributeUsage()
     {
@@ -228,25 +248,27 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Method, usage.ValidOn);
-        Assert.False(usage.AllowMultiple);
-        Assert.False(usage.Inherited);
+        ScenarioExpect.Equal(AttributeTargets.Method, usage.ValidOn);
+        ScenarioExpect.False(usage.AllowMultiple);
+        ScenarioExpect.False(usage.Inherited);
     }
 
     #endregion
 
     #region FactoryMethodAttribute Tests
 
+    [Scenario("FactoryMethodAttribute Constructor Sets KeyType")]
     [Fact]
     public void FactoryMethodAttribute_Constructor_Sets_KeyType()
     {
         var attr = new Factories.FactoryMethodAttribute(typeof(string));
 
-        Assert.Equal(typeof(string), attr.KeyType);
-        Assert.Equal("Create", attr.CreateMethodName);
-        Assert.True(attr.CaseInsensitiveStrings);
+        ScenarioExpect.Equal(typeof(string), attr.KeyType);
+        ScenarioExpect.Equal("Create", attr.CreateMethodName);
+        ScenarioExpect.True(attr.CaseInsensitiveStrings);
     }
 
+    [Scenario("FactoryMethodAttribute Custom Properties")]
     [Fact]
     public void FactoryMethodAttribute_Custom_Properties()
     {
@@ -256,11 +278,12 @@ public class AbstractionsTests
             CaseInsensitiveStrings = false
         };
 
-        Assert.Equal(typeof(int), attr.KeyType);
-        Assert.Equal("Make", attr.CreateMethodName);
-        Assert.False(attr.CaseInsensitiveStrings);
+        ScenarioExpect.Equal(typeof(int), attr.KeyType);
+        ScenarioExpect.Equal("Make", attr.CreateMethodName);
+        ScenarioExpect.False(attr.CaseInsensitiveStrings);
     }
 
+    [Scenario("FactoryMethodAttribute Has Correct AttributeUsage")]
     [Fact]
     public void FactoryMethodAttribute_Has_Correct_AttributeUsage()
     {
@@ -269,29 +292,32 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Class, usage.ValidOn);
+        ScenarioExpect.Equal(AttributeTargets.Class, usage.ValidOn);
     }
 
     #endregion
 
     #region FactoryCaseAttribute Tests
 
+    [Scenario("FactoryCaseAttribute Constructor Sets Key")]
     [Fact]
     public void FactoryCaseAttribute_Constructor_Sets_Key()
     {
         var attr = new Factories.FactoryCaseAttribute("testKey");
 
-        Assert.Equal("testKey", attr.Key);
+        ScenarioExpect.Equal("testKey", attr.Key);
     }
 
+    [Scenario("FactoryCaseAttribute With Int Key")]
     [Fact]
     public void FactoryCaseAttribute_With_Int_Key()
     {
         var attr = new Factories.FactoryCaseAttribute(42);
 
-        Assert.Equal(42, attr.Key);
+        ScenarioExpect.Equal(42, attr.Key);
     }
 
+    [Scenario("FactoryCaseAttribute Has Correct AttributeUsage")]
     [Fact]
     public void FactoryCaseAttribute_Has_Correct_AttributeUsage()
     {
@@ -300,21 +326,23 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Method, usage.ValidOn);
-        Assert.True(usage.AllowMultiple);
+        ScenarioExpect.Equal(AttributeTargets.Method, usage.ValidOn);
+        ScenarioExpect.True(usage.AllowMultiple);
     }
 
     #endregion
 
     #region FactoryDefaultAttribute Tests
 
+    [Scenario("FactoryDefaultAttribute Can Be Created")]
     [Fact]
     public void FactoryDefaultAttribute_Can_Be_Created()
     {
         var attr = new Factories.FactoryDefaultAttribute();
-        Assert.NotNull(attr);
+        ScenarioExpect.NotNull(attr);
     }
 
+    [Scenario("FactoryDefaultAttribute Has Correct AttributeUsage")]
     [Fact]
     public void FactoryDefaultAttribute_Has_Correct_AttributeUsage()
     {
@@ -323,24 +351,26 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Method, usage.ValidOn);
+        ScenarioExpect.Equal(AttributeTargets.Method, usage.ValidOn);
     }
 
     #endregion
 
     #region FactoryClassAttribute Tests
 
+    [Scenario("FactoryClassAttribute Constructor Sets KeyType")]
     [Fact]
     public void FactoryClassAttribute_Constructor_Sets_KeyType()
     {
         var attr = new Factories.FactoryClassAttribute(typeof(string));
 
-        Assert.Equal(typeof(string), attr.KeyType);
-        Assert.Null(attr.FactoryTypeName);
-        Assert.True(attr.GenerateTryCreate);
-        Assert.False(attr.GenerateEnumKeys);
+        ScenarioExpect.Equal(typeof(string), attr.KeyType);
+        ScenarioExpect.Null(attr.FactoryTypeName);
+        ScenarioExpect.True(attr.GenerateTryCreate);
+        ScenarioExpect.False(attr.GenerateEnumKeys);
     }
 
+    [Scenario("FactoryClassAttribute Custom Properties")]
     [Fact]
     public void FactoryClassAttribute_Custom_Properties()
     {
@@ -351,12 +381,13 @@ public class AbstractionsTests
             GenerateEnumKeys = true
         };
 
-        Assert.Equal(typeof(int), attr.KeyType);
-        Assert.Equal("MessageFactory", attr.FactoryTypeName);
-        Assert.False(attr.GenerateTryCreate);
-        Assert.True(attr.GenerateEnumKeys);
+        ScenarioExpect.Equal(typeof(int), attr.KeyType);
+        ScenarioExpect.Equal("MessageFactory", attr.FactoryTypeName);
+        ScenarioExpect.False(attr.GenerateTryCreate);
+        ScenarioExpect.True(attr.GenerateEnumKeys);
     }
 
+    [Scenario("FactoryClassAttribute Has Correct AttributeUsage")]
     [Fact]
     public void FactoryClassAttribute_Has_Correct_AttributeUsage()
     {
@@ -365,29 +396,32 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Interface | AttributeTargets.Class, usage.ValidOn);
+        ScenarioExpect.Equal(AttributeTargets.Interface | AttributeTargets.Class, usage.ValidOn);
     }
 
     #endregion
 
     #region FactoryClassKeyAttribute Tests
 
+    [Scenario("FactoryClassKeyAttribute Constructor Sets Key")]
     [Fact]
     public void FactoryClassKeyAttribute_Constructor_Sets_Key()
     {
         var attr = new Factories.FactoryClassKeyAttribute("email");
 
-        Assert.Equal("email", attr.Key);
+        ScenarioExpect.Equal("email", attr.Key);
     }
 
+    [Scenario("FactoryClassKeyAttribute With Int Key")]
     [Fact]
     public void FactoryClassKeyAttribute_With_Int_Key()
     {
         var attr = new Factories.FactoryClassKeyAttribute(123);
 
-        Assert.Equal(123, attr.Key);
+        ScenarioExpect.Equal(123, attr.Key);
     }
 
+    [Scenario("FactoryClassKeyAttribute Has Correct AttributeUsage")]
     [Fact]
     public void FactoryClassKeyAttribute_Has_Correct_AttributeUsage()
     {
@@ -396,7 +430,7 @@ public class AbstractionsTests
             .Cast<AttributeUsageAttribute>()
             .Single();
 
-        Assert.Equal(AttributeTargets.Class, usage.ValidOn);
+        ScenarioExpect.Equal(AttributeTargets.Class, usage.ValidOn);
     }
 
     #endregion

--- a/test/PatternKit.Generators.Tests/AdapterGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/AdapterGeneratorTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.CodeAnalysis;
 using PatternKit.Generators.Adapter;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class AdapterGeneratorTests
 {
+    [Scenario("GenerateSimpleAdapter")]
     [Fact]
     public void GenerateSimpleAdapter()
     {
@@ -36,11 +38,11 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Adapter file is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.LegacyClockToIClockAdapter.Adapter.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.LegacyClockToIClockAdapter.Adapter.g.cs", names);
 
         // Generated code contains expected shape
         var generatedSource = result.Results
@@ -48,15 +50,16 @@ public class AdapterGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.LegacyClockToIClockAdapter.Adapter.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public sealed partial class LegacyClockToIClockAdapter : global::TestNamespace.IClock", generatedSource);
-        Assert.Contains("private readonly global::TestNamespace.LegacyClock _adaptee;", generatedSource);
-        Assert.Contains("public LegacyClockToIClockAdapter(global::TestNamespace.LegacyClock adaptee)", generatedSource);
+        ScenarioExpect.Contains("public sealed partial class LegacyClockToIClockAdapter : global::TestNamespace.IClock", generatedSource);
+        ScenarioExpect.Contains("private readonly global::TestNamespace.LegacyClock _adaptee;", generatedSource);
+        ScenarioExpect.Contains("public LegacyClockToIClockAdapter(global::TestNamespace.LegacyClock adaptee)", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateAdapterWithMethods")]
     [Fact]
     public void GenerateAdapterWithMethods()
     {
@@ -97,7 +100,7 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Generated code contains method
         var generatedSource = result.Results
@@ -105,13 +108,14 @@ public class AdapterGeneratorTests
             .First(gs => gs.HintName.Contains("LegacyClockToIClockAdapter"))
             .SourceText.ToString();
 
-        Assert.Contains("public global::System.Threading.Tasks.ValueTask DelayAsync", generatedSource);
+        ScenarioExpect.Contains("public global::System.Threading.Tasks.ValueTask DelayAsync", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateAdapterWithCustomName")]
     [Fact]
     public void GenerateAdapterWithCustomName()
     {
@@ -143,16 +147,17 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Custom named adapter file is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.ClockAdapter.Adapter.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.ClockAdapter.Adapter.g.cs", names);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenHostNotStaticPartial")]
     [Fact]
     public void ErrorWhenHostNotStaticPartial()
     {
@@ -180,9 +185,10 @@ public class AdapterGeneratorTests
 
         // PKADP001 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP001");
     }
 
+    [Scenario("ErrorWhenTargetNotInterfaceOrAbstract")]
     [Fact]
     public void ErrorWhenTargetNotInterfaceOrAbstract()
     {
@@ -208,9 +214,10 @@ public class AdapterGeneratorTests
 
         // PKADP002 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP002");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP002");
     }
 
+    [Scenario("ErrorWhenMissingMapping")]
     [Fact]
     public void ErrorWhenMissingMapping()
     {
@@ -242,9 +249,10 @@ public class AdapterGeneratorTests
 
         // PKADP003 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP003");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP003");
     }
 
+    [Scenario("ErrorWhenDuplicateMapping")]
     [Fact]
     public void ErrorWhenDuplicateMapping()
     {
@@ -277,9 +285,10 @@ public class AdapterGeneratorTests
 
         // PKADP004 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP004");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP004");
     }
 
+    [Scenario("ErrorWhenSignatureMismatch")]
     [Fact]
     public void ErrorWhenSignatureMismatch()
     {
@@ -309,9 +318,10 @@ public class AdapterGeneratorTests
 
         // PKADP005 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP005");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP005");
     }
 
+    [Scenario("GenerateThrowingStubWhenPolicySet")]
     [Fact]
     public void GenerateThrowingStubWhenPolicySet()
     {
@@ -342,7 +352,7 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics (ThrowingStub policy allows missing maps)
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Generated code contains throwing stub
         var generatedSource = result.Results
@@ -350,13 +360,14 @@ public class AdapterGeneratorTests
             .First(gs => gs.HintName.Contains("Adapter"))
             .SourceText.ToString();
 
-        Assert.Contains("throw new global::System.NotImplementedException", generatedSource);
+        ScenarioExpect.Contains("throw new global::System.NotImplementedException", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateAdapterWithAbstractClassTarget")]
     [Fact]
     public void GenerateAdapterWithAbstractClassTarget()
     {
@@ -388,7 +399,7 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Adapter inherits from abstract class
         var generatedSource = result.Results
@@ -396,12 +407,13 @@ public class AdapterGeneratorTests
             .First(gs => gs.HintName.Contains("Adapter"))
             .SourceText.ToString();
 
-        Assert.Contains(": global::TestNamespace.ClockBase", generatedSource);
+        ScenarioExpect.Contains(": global::TestNamespace.ClockBase", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateMultipleAdaptersFromSameHost")]
     [Fact]
     public void GenerateMultipleAdaptersFromSameHost()
     {
@@ -440,17 +452,18 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Both adapters are generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains(names, n => n.Contains("LegacyClockToIClockAdapter"));
-        Assert.Contains(names, n => n.Contains("LegacyTimerToITimerAdapter"));
+        ScenarioExpect.Contains(names, n => n.Contains("LegacyClockToIClockAdapter"));
+        ScenarioExpect.Contains(names, n => n.Contains("LegacyTimerToITimerAdapter"));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateAdapterInGlobalNamespace")]
     [Fact]
     public void GenerateAdapterInGlobalNamespace()
     {
@@ -473,7 +486,7 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Adapter is generated without namespace
         var generatedSource = result.Results
@@ -481,12 +494,13 @@ public class AdapterGeneratorTests
             .First(gs => gs.HintName.Contains("Adapter"))
             .SourceText.ToString();
 
-        Assert.DoesNotContain("namespace", generatedSource);
+        ScenarioExpect.DoesNotContain("namespace", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateNonSealedAdapter")]
     [Fact]
     public void GenerateNonSealedAdapter()
     {
@@ -515,13 +529,14 @@ public class AdapterGeneratorTests
             .First(gs => gs.HintName.Contains("Adapter"))
             .SourceText.ToString();
 
-        Assert.DoesNotContain("sealed", generatedSource);
-        Assert.Contains("public partial class", generatedSource);
+        ScenarioExpect.DoesNotContain("sealed", generatedSource);
+        ScenarioExpect.Contains("public partial class", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateAdapterWithMethodParameters")]
     [Fact]
     public void GenerateAdapterWithMethodParameters()
     {
@@ -558,20 +573,21 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName.Contains("Adapter"))
             .SourceText.ToString();
 
-        Assert.Contains("public int Add(int a, int b)", generatedSource);
-        Assert.Contains("public int Multiply(int x, int y)", generatedSource);
+        ScenarioExpect.Contains("public int Add(int a, int b)", generatedSource);
+        ScenarioExpect.Contains("public int Multiply(int x, int y)", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenAdapteeIsAbstract")]
     [Fact]
     public void ErrorWhenAdapteeIsAbstract()
     {
@@ -597,9 +613,10 @@ public class AdapterGeneratorTests
 
         // PKADP007 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP007");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP007");
     }
 
+    [Scenario("ErrorWhenMappingMethodNotStatic")]
     [Fact]
     public void ErrorWhenMappingMethodNotStatic()
     {
@@ -629,9 +646,10 @@ public class AdapterGeneratorTests
 
         // PKADP008 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP008");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP008");
     }
 
+    [Scenario("MultipleAdaptersWithOverlappingMemberNames")]
     [Fact]
     public void MultipleAdaptersWithOverlappingMemberNames()
     {
@@ -664,17 +682,18 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics (mappings are distinguished by adaptee type)
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Both adapters generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains(names, n => n.Contains("LegacyClockToIClockAdapter"));
-        Assert.Contains(names, n => n.Contains("LegacyTimerToITimerAdapter"));
+        ScenarioExpect.Contains(names, n => n.Contains("LegacyClockToIClockAdapter"));
+        ScenarioExpect.Contains(names, n => n.Contains("LegacyTimerToITimerAdapter"));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("InterfaceDiamondDeduplication")]
     [Fact]
     public void InterfaceDiamondDeduplication()
     {
@@ -711,7 +730,7 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Should only have one DoWork method in generated code, not duplicates
         var generatedSource = result.Results
@@ -720,12 +739,13 @@ public class AdapterGeneratorTests
             .SourceText.ToString();
 
         var doWorkCount = generatedSource.Split("public void DoWork()").Length - 1;
-        Assert.Equal(1, doWorkCount);
+        ScenarioExpect.Equal(1, doWorkCount);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("RefParameterValidation")]
     [Fact]
     public void RefParameterValidation()
     {
@@ -755,9 +775,10 @@ public class AdapterGeneratorTests
 
         // PKADP005 diagnostic is reported for ref kind mismatch
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP005" && d.GetMessage().Contains("ref kind"));
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP005" && d.GetMessage().Contains("ref kind"));
     }
 
+    [Scenario("ErrorWhenTargetHasEvents")]
     [Fact]
     public void ErrorWhenTargetHasEvents()
     {
@@ -784,9 +805,10 @@ public class AdapterGeneratorTests
 
         // PKADP009 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP009");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP009");
     }
 
+    [Scenario("ErrorWhenTargetHasGenericMethods")]
     [Fact]
     public void ErrorWhenTargetHasGenericMethods()
     {
@@ -812,9 +834,10 @@ public class AdapterGeneratorTests
 
         // PKADP010 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP010");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP010");
     }
 
+    [Scenario("ErrorWhenTargetHasOverloadedMethods")]
     [Fact]
     public void ErrorWhenTargetHasOverloadedMethods()
     {
@@ -841,9 +864,10 @@ public class AdapterGeneratorTests
 
         // PKADP011 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP011");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP011");
     }
 
+    [Scenario("ErrorWhenAbstractClassHasNoParameterlessCtor")]
     [Fact]
     public void ErrorWhenAbstractClassHasNoParameterlessCtor()
     {
@@ -874,9 +898,10 @@ public class AdapterGeneratorTests
 
         // PKADP012 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP012");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP012");
     }
 
+    [Scenario("ErrorWhenAdapterTypeNameConflicts")]
     [Fact]
     public void ErrorWhenAdapterTypeNameConflicts()
     {
@@ -909,9 +934,10 @@ public class AdapterGeneratorTests
 
         // PKADP006 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP006");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP006");
     }
 
+    [Scenario("StructAdapteeNoNullCheck")]
     [Fact]
     public void StructAdapteeNoNullCheck()
     {
@@ -943,7 +969,7 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Generated code should NOT have null check for struct
         var generatedSource = result.Results
@@ -951,13 +977,14 @@ public class AdapterGeneratorTests
             .First(gs => gs.HintName.Contains("Adapter"))
             .SourceText.ToString();
 
-        Assert.DoesNotContain("throw new global::System.ArgumentNullException", generatedSource);
-        Assert.Contains("_adaptee = adaptee;", generatedSource);
+        ScenarioExpect.DoesNotContain("throw new global::System.ArgumentNullException", generatedSource);
+        ScenarioExpect.Contains("_adaptee = adaptee;", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenTargetHasSettableProperty")]
     [Fact]
     public void ErrorWhenTargetHasSettableProperty()
     {
@@ -983,9 +1010,10 @@ public class AdapterGeneratorTests
 
         // PKADP013 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP013");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP013");
     }
 
+    [Scenario("ReadOnlyPropertyIsSupported")]
     [Fact]
     public void ReadOnlyPropertyIsSupported()
     {
@@ -1017,12 +1045,13 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics (read-only properties are fine)
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenHostIsNested")]
     [Fact]
     public void ErrorWhenHostIsNested()
     {
@@ -1051,9 +1080,10 @@ public class AdapterGeneratorTests
 
         // PKADP014 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP014");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP014");
     }
 
+    [Scenario("ErrorWhenHostIsGeneric")]
     [Fact]
     public void ErrorWhenHostIsGeneric()
     {
@@ -1079,9 +1109,10 @@ public class AdapterGeneratorTests
 
         // PKADP014 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP014");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP014");
     }
 
+    [Scenario("ErrorWhenMappingMethodNotAccessible")]
     [Fact]
     public void ErrorWhenMappingMethodNotAccessible()
     {
@@ -1111,9 +1142,10 @@ public class AdapterGeneratorTests
 
         // PKADP015 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP015");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP015");
     }
 
+    [Scenario("ErrorWhenTargetHasStaticMembers")]
     [Fact]
     public void ErrorWhenTargetHasStaticMembers()
     {
@@ -1144,9 +1176,10 @@ public class AdapterGeneratorTests
 
         // PKADP016 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP016");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP016");
     }
 
+    [Scenario("ErrorWhenTargetHasRefReturnProperty")]
     [Fact]
     public void ErrorWhenTargetHasRefReturnProperty()
     {
@@ -1172,9 +1205,10 @@ public class AdapterGeneratorTests
 
         // PKADP017 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP017");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP017");
     }
 
+    [Scenario("ErrorWhenTargetHasRefReturnMethod")]
     [Fact]
     public void ErrorWhenTargetHasRefReturnMethod()
     {
@@ -1200,9 +1234,10 @@ public class AdapterGeneratorTests
 
         // PKADP017 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP017");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP017");
     }
 
+    [Scenario("ErrorWhenTargetHasIndexer")]
     [Fact]
     public void ErrorWhenTargetHasIndexer()
     {
@@ -1228,9 +1263,10 @@ public class AdapterGeneratorTests
 
         // PKADP018 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP018");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP018");
     }
 
+    [Scenario("ErrorWhenTwoHostsGenerateSameAdapterTypeName")]
     [Fact]
     public void ErrorWhenTwoHostsGenerateSameAdapterTypeName()
     {
@@ -1275,9 +1311,10 @@ public class AdapterGeneratorTests
 
         // PKADP006 diagnostic is reported (at least once, possibly twice)
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKADP006");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKADP006");
     }
 
+    [Scenario("GenerateAdapter ThrowingStubWithDefaultsRefsAndCustomNamespace")]
     [Fact]
     public void GenerateAdapter_ThrowingStubWithDefaultsRefsAndCustomNamespace()
     {
@@ -1313,28 +1350,29 @@ public class AdapterGeneratorTests
         var gen = new AdapterGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .Single(gs => gs.HintName == "Generated.ServiceAdapter.Adapter.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("namespace Generated;", generatedSource);
-        Assert.Contains("public partial class ServiceAdapter : global::TestNamespace.IService", generatedSource);
-        Assert.Contains("Name", generatedSource);
-        Assert.Contains("get => throw new global::System.NotImplementedException", generatedSource);
-        Assert.Contains("ref int source", generatedSource);
-        Assert.Contains("out int destination", generatedSource);
-        Assert.Contains("in bool enabled", generatedSource);
-        Assert.Contains("string? label = null", generatedSource);
-        Assert.Contains("global::TestNamespace.Mode mode = global::TestNamespace.Mode.Fast", generatedSource);
-        Assert.Contains("int count = 3", generatedSource);
+        ScenarioExpect.Contains("namespace Generated;", generatedSource);
+        ScenarioExpect.Contains("public partial class ServiceAdapter : global::TestNamespace.IService", generatedSource);
+        ScenarioExpect.Contains("Name", generatedSource);
+        ScenarioExpect.Contains("get => throw new global::System.NotImplementedException", generatedSource);
+        ScenarioExpect.Contains("ref int source", generatedSource);
+        ScenarioExpect.Contains("out int destination", generatedSource);
+        ScenarioExpect.Contains("in bool enabled", generatedSource);
+        ScenarioExpect.Contains("string? label = null", generatedSource);
+        ScenarioExpect.Contains("global::TestNamespace.Mode mode = global::TestNamespace.Mode.Fast", generatedSource);
+        ScenarioExpect.Contains("int count = 3", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("AdapterDiagnostics OpenGenericAbstractCtorAndBadMapSignatures")]
     [Fact]
     public void AdapterDiagnostics_OpenGenericAbstractCtorAndBadMapSignatures()
     {
@@ -1388,10 +1426,10 @@ public class AdapterGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKADP002" && d.GetMessage().Contains("IGeneric"));
-        Assert.Contains(diagnostics, d => d.Id == "PKADP007" && d.GetMessage().Contains("AbstractAdaptee"));
-        Assert.Contains(diagnostics, d => d.Id == "PKADP012" && d.GetMessage().Contains("TargetWithoutDefaultCtor"));
-        Assert.Contains(diagnostics, d => d.Id == "PKADP005" && d.GetMessage().Contains("Return type"));
-        Assert.Contains(diagnostics, d => d.Id == "PKADP005" && d.GetMessage().Contains("ref kind mismatch"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKADP002" && d.GetMessage().Contains("IGeneric"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKADP007" && d.GetMessage().Contains("AbstractAdaptee"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKADP012" && d.GetMessage().Contains("TargetWithoutDefaultCtor"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKADP005" && d.GetMessage().Contains("Return type"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKADP005" && d.GetMessage().Contains("ref kind mismatch"));
     }
 }

--- a/test/PatternKit.Generators.Tests/BridgeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/BridgeGeneratorTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Generators.Bridge;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class BridgeGeneratorTests
 {
+    [Scenario("GeneratesBridgeForwardingAndDefaultType")]
     [Fact]
     public void GeneratesBridgeForwardingAndDefaultType()
     {
@@ -32,20 +34,21 @@ public class BridgeGeneratorTests
         var gen = new BridgeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
-        Assert.Contains(generated, s => s.HintName == "Shape.Bridge.g.cs");
-        Assert.Contains(generated, s => s.HintName == "DefaultShape.Bridge.Default.g.cs");
+        ScenarioExpect.Contains(generated, s => s.HintName == "Shape.Bridge.g.cs");
+        ScenarioExpect.Contains(generated, s => s.HintName == "DefaultShape.Bridge.Default.g.cs");
 
         var bridgeSource = generated.First(s => s.HintName == "Shape.Bridge.g.cs").SourceText.ToString();
-        Assert.Contains("protected global::TestNamespace.IRenderer Implementor { get; }", bridgeSource);
-        Assert.Contains("protected void DrawLine(int x1, int y1, int x2, int y2)", bridgeSource);
-        Assert.Contains("protected global::System.Threading.Tasks.ValueTask FlushAsync", bridgeSource);
+        ScenarioExpect.Contains("protected global::TestNamespace.IRenderer Implementor { get; }", bridgeSource);
+        ScenarioExpect.Contains("protected void DrawLine(int x1, int y1, int x2, int y2)", bridgeSource);
+        ScenarioExpect.Contains("protected global::System.Threading.Tasks.ValueTask FlushAsync", bridgeSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsDiagnosticWhenAbstractionIsNotPartial")]
     [Fact]
     public void ReportsDiagnosticWhenAbstractionIsNotPartial()
     {
@@ -70,9 +73,10 @@ public class BridgeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKBRG001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKBRG001");
     }
 
+    [Scenario("ReportsDiagnosticWhenImplementorIsConcrete")]
     [Fact]
     public void ReportsDiagnosticWhenImplementorIsConcrete()
     {
@@ -97,9 +101,10 @@ public class BridgeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKBRG002");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKBRG002");
     }
 
+    [Scenario("GeneratesGenericBridgeWithForwardedPropertiesRefParametersAndDefaults")]
     [Fact]
     public void GeneratesGenericBridgeWithForwardedPropertiesRefParametersAndDefaults()
     {
@@ -126,20 +131,21 @@ public class BridgeGeneratorTests
         var gen = new BridgeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Store.Bridge.g.cs").SourceText.ToString();
-        Assert.Contains("public abstract partial record class Store<T>", generated);
-        Assert.Contains("protected string Name => Backend.Name;", generated);
-        Assert.Contains("ref int source, out int destination, in bool enabled", generated);
-        Assert.Contains("Backend.Copy(ref source, out destination, in enabled)", generated);
-        Assert.Contains(@"string value = @""quoted""", generated);
-        Assert.Contains("bool enabled = true", generated);
-        Assert.Contains("int count = 3", generated);
-        Assert.Contains("object? state = default", generated);
-        Assert.DoesNotContain("Ignored", generated);
-        Assert.True(updated.Emit(Stream.Null).Success, string.Join("\n", updated.GetDiagnostics()));
+        ScenarioExpect.Contains("public abstract partial record class Store<T>", generated);
+        ScenarioExpect.Contains("protected string Name => Backend.Name;", generated);
+        ScenarioExpect.Contains("ref int source, out int destination, in bool enabled", generated);
+        ScenarioExpect.Contains("Backend.Copy(ref source, out destination, in enabled)", generated);
+        ScenarioExpect.Contains(@"string value = @""quoted""", generated);
+        ScenarioExpect.Contains("bool enabled = true", generated);
+        ScenarioExpect.Contains("int count = 3", generated);
+        ScenarioExpect.Contains("object? state = default", generated);
+        ScenarioExpect.DoesNotContain("Ignored", generated);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success, string.Join("\n", updated.GetDiagnostics()));
     }
 
+    [Scenario("ReportsDiagnosticForEventMembersAndDefaultNameConflicts")]
     [Fact]
     public void ReportsDiagnosticForEventMembersAndDefaultNameConflicts()
     {
@@ -185,7 +191,7 @@ public class BridgeGeneratorTests
         _ = RoslynTestHelpers.Run(eventComp, gen, out var eventResult, out _);
         _ = RoslynTestHelpers.Run(conflictComp, gen, out var conflictResult, out _);
 
-        Assert.Contains(eventResult.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKBRG003");
-        Assert.Contains(conflictResult.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKBRG004");
+        ScenarioExpect.Contains(eventResult.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKBRG003");
+        ScenarioExpect.Contains(conflictResult.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKBRG004");
     }
 }

--- a/test/PatternKit.Generators.Tests/BuilderGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/BuilderGeneratorTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.Loader;
 using PatternKit.Generators.Builders;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -41,6 +42,7 @@ public class BuilderGeneratorTests
         }
         """;
 
+    [Scenario("MutableBuilder Generates And Runs")]
     [Fact]
     public async Task MutableBuilder_Generates_And_Runs()
     {
@@ -91,15 +93,15 @@ public class BuilderGeneratorTests
         var comp = RoslynTestHelpers.CreateCompilation(user, nameof(MutableBuilder_Generates_And_Runs));
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success, string.Join(Environment.NewLine, res.Diagnostics));
+        ScenarioExpect.True(res.Success, string.Join(Environment.NewLine, res.Diagnostics));
         pe.Position = 0;
         pdb.Position = 0;
 
@@ -107,24 +109,25 @@ public class BuilderGeneratorTests
         var sync = asm.GetType("PatternKit.Examples.Builders.MutableDemo")!
             .GetMethod("Run")!
             .Invoke(null, null) as string;
-        Assert.Equal("Ada:37", sync);
+        ScenarioExpect.Equal("Ada:37", sync);
 
         var helper = asm.GetType("PatternKit.Examples.Builders.MutableDemo")!
             .GetMethod("BuildViaHelpers")!
             .Invoke(null, null) as string;
-        Assert.Equal("Cara:25", helper);
+        ScenarioExpect.Equal("Cara:25", helper);
 
         var asyncMethod = asm.GetType("PatternKit.Examples.Builders.MutableDemo")!
             .GetMethod("RunAsync")!;
         var task = (Task<string>)asyncMethod.Invoke(null, null)!;
-        Assert.Equal("Bob:42", await task);
+        ScenarioExpect.Equal("Bob:42", await task);
 
         var helperAsync = asm.GetType("PatternKit.Examples.Builders.MutableDemo")!
             .GetMethod("BuildViaHelpersAsync")!;
         var helperTask = (Task<string>)helperAsync.Invoke(null, null)!;
-        Assert.Equal("Dan:50", await helperTask);
+        ScenarioExpect.Equal("Dan:50", await helperTask);
     }
 
+    [Scenario("ProjectionBuilder Composes State And Projector")]
     [Fact]
     public async Task ProjectionBuilder_Composes_State_And_Projector()
     {
@@ -164,15 +167,15 @@ public class BuilderGeneratorTests
         var comp = RoslynTestHelpers.CreateCompilation(user, nameof(ProjectionBuilder_Composes_State_And_Projector));
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success, string.Join(Environment.NewLine, res.Diagnostics));
+        ScenarioExpect.True(res.Success, string.Join(Environment.NewLine, res.Diagnostics));
         pe.Position = 0;
         pdb.Position = 0;
 
@@ -180,14 +183,15 @@ public class BuilderGeneratorTests
         var sync = asm.GetType("PatternKit.Examples.Builders.ProjectionDemo")!
             .GetMethod("BuildSync")!
             .Invoke(null, null) as string;
-        Assert.Equal("Lin:28", sync);
+        ScenarioExpect.Equal("Lin:28", sync);
 
         var asyncMethod = asm.GetType("PatternKit.Examples.Builders.ProjectionDemo")!
             .GetMethod("BuildAsync")!;
         var valueTask = (ValueTask<string>)asyncMethod.Invoke(null, null)!;
-        Assert.Equal("Quinn:31", await valueTask);
+        ScenarioExpect.Equal("Quinn:31", await valueTask);
     }
 
+    [Scenario("Required Member Throws When Missing")]
     [Fact]
     public void Required_Member_Throws_When_Missing()
     {
@@ -208,7 +212,7 @@ public class BuilderGeneratorTests
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success, string.Join(Environment.NewLine, res.Diagnostics));
+        ScenarioExpect.True(res.Success, string.Join(Environment.NewLine, res.Diagnostics));
         pe.Position = 0;
         pdb.Position = 0;
 
@@ -216,11 +220,12 @@ public class BuilderGeneratorTests
         var run = asm.GetType("PatternKit.Examples.Builders.MissingRequiredDemo")!
             .GetMethod("Run")!;
 
-        var ex = Assert.Throws<TargetInvocationException>(() => run.Invoke(null, null));
-        Assert.IsType<InvalidOperationException>(ex.InnerException);
-        Assert.Equal("Name is required.", ex.InnerException?.Message);
+        var ex = ScenarioExpect.Throws<TargetInvocationException>(() => run.Invoke(null, null));
+        ScenarioExpect.IsType<InvalidOperationException>(ex.InnerException);
+        ScenarioExpect.Equal("Name is required.", ex.InnerException?.Message);
     }
 
+    [Scenario("NotPartial Type Emits Diagnostic")]
     [Fact]
     public void NotPartial_Type_Emits_Diagnostic()
     {
@@ -241,10 +246,11 @@ public class BuilderGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diag = run.Results.SelectMany(r => r.Diagnostics).FirstOrDefault();
-        Assert.NotNull(diag);
-        Assert.Equal("B001", diag.Id);
+        ScenarioExpect.NotNull(diag);
+        ScenarioExpect.Equal("B001", diag.Id);
     }
 
+    [Scenario("Generic Type Emits Diagnostic")]
     [Fact]
     public void Generic_Type_Emits_Diagnostic()
     {
@@ -265,10 +271,11 @@ public class BuilderGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diag = run.Results.SelectMany(r => r.Diagnostics).FirstOrDefault();
-        Assert.NotNull(diag);
-        Assert.Equal("B001", diag.Id);
+        ScenarioExpect.NotNull(diag);
+        ScenarioExpect.Equal("B001", diag.Id);
     }
 
+    [Scenario("Multiple BuilderConstructor Attributes Emit Diagnostic")]
     [Fact]
     public void Multiple_BuilderConstructor_Attributes_Emit_Diagnostic()
     {
@@ -295,10 +302,11 @@ public class BuilderGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diag = run.Results.SelectMany(r => r.Diagnostics).FirstOrDefault();
-        Assert.NotNull(diag);
-        Assert.Equal("B004", diag.Id);
+        ScenarioExpect.NotNull(diag);
+        ScenarioExpect.Equal("B004", diag.Id);
     }
 
+    [Scenario("No Usable Constructor Emits Diagnostic")]
     [Fact]
     public void No_Usable_Constructor_Emits_Diagnostic()
     {
@@ -321,10 +329,11 @@ public class BuilderGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diag = run.Results.SelectMany(r => r.Diagnostics).FirstOrDefault();
-        Assert.NotNull(diag);
-        Assert.Equal("B003", diag.Id);
+        ScenarioExpect.NotNull(diag);
+        ScenarioExpect.Equal("B003", diag.Id);
     }
 
+    [Scenario("Struct Builder Generates Without Errors")]
     [Fact]
     public void Struct_Builder_Generates_Without_Errors()
     {
@@ -348,23 +357,24 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         // Verify the builder type was generated
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var builderType = asm.GetType("PatternKit.Examples.Builders.PointBuilder");
-        Assert.NotNull(builderType);
-        Assert.NotNull(builderType.GetMethod("New"));
-        Assert.NotNull(builderType.GetMethod("WithX"));
-        Assert.NotNull(builderType.GetMethod("WithY"));
-        Assert.NotNull(builderType.GetMethod("Build"));
+        ScenarioExpect.NotNull(builderType);
+        ScenarioExpect.NotNull(builderType.GetMethod("New"));
+        ScenarioExpect.NotNull(builderType.GetMethod("WithX"));
+        ScenarioExpect.NotNull(builderType.GetMethod("WithY"));
+        ScenarioExpect.NotNull(builderType.GetMethod("Build"));
     }
 
+    [Scenario("IncludeFields Generates Field Setters")]
     [Fact]
     public void IncludeFields_Generates_Field_Setters()
     {
@@ -397,20 +407,21 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var result = asm.GetType("PatternKit.Examples.Builders.FieldDemo")!
             .GetMethod("Run")!
             .Invoke(null, null) as string;
-        Assert.Equal("Test:42", result);
+        ScenarioExpect.Equal("Test:42", result);
     }
 
+    [Scenario("BuilderIgnore Skips Property")]
     [Fact]
     public void BuilderIgnore_Skips_Property()
     {
@@ -444,20 +455,21 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var result = asm.GetType("PatternKit.Examples.Builders.IgnoreDemo")!
             .GetMethod("Run")!
             .Invoke(null, null) as string;
-        Assert.Equal("test:TEST", result);
+        ScenarioExpect.Equal("test:TEST", result);
     }
 
+    [Scenario("Custom Method Names Work")]
     [Fact]
     public void Custom_Method_Names_Work()
     {
@@ -488,20 +500,21 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var result = asm.GetType("PatternKit.Examples.Builders.CustomNamesDemo")!
             .GetMethod("Run")!
             .Invoke(null, null) as string;
-        Assert.Equal("Hello", result);
+        ScenarioExpect.Equal("Hello", result);
     }
 
+    [Scenario("Projection Missing Seed Emits Diagnostic")]
     [Fact]
     public void Projection_Missing_Seed_Emits_Diagnostic()
     {
@@ -522,10 +535,11 @@ public class BuilderGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diag = run.Results.SelectMany(r => r.Diagnostics).FirstOrDefault();
-        Assert.NotNull(diag);
-        Assert.Equal("BP001", diag.Id);
+        ScenarioExpect.NotNull(diag);
+        ScenarioExpect.Equal("BP001", diag.Id);
     }
 
+    [Scenario("Projection Multiple Projectors Emits Diagnostic")]
     [Fact]
     public void Projection_Multiple_Projectors_Emits_Diagnostic()
     {
@@ -555,10 +569,11 @@ public class BuilderGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diag = run.Results.SelectMany(r => r.Diagnostics).FirstOrDefault();
-        Assert.NotNull(diag);
-        Assert.Equal("BP002", diag.Id);
+        ScenarioExpect.NotNull(diag);
+        ScenarioExpect.Equal("BP002", diag.Id);
     }
 
+    [Scenario("Projection Invalid Projector Emits Diagnostic")]
     [Fact]
     public void Projection_Invalid_Projector_Emits_Diagnostic()
     {
@@ -584,10 +599,11 @@ public class BuilderGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diag = run.Results.SelectMany(r => r.Diagnostics).FirstOrDefault();
-        Assert.NotNull(diag);
-        Assert.Equal("BP003", diag.Id);
+        ScenarioExpect.NotNull(diag);
+        ScenarioExpect.Equal("BP003", diag.Id);
     }
 
+    [Scenario("Mutable With ParameterizedCtor Uses Defaults")]
     [Fact]
     public void Mutable_With_ParameterizedCtor_Uses_Defaults()
     {
@@ -627,20 +643,21 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var result = asm.GetType("PatternKit.Examples.Builders.ParamCtorDemo")!
             .GetMethod("Run")!
             .Invoke(null, null) as string;
-        Assert.Equal("Test:25", result);
+        ScenarioExpect.Equal("Test:25", result);
     }
 
+    [Scenario("Internal Type Generates Internal Builder")]
     [Fact]
     public void Internal_Type_Generates_Internal_Builder()
     {
@@ -671,20 +688,21 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var result = asm.GetType("PatternKit.Examples.Builders.InternalDemo")!
             .GetMethod("Run")!
             .Invoke(null, null) as string;
-        Assert.Equal("Internal", result);
+        ScenarioExpect.Equal("Internal", result);
     }
 
+    [Scenario("RequireAsync Validation Works")]
     [Fact]
     public void RequireAsync_Validation_Works()
     {
@@ -723,13 +741,14 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
     }
 
+    [Scenario("Projection RequireAsync Works")]
     [Fact]
     public void Projection_RequireAsync_Works()
     {
@@ -773,10 +792,10 @@ public class BuilderGeneratorTests
         var gen = new BuilderGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
     }
 }

--- a/test/PatternKit.Generators.Tests/ChainGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ChainGeneratorTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Generators.Chain;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class ChainGeneratorTests
 {
+    [Scenario("GeneratesResponsibilityChain")]
     [Fact]
     public void GeneratesResponsibilityChain()
     {
@@ -34,15 +36,16 @@ public class ChainGeneratorTests
         var gen = new ChainGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Router.Chain.g.cs").SourceText.ToString();
-        Assert.Contains("public bool TryHandle(in global::TestNamespace.Request input, out global::TestNamespace.Response output)", generated);
-        Assert.Contains("public global::TestNamespace.Response Handle", generated);
+        ScenarioExpect.Contains("public bool TryHandle(in global::TestNamespace.Request input, out global::TestNamespace.Response output)", generated);
+        ScenarioExpect.Contains("public global::TestNamespace.Response Handle", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsDuplicateOrder")]
     [Fact]
     public void ReportsDuplicateOrder()
     {
@@ -66,9 +69,10 @@ public class ChainGeneratorTests
         var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsDuplicateOrder));
         var gen = new ChainGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
-        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKCH003");
+        ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKCH003");
     }
 
+    [Scenario("ReportsResponsibilityChainDiagnostics")]
     [Theory]
     [InlineData("""
         [Chain]
@@ -125,9 +129,10 @@ public class ChainGeneratorTests
         var gen = new ChainGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
-        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
+        ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
     }
 
+    [Scenario("ReportsPipelineTerminalDiagnostics")]
     [Theory]
     [InlineData("", "PKCH005")]
     [InlineData("""
@@ -155,9 +160,10 @@ public class ChainGeneratorTests
         var gen = new ChainGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
-        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
+        ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
     }
 
+    [Scenario("GeneratesResponsibilityChainWithCustomMethodNamesInGlobalNamespace")]
     [Fact]
     public void GeneratesResponsibilityChainWithCustomMethodNamesInGlobalNamespace()
     {
@@ -179,11 +185,11 @@ public class ChainGeneratorTests
         var gen = new ChainGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Router.Chain.g.cs").SourceText.ToString();
-        Assert.Contains("public bool TryRoute", generated);
-        Assert.Contains("public global::Response Route", generated);
-        Assert.DoesNotContain("namespace ", generated);
-        Assert.True(updated.Emit(Stream.Null).Success);
+        ScenarioExpect.Contains("public bool TryRoute", generated);
+        ScenarioExpect.Contains("public global::Response Route", generated);
+        ScenarioExpect.DoesNotContain("namespace ", generated);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
     }
 }

--- a/test/PatternKit.Generators.Tests/CommandGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/CommandGeneratorTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Generators.Command;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class CommandGeneratorTests
 {
+    [Scenario("GeneratesCommandExecutor")]
     [Fact]
     public void GeneratesCommandExecutor()
     {
@@ -27,15 +29,16 @@ public class CommandGeneratorTests
         var gen = new CommandGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "RenameUser.Command.g.cs").SourceText.ToString();
-        Assert.Contains("public readonly partial struct RenameUserCommand", generated);
-        Assert.Contains("public static void Execute(global::TestNamespace.UserService handler, in global::TestNamespace.RenameUser command)", generated);
+        ScenarioExpect.Contains("public readonly partial struct RenameUserCommand", generated);
+        ScenarioExpect.Contains("public static void Execute(global::TestNamespace.UserService handler, in global::TestNamespace.RenameUser command)", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsMissingHandler")]
     [Fact]
     public void ReportsMissingHandler()
     {
@@ -51,9 +54,10 @@ public class CommandGeneratorTests
         var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsMissingHandler));
         var gen = new CommandGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
-        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKCMD002");
+        ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKCMD002");
     }
 
+    [Scenario("GeneratesAsyncCommandExecutorWithCancellationToken")]
     [Fact]
     public void GeneratesAsyncCommandExecutorWithCancellationToken()
     {
@@ -78,13 +82,14 @@ public class CommandGeneratorTests
         var gen = new CommandGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "RefreshUser.Command.g.cs").SourceText.ToString();
-        Assert.Contains("public static global::System.Threading.Tasks.ValueTask ExecuteAsync", generated);
-        Assert.Contains("handler.Handle(command, ct)", generated);
-        Assert.True(updated.Emit(Stream.Null).Success);
+        ScenarioExpect.Contains("public static global::System.Threading.Tasks.ValueTask ExecuteAsync", generated);
+        ScenarioExpect.Contains("handler.Handle(command, ct)", generated);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
     }
 
+    [Scenario("ReportsCommandShapeDiagnostics")]
     [Theory]
     [InlineData("public readonly record struct RenameUser(string NewName);", "PKCMD001")]
     [InlineData("""
@@ -117,6 +122,6 @@ public class CommandGeneratorTests
         var gen = new CommandGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
-        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
+        ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == diagnosticId);
     }
 }

--- a/test/PatternKit.Generators.Tests/ComposerGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ComposerGeneratorTests.cs
@@ -1,9 +1,11 @@
 using Microsoft.CodeAnalysis;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class ComposerGeneratorTests
 {
+    [Scenario("BasicSyncPipeline GeneratesCorrectly")]
     [Fact]
     public void BasicSyncPipeline_GeneratesCorrectly()
     {
@@ -43,21 +45,22 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated the expected file
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("RequestPipeline.Composer.g.cs", names);
+        ScenarioExpect.Contains("RequestPipeline.Composer.g.cs", names);
 
         // Verify the generated source contains Invoke method
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("public global::PatternKit.Examples.Response Invoke(in global::PatternKit.Examples.Request input)", generatedSource);
+        ScenarioExpect.Contains("public global::PatternKit.Examples.Response Invoke(in global::PatternKit.Examples.Request input)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("AsyncPipeline WithValueTask GeneratesCorrectly")]
     [Fact]
     public void AsyncPipeline_WithValueTask_GeneratesCorrectly()
     {
@@ -95,23 +98,24 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated the expected file
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("AsyncRequestPipeline.Composer.g.cs", names);
+        ScenarioExpect.Contains("AsyncRequestPipeline.Composer.g.cs", names);
 
         // Verify the generated source contains InvokeAsync method
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("InvokeAsync", generatedSource);
-        Assert.Contains("ValueTask", generatedSource);
-        Assert.Contains("CancellationToken", generatedSource);
+        ScenarioExpect.Contains("InvokeAsync", generatedSource);
+        ScenarioExpect.Contains("ValueTask", generatedSource);
+        ScenarioExpect.Contains("CancellationToken", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("NotPartial ProducesDiagnostic")]
     [Fact]
     public void NotPartial_ProducesDiagnostic()
     {
@@ -140,10 +144,11 @@ public class ComposerGeneratorTests
 
         // Should have PKCOM001 diagnostic
         var diagnostics = result.Results[0].Diagnostics;
-        Assert.NotEmpty(diagnostics);
-        Assert.Contains(diagnostics, d => d.Id == "PKCOM001");
+        ScenarioExpect.NotEmpty(diagnostics);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKCOM001");
     }
 
+    [Scenario("NoSteps ProducesDiagnostic")]
     [Fact]
     public void NoSteps_ProducesDiagnostic()
     {
@@ -169,10 +174,11 @@ public class ComposerGeneratorTests
 
         // Should have PKCOM002 diagnostic
         var diagnostics = result.Results[0].Diagnostics;
-        Assert.NotEmpty(diagnostics);
-        Assert.Contains(diagnostics, d => d.Id == "PKCOM002");
+        ScenarioExpect.NotEmpty(diagnostics);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKCOM002");
     }
 
+    [Scenario("NoTerminal ProducesDiagnostic")]
     [Fact]
     public void NoTerminal_ProducesDiagnostic()
     {
@@ -198,10 +204,11 @@ public class ComposerGeneratorTests
 
         // Should have PKCOM004 diagnostic
         var diagnostics = result.Results[0].Diagnostics;
-        Assert.NotEmpty(diagnostics);
-        Assert.Contains(diagnostics, d => d.Id == "PKCOM004");
+        ScenarioExpect.NotEmpty(diagnostics);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKCOM004");
     }
 
+    [Scenario("MultipleTerminals ProducesDiagnostic")]
     [Fact]
     public void MultipleTerminals_ProducesDiagnostic()
     {
@@ -233,10 +240,11 @@ public class ComposerGeneratorTests
 
         // Should have PKCOM005 diagnostic
         var diagnostics = result.Results[0].Diagnostics;
-        Assert.NotEmpty(diagnostics);
-        Assert.Contains(diagnostics, d => d.Id == "PKCOM005");
+        ScenarioExpect.NotEmpty(diagnostics);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKCOM005");
     }
 
+    [Scenario("DuplicateOrder ProducesDiagnostic")]
     [Fact]
     public void DuplicateOrder_ProducesDiagnostic()
     {
@@ -268,10 +276,11 @@ public class ComposerGeneratorTests
 
         // Should have PKCOM003 diagnostic
         var diagnostics = result.Results[0].Diagnostics;
-        Assert.NotEmpty(diagnostics);
-        Assert.Contains(diagnostics, d => d.Id == "PKCOM003");
+        ScenarioExpect.NotEmpty(diagnostics);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKCOM003");
     }
 
+    [Scenario("StructType GeneratesCorrectly")]
     [Fact]
     public void StructType_GeneratesCorrectly()
     {
@@ -299,21 +308,22 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated the expected file
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("RequestPipeline.Composer.g.cs", names);
+        ScenarioExpect.Contains("RequestPipeline.Composer.g.cs", names);
 
         // Verify the generated source contains 'partial struct'
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("partial struct RequestPipeline", generatedSource);
+        ScenarioExpect.Contains("partial struct RequestPipeline", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("RecordClass GeneratesCorrectly")]
     [Fact]
     public void RecordClass_GeneratesCorrectly()
     {
@@ -341,21 +351,22 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated the expected file
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("RequestPipeline.Composer.g.cs", names);
+        ScenarioExpect.Contains("RequestPipeline.Composer.g.cs", names);
 
         // Verify the generated source contains 'partial record class'
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("partial record class RequestPipeline", generatedSource);
+        ScenarioExpect.Contains("partial record class RequestPipeline", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("RecordStruct GeneratesCorrectly")]
     [Fact]
     public void RecordStruct_GeneratesCorrectly()
     {
@@ -383,21 +394,22 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated the expected file
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("RequestPipeline.Composer.g.cs", names);
+        ScenarioExpect.Contains("RequestPipeline.Composer.g.cs", names);
 
         // Verify the generated source contains 'partial record struct'
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("partial record struct RequestPipeline", generatedSource);
+        ScenarioExpect.Contains("partial record struct RequestPipeline", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("OrderingOuterFirst WrapsCorrectly")]
     [Fact]
     public void OrderingOuterFirst_WrapsCorrectly()
     {
@@ -444,22 +456,23 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify the generated source
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
 
         // The pipeline should be built from terminal and wrapped by steps
-        Assert.Contains("pipeline", generatedSource);
-        Assert.Contains("First", generatedSource);
-        Assert.Contains("Second", generatedSource);
-        Assert.Contains("Terminal", generatedSource);
+        ScenarioExpect.Contains("pipeline", generatedSource);
+        ScenarioExpect.Contains("First", generatedSource);
+        ScenarioExpect.Contains("Second", generatedSource);
+        ScenarioExpect.Contains("Terminal", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("OrderingInnerFirst WrapsCorrectly")]
     [Fact]
     public void OrderingInnerFirst_WrapsCorrectly()
     {
@@ -506,22 +519,23 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify the generated source
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
 
         // The pipeline should be built from terminal and wrapped by steps
-        Assert.Contains("pipeline", generatedSource);
-        Assert.Contains("First", generatedSource);
-        Assert.Contains("Second", generatedSource);
-        Assert.Contains("Terminal", generatedSource);
+        ScenarioExpect.Contains("pipeline", generatedSource);
+        ScenarioExpect.Contains("First", generatedSource);
+        ScenarioExpect.Contains("Second", generatedSource);
+        ScenarioExpect.Contains("Terminal", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ComposeIgnoreAttribute SkipsMethod")]
     [Fact]
     public void ComposeIgnoreAttribute_SkipsMethod()
     {
@@ -553,20 +567,21 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify the generated source
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
 
         // Should only have pipeline using Step1, not Step2
-        Assert.Contains("Step1", generatedSource);
-        Assert.DoesNotContain("Step2", generatedSource);
+        ScenarioExpect.Contains("Step1", generatedSource);
+        ScenarioExpect.DoesNotContain("Step2", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("CustomInvokeMethodName GeneratesCorrectly")]
     [Fact]
     public void CustomInvokeMethodName_GeneratesCorrectly()
     {
@@ -594,18 +609,19 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify the generated source contains custom method name
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("public global::PatternKit.Examples.Response Execute(in global::PatternKit.Examples.Request input)", generatedSource);
-        Assert.DoesNotContain("public global::PatternKit.Examples.Response Invoke(in global::PatternKit.Examples.Request input)", generatedSource);
+        ScenarioExpect.Contains("public global::PatternKit.Examples.Response Execute(in global::PatternKit.Examples.Request input)", generatedSource);
+        ScenarioExpect.DoesNotContain("public global::PatternKit.Examples.Response Invoke(in global::PatternKit.Examples.Request input)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("SyncPipelineWithForceAsync GeneratesBoth")]
     [Fact]
     public void SyncPipelineWithForceAsync_GeneratesBoth()
     {
@@ -640,18 +656,19 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify the generated source contains both Invoke and InvokeAsync
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("public global::PatternKit.Examples.Response Invoke(in global::PatternKit.Examples.Request input)", generatedSource);
-        Assert.Contains("InvokeAsync", generatedSource);
+        ScenarioExpect.Contains("public global::PatternKit.Examples.Response Invoke(in global::PatternKit.Examples.Request input)", generatedSource);
+        ScenarioExpect.Contains("InvokeAsync", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("AsyncStruct GeneratesCorrectly")]
     [Fact]
     public void AsyncStruct_GeneratesCorrectly()
     {
@@ -689,18 +706,19 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify the generated source contains InvokeAsync method
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("InvokeAsync", generatedSource);
-        Assert.Contains("ValueTask", generatedSource);
+        ScenarioExpect.Contains("InvokeAsync", generatedSource);
+        ScenarioExpect.Contains("ValueTask", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("InvalidStepSignature ProducesDiagnostic")]
     [Fact]
     public void InvalidStepSignature_ProducesDiagnostic()
     {
@@ -732,10 +750,11 @@ public class ComposerGeneratorTests
 
         // Should have PKCOM006 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToList();
-        Assert.NotEmpty(diagnostics);
-        Assert.Contains(diagnostics, d => d.Id == "PKCOM006");
+        ScenarioExpect.NotEmpty(diagnostics);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKCOM006");
     }
 
+    [Scenario("InvalidTerminalSignature ProducesDiagnostic")]
     [Fact]
     public void InvalidTerminalSignature_ProducesDiagnostic()
     {
@@ -767,10 +786,11 @@ public class ComposerGeneratorTests
 
         // Should have PKCOM007 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToList();
-        Assert.NotEmpty(diagnostics);
-        Assert.Contains(diagnostics, d => d.Id == "PKCOM007");
+        ScenarioExpect.NotEmpty(diagnostics);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKCOM007");
     }
 
+    [Scenario("TrulyMixedSyncAndAsync GeneratesAsyncOnly")]
     [Fact]
     public void TrulyMixedSyncAndAsync_GeneratesAsyncOnly()
     {
@@ -812,17 +832,18 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify the generated source contains InvokeAsync (mixed scenario only generates async)
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("InvokeAsync", generatedSource);
+        ScenarioExpect.Contains("InvokeAsync", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StructComposer ForceAsync CustomNames InnerFirst CoversStructAsyncPipeline")]
     [Fact]
     public void StructComposer_ForceAsync_CustomNames_InnerFirst_CoversStructAsyncPipeline()
     {
@@ -858,20 +879,21 @@ public class ComposerGeneratorTests
         var gen = new ComposerGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("RunAsync", generatedSource);
-        Assert.Contains("var self = this;", generatedSource);
-        Assert.Contains("terminalFunc", generatedSource);
-        Assert.Contains("self.AuthAsync(arg, pipeline)", generatedSource);
-        Assert.Contains("self.Audit(in arg, inp => pipeline(inp).GetAwaiter().GetResult())", generatedSource);
-        Assert.DoesNotContain("public Response Run(", generatedSource);
+        ScenarioExpect.Contains("RunAsync", generatedSource);
+        ScenarioExpect.Contains("var self = this;", generatedSource);
+        ScenarioExpect.Contains("terminalFunc", generatedSource);
+        ScenarioExpect.Contains("self.AuthAsync(arg, pipeline)", generatedSource);
+        ScenarioExpect.Contains("self.Audit(in arg, inp => pipeline(inp).GetAwaiter().GetResult())", generatedSource);
+        ScenarioExpect.DoesNotContain("public Response Run(", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("AsyncSignatureWarnings WhenCancellationTokenIsWrongType")]
     [Fact]
     public void AsyncSignatureWarnings_WhenCancellationTokenIsWrongType()
     {
@@ -903,12 +925,13 @@ public class ComposerGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Equal(2, diagnostics.Count(d => d.Id == "PKCOM009"));
+        ScenarioExpect.Equal(2, diagnostics.Count(d => d.Id == "PKCOM009"));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.False(emit.Success);
+        ScenarioExpect.False(emit.Success);
     }
 
+    [Scenario("InvalidStep WithTooFewParameters ReportsDiagnostic")]
     [Fact]
     public void InvalidStep_WithTooFewParameters_ReportsDiagnostic()
     {
@@ -933,11 +956,12 @@ public class ComposerGeneratorTests
         var gen = new ComposerGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
-        var diagnostic = Assert.Single(result.Results.SelectMany(r => r.Diagnostics));
-        Assert.Equal("PKCOM006", diagnostic.Id);
-        Assert.Contains("Step", diagnostic.GetMessage(), StringComparison.Ordinal);
+        var diagnostic = ScenarioExpect.Single(result.Results.SelectMany(r => r.Diagnostics));
+        ScenarioExpect.Equal("PKCOM006", diagnostic.Id);
+        ScenarioExpect.Contains("Step", diagnostic.GetMessage(), StringComparison.Ordinal);
     }
 
+    [Scenario("InvalidTerminal WithTooManyParameters ReportsDiagnostic")]
     [Fact]
     public void InvalidTerminal_WithTooManyParameters_ReportsDiagnostic()
     {
@@ -962,11 +986,12 @@ public class ComposerGeneratorTests
         var gen = new ComposerGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
-        var diagnostic = Assert.Single(result.Results.SelectMany(r => r.Diagnostics));
-        Assert.Equal("PKCOM007", diagnostic.Id);
-        Assert.Contains("Terminal", diagnostic.GetMessage(), StringComparison.Ordinal);
+        var diagnostic = ScenarioExpect.Single(result.Results.SelectMany(r => r.Diagnostics));
+        ScenarioExpect.Equal("PKCOM007", diagnostic.Id);
+        ScenarioExpect.Contains("Terminal", diagnostic.GetMessage(), StringComparison.Ordinal);
     }
 
+    [Scenario("TaskBasedAsyncPipeline CustomAsyncName GeneratesTaskUnwrapAndNoCancellationTokenCalls")]
     [Fact]
     public void TaskBasedAsyncPipeline_CustomAsyncName_GeneratesTaskUnwrapAndNoCancellationTokenCalls()
     {
@@ -999,19 +1024,20 @@ public class ComposerGeneratorTests
         var gen = new ComposerGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
-        Assert.Contains("ExecuteAsync", generatedSource);
-        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(TerminalAsync(arg))", generatedSource);
-        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(SecondAsync(arg, pipeline))", generatedSource);
-        Assert.Contains("First(in arg, inp => prevPipeline(inp).GetAwaiter().GetResult())", generatedSource);
-        Assert.DoesNotContain("namespace ", generatedSource);
+        ScenarioExpect.Contains("ExecuteAsync", generatedSource);
+        ScenarioExpect.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(TerminalAsync(arg))", generatedSource);
+        ScenarioExpect.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(SecondAsync(arg, pipeline))", generatedSource);
+        ScenarioExpect.Contains("First(in arg, inp => prevPipeline(inp).GetAwaiter().GetResult())", generatedSource);
+        ScenarioExpect.DoesNotContain("namespace ", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StructTaskBasedAsyncPipeline WithCancellationToken WrapsTaskCalls")]
     [Fact]
     public void StructTaskBasedAsyncPipeline_WithCancellationToken_WrapsTaskCalls()
     {
@@ -1041,14 +1067,14 @@ public class ComposerGeneratorTests
         var gen = new ComposerGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
-        Assert.Contains("var self = this;", generatedSource);
-        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(self.TerminalAsync(arg, cancellationToken))", generatedSource);
-        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(self.StepAsync(arg, pipeline, cancellationToken))", generatedSource);
+        ScenarioExpect.Contains("var self = this;", generatedSource);
+        ScenarioExpect.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(self.TerminalAsync(arg, cancellationToken))", generatedSource);
+        ScenarioExpect.Contains("new global::System.Threading.Tasks.ValueTask<global::Response>(self.StepAsync(arg, pipeline, cancellationToken))", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 }

--- a/test/PatternKit.Generators.Tests/CompositeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/CompositeGeneratorTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Generators.Composite;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class CompositeGeneratorTests
 {
+    [Scenario("GeneratesCompositeBasesAndTraversalHelpers")]
     [Fact]
     public void GeneratesCompositeBasesAndTraversalHelpers()
     {
@@ -35,20 +37,21 @@ public class CompositeGeneratorTests
         var gen = new CompositeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
-        Assert.Contains(generated, s => s.HintName == "ICategory.Composite.g.cs");
-        Assert.Contains(generated, s => s.HintName == "ICategory.Composite.Traversal.g.cs");
+        ScenarioExpect.Contains(generated, s => s.HintName == "ICategory.Composite.g.cs");
+        ScenarioExpect.Contains(generated, s => s.HintName == "ICategory.Composite.Traversal.g.cs");
 
         var sourceText = generated.First(s => s.HintName == "ICategory.Composite.g.cs").SourceText.ToString();
-        Assert.Contains("public abstract partial class CategoryComponentBase : global::TestNamespace.ICategory", sourceText);
-        Assert.Contains("public override void Add(global::TestNamespace.ICategory child)", sourceText);
-        Assert.Contains("throw new global::System.NotSupportedException()", sourceText);
+        ScenarioExpect.Contains("public abstract partial class CategoryComponentBase : global::TestNamespace.ICategory", sourceText);
+        ScenarioExpect.Contains("public override void Add(global::TestNamespace.ICategory child)", sourceText);
+        ScenarioExpect.Contains("throw new global::System.NotSupportedException()", sourceText);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsDiagnosticWhenComponentIsNotPartial")]
     [Fact]
     public void ReportsDiagnosticWhenComponentIsNotPartial()
     {
@@ -69,9 +72,10 @@ public class CompositeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKCMP001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKCMP001");
     }
 
+    [Scenario("ReportsDiagnosticWhenComponentIsConcrete")]
     [Fact]
     public void ReportsDiagnosticWhenComponentIsConcrete()
     {
@@ -91,6 +95,6 @@ public class CompositeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKCMP002");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKCMP002");
     }
 }

--- a/test/PatternKit.Generators.Tests/ContentRouterGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ContentRouterGeneratorTests.cs
@@ -1,11 +1,13 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using PatternKit.Generators.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public sealed class ContentRouterGeneratorTests
 {
+    [Scenario("GeneratesContentRouterFactory")]
     [Fact]
     public void GeneratesContentRouterFactory()
     {
@@ -47,19 +49,20 @@ public sealed class ContentRouterGeneratorTests
         var gen = new ContentRouterGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
-        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
-        Assert.Equal("OrderRouter.ContentRouter.g.cs", generated.HintName);
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        ScenarioExpect.Equal("OrderRouter.ContentRouter.g.cs", generated.HintName);
         var text = generated.SourceText.ToString();
-        Assert.Contains(".When(IsWholesale).Then(Wholesale)", text);
-        Assert.Contains(".When(IsRetail).Then(Retail)", text);
-        Assert.Contains(".Default(Default)", text);
-        Assert.True(text.IndexOf("IsWholesale", StringComparison.Ordinal) < text.IndexOf("IsRetail", StringComparison.Ordinal));
+        ScenarioExpect.Contains(".When(IsWholesale).Then(Wholesale)", text);
+        ScenarioExpect.Contains(".When(IsRetail).Then(Retail)", text);
+        ScenarioExpect.Contains(".Default(Default)", text);
+        ScenarioExpect.True(text.IndexOf("IsWholesale", StringComparison.Ordinal) < text.IndexOf("IsRetail", StringComparison.Ordinal));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsDiagnosticForNonPartialRouter")]
     [Fact]
     public void ReportsDiagnosticForNonPartialRouter()
     {
@@ -85,10 +88,11 @@ public sealed class ContentRouterGeneratorTests
         var gen = new ContentRouterGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKCR001", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKCR001", diagnostic.Id);
     }
 
+    [Scenario("ReportsDiagnosticForMissingRoutes")]
     [Fact]
     public void ReportsDiagnosticForMissingRoutes()
     {
@@ -107,10 +111,11 @@ public sealed class ContentRouterGeneratorTests
         var gen = new ContentRouterGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKCR002", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKCR002", diagnostic.Id);
     }
 
+    [Scenario("ReportsDiagnosticForInvalidRouteSignature")]
     [Fact]
     public void ReportsDiagnosticForInvalidRouteSignature()
     {
@@ -136,10 +141,11 @@ public sealed class ContentRouterGeneratorTests
         var gen = new ContentRouterGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKCR003", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKCR003", diagnostic.Id);
     }
 
+    [Scenario("ReportsDiagnosticForInvalidDefaultSignature")]
     [Fact]
     public void ReportsDiagnosticForInvalidDefaultSignature()
     {
@@ -168,10 +174,11 @@ public sealed class ContentRouterGeneratorTests
         var gen = new ContentRouterGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKCR004", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKCR004", diagnostic.Id);
     }
 
+    [Scenario("ReportsDiagnosticForDuplicateRouteNameOrOrder")]
     [Fact]
     public void ReportsDiagnosticForDuplicateRouteNameOrOrder()
     {
@@ -201,8 +208,8 @@ public sealed class ContentRouterGeneratorTests
         var gen = new ContentRouterGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKCR005", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKCR005", diagnostic.Id);
     }
 
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)

--- a/test/PatternKit.Generators.Tests/DecoratorGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/DecoratorGeneratorTests.cs
@@ -1,9 +1,11 @@
 using Microsoft.CodeAnalysis;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class DecoratorGeneratorTests
 {
+    [Scenario("GenerateDecoratorForInterface BasicContract")]
     [Fact]
     public void GenerateDecoratorForInterface_BasicContract()
     {
@@ -25,11 +27,11 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Decorator class is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace_IStorage.Decorator.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace_IStorage.Decorator.g.cs", names);
 
         // Verify generated content contains expected elements
         var generatedSource = result.Results
@@ -37,23 +39,24 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IStorage.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.True(generatedSource.Length > 100, $"Generated source is too short ({generatedSource.Length} chars): {generatedSource}");
+        ScenarioExpect.True(generatedSource.Length > 100, $"Generated source is too short ({generatedSource.Length} chars): {generatedSource}");
 
         // The Inner property will use fully qualified names
-        Assert.Contains("StorageDecoratorBase", generatedSource);
-        Assert.Contains("protected", generatedSource);
-        Assert.Contains(" Inner ", generatedSource);
-        Assert.Contains("public virtual", generatedSource);
-        Assert.Contains("ReadFile", generatedSource);
-        Assert.Contains("WriteFile", generatedSource);
-        Assert.Contains("StorageDecorators", generatedSource);
-        Assert.Contains("Compose", generatedSource);
+        ScenarioExpect.Contains("StorageDecoratorBase", generatedSource);
+        ScenarioExpect.Contains("protected", generatedSource);
+        ScenarioExpect.Contains(" Inner ", generatedSource);
+        ScenarioExpect.Contains("public virtual", generatedSource);
+        ScenarioExpect.Contains("ReadFile", generatedSource);
+        ScenarioExpect.Contains("WriteFile", generatedSource);
+        ScenarioExpect.Contains("StorageDecorators", generatedSource);
+        ScenarioExpect.Contains("Compose", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface WithAsyncMethods")]
     [Fact]
     public void GenerateDecoratorForInterface_WithAsyncMethods()
     {
@@ -77,7 +80,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content contains async method forwarding (direct forwarding without async/await)
         var generatedSource = result.Results
@@ -85,18 +88,19 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IAsyncStorage.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public", generatedSource);
-        Assert.Contains("virtual", generatedSource);
-        Assert.Contains("ReadFileAsync", generatedSource);
-        Assert.Contains("=> Inner.ReadFileAsync", generatedSource);
-        Assert.Contains("WriteFileAsync", generatedSource);
-        Assert.Contains("=> Inner.WriteFileAsync", generatedSource);
+        ScenarioExpect.Contains("public", generatedSource);
+        ScenarioExpect.Contains("virtual", generatedSource);
+        ScenarioExpect.Contains("ReadFileAsync", generatedSource);
+        ScenarioExpect.Contains("=> Inner.ReadFileAsync", generatedSource);
+        ScenarioExpect.Contains("WriteFileAsync", generatedSource);
+        ScenarioExpect.Contains("=> Inner.WriteFileAsync", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface WithProperties")]
     [Fact]
     public void GenerateDecoratorForInterface_WithProperties()
     {
@@ -119,7 +123,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content contains properties
         var generatedSource = result.Results
@@ -127,17 +131,18 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IConfiguration.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public virtual string ApiKey", generatedSource);
-        Assert.Contains("get => Inner.ApiKey", generatedSource);
-        Assert.Contains("set => Inner.ApiKey = value", generatedSource);
-        Assert.Contains("public virtual int Timeout => Inner.Timeout", generatedSource);
-        Assert.Contains("public virtual bool IsEnabled", generatedSource);
+        ScenarioExpect.Contains("public virtual string ApiKey", generatedSource);
+        ScenarioExpect.Contains("get => Inner.ApiKey", generatedSource);
+        ScenarioExpect.Contains("set => Inner.ApiKey = value", generatedSource);
+        ScenarioExpect.Contains("public virtual int Timeout => Inner.Timeout", generatedSource);
+        ScenarioExpect.Contains("public virtual bool IsEnabled", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface WithDecoratorIgnore")]
     [Fact]
     public void GenerateDecoratorForInterface_WithDecoratorIgnore()
     {
@@ -161,7 +166,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content - ignored methods are still forwarded but not virtual
         var generatedSource = result.Results
@@ -169,9 +174,9 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IRepository.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("void Save", generatedSource);
-        Assert.Contains("virtual", generatedSource); // Save should be virtual
-        Assert.Contains("InternalMethod", generatedSource); // Still present, forwarded to Inner
+        ScenarioExpect.Contains("void Save", generatedSource);
+        ScenarioExpect.Contains("virtual", generatedSource); // Save should be virtual
+        ScenarioExpect.Contains("InternalMethod", generatedSource); // Still present, forwarded to Inner
 
         // InternalMethod should be present and non-virtual (i.e., not declared as virtual)
         // We can't easily check "public void InternalMethod" vs "public virtual void InternalMethod"
@@ -179,9 +184,10 @@ public class DecoratorGeneratorTests
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface CustomNames")]
     [Fact]
     public void GenerateDecoratorForInterface_CustomNames()
     {
@@ -202,7 +208,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify custom names are used
         var generatedSource = result.Results
@@ -210,14 +216,15 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IStorage.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("class CustomStorageDecorator", generatedSource);
-        Assert.Contains("class CustomHelpers", generatedSource);
+        ScenarioExpect.Contains("class CustomStorageDecorator", generatedSource);
+        ScenarioExpect.Contains("class CustomHelpers", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface NoCompositionHelpers")]
     [Fact]
     public void GenerateDecoratorForInterface_NoCompositionHelpers()
     {
@@ -238,7 +245,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify composition helpers are NOT generated
         var generatedSource = result.Results
@@ -246,15 +253,16 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IStorage.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("class StorageDecoratorBase", generatedSource);
-        Assert.DoesNotContain("class StorageDecorators", generatedSource);
-        Assert.DoesNotContain("public static IStorage Compose", generatedSource);
+        ScenarioExpect.Contains("class StorageDecoratorBase", generatedSource);
+        ScenarioExpect.DoesNotContain("class StorageDecorators", generatedSource);
+        ScenarioExpect.DoesNotContain("public static IStorage Compose", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForAbstractClass VirtualMembersOnly")]
     [Fact]
     public void GenerateDecoratorForAbstractClass_VirtualMembersOnly()
     {
@@ -277,7 +285,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify only virtual/abstract members are included
         var generatedSource = result.Results
@@ -286,16 +294,17 @@ public class DecoratorGeneratorTests
             .SourceText.ToString();
 
         // For abstract classes, methods use "override" not "virtual"
-        Assert.Contains("public override", generatedSource);
-        Assert.Contains("ReadFile", generatedSource);
-        Assert.Contains("WriteFile", generatedSource);
-        Assert.DoesNotContain("NonVirtualMethod", generatedSource);
+        ScenarioExpect.Contains("public override", generatedSource);
+        ScenarioExpect.Contains("ReadFile", generatedSource);
+        ScenarioExpect.Contains("WriteFile", generatedSource);
+        ScenarioExpect.DoesNotContain("NonVirtualMethod", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface WithDefaultParameters")]
     [Fact]
     public void GenerateDecoratorForInterface_WithDefaultParameters()
     {
@@ -318,7 +327,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify default parameters are preserved
         var generatedSource = result.Results
@@ -326,14 +335,15 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IStorage.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("int bufferSize = 4096", generatedSource);
-        Assert.Contains("bool append = false", generatedSource);
+        ScenarioExpect.Contains("int bufferSize = 4096", generatedSource);
+        ScenarioExpect.Contains("bool append = false", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface DeterministicOrdering")]
     [Fact]
     public void GenerateDecoratorForInterface_DeterministicOrdering()
     {
@@ -357,7 +367,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify members are ordered alphabetically
         var generatedSource = result.Results
@@ -370,15 +380,16 @@ public class DecoratorGeneratorTests
         var mangoIndex = generatedSource.IndexOf("void Mango");
         var zebraIndex = generatedSource.IndexOf("void Zebra");
 
-        Assert.True(appleIndex < bananaIndex);
-        Assert.True(bananaIndex < mangoIndex);
-        Assert.True(mangoIndex < zebraIndex);
+        ScenarioExpect.True(appleIndex < bananaIndex);
+        ScenarioExpect.True(bananaIndex < mangoIndex);
+        ScenarioExpect.True(mangoIndex < zebraIndex);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface WithRefParameters")]
     [Fact]
     public void GenerateDecoratorForInterface_WithRefParameters()
     {
@@ -401,7 +412,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify ref/out/in parameters are preserved
         var generatedSource = result.Results
@@ -409,15 +420,16 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_ICalculator.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("ref int value", generatedSource);
-        Assert.Contains("out int result", generatedSource);
-        Assert.Contains("in int value", generatedSource);
+        ScenarioExpect.Contains("ref int value", generatedSource);
+        ScenarioExpect.Contains("out int result", generatedSource);
+        ScenarioExpect.Contains("in int value", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface ComplexExample")]
     [Fact]
     public void GenerateDecoratorForInterface_ComplexExample()
     {
@@ -446,7 +458,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify all methods are generated correctly
         var generatedSource = result.Results
@@ -454,20 +466,21 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IStorage.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("OpenRead", generatedSource);
-        Assert.Contains("OpenReadAsync", generatedSource);
-        Assert.Contains("Write", generatedSource);
-        Assert.Contains("WriteAsync", generatedSource);
-        Assert.Contains("Exists", generatedSource);
-        Assert.Contains("Delete", generatedSource);
-        Assert.Contains("virtual", generatedSource);
+        ScenarioExpect.Contains("OpenRead", generatedSource);
+        ScenarioExpect.Contains("OpenReadAsync", generatedSource);
+        ScenarioExpect.Contains("Write", generatedSource);
+        ScenarioExpect.Contains("WriteAsync", generatedSource);
+        ScenarioExpect.Contains("Exists", generatedSource);
+        ScenarioExpect.Contains("Delete", generatedSource);
+        ScenarioExpect.Contains("virtual", generatedSource);
         // Async methods use direct forwarding (no async/await keywords)
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForInterface InheritedMembers")]
     [Fact]
     public void GenerateDecoratorForInterface_InheritedMembers()
     {
@@ -493,7 +506,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify inherited members are included
         var generatedSource = result.Results
@@ -501,14 +514,15 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IStorage.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public virtual string Read", generatedSource);
-        Assert.Contains("public virtual void Write", generatedSource);
+        ScenarioExpect.Contains("public virtual string Read", generatedSource);
+        ScenarioExpect.Contains("public virtual void Write", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("DecoratorComposition AppliesInCorrectOrder")]
     [Fact]
     public void DecoratorComposition_AppliesInCorrectOrder()
     {
@@ -568,13 +582,14 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Diagnostic PKDEC001 UnsupportedTargetType")]
     [Fact]
     public void Diagnostic_PKDEC001_UnsupportedTargetType()
     {
@@ -596,10 +611,11 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC001 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC001");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("ConcreteClass"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC001");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("ConcreteClass"));
     }
 
+    [Scenario("Diagnostic PKDEC002 UnsupportedMemberKind Event")]
     [Fact]
     public void Diagnostic_PKDEC002_UnsupportedMemberKind_Event()
     {
@@ -622,13 +638,14 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC002 diagnostic for the event
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Changed"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Changed"));
 
         // Generation should be skipped when PKDEC002 (error) is reported
         var generatedSources = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
-        Assert.Empty(generatedSources);
+        ScenarioExpect.Empty(generatedSources);
     }
 
+    [Scenario("Diagnostic PKDEC003 NameConflict BaseType")]
     [Fact]
     public void Diagnostic_PKDEC003_NameConflict_BaseType()
     {
@@ -655,9 +672,10 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC003 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC003" && d.GetMessage().Contains("ServiceDecoratorBase"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC003" && d.GetMessage().Contains("ServiceDecoratorBase"));
     }
 
+    [Scenario("Diagnostic PKDEC003 NameConflict HelpersType")]
     [Fact]
     public void Diagnostic_PKDEC003_NameConflict_HelpersType()
     {
@@ -684,9 +702,10 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC003 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC003" && d.GetMessage().Contains("ServiceDecorators"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC003" && d.GetMessage().Contains("ServiceDecorators"));
     }
 
+    [Scenario("Diagnostic PKDEC002 Indexer")]
     [Fact]
     public void Diagnostic_PKDEC002_Indexer()
     {
@@ -708,13 +727,14 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC002 diagnostic for the indexer
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Indexer"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Indexer"));
 
         // Generation should be skipped when PKDEC002 (error) is reported
         var generatedSources = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
-        Assert.Empty(generatedSources);
+        ScenarioExpect.Empty(generatedSources);
     }
 
+    [Scenario("Diagnostic PKDEC005 GenericContract")]
     [Fact]
     public void Diagnostic_PKDEC005_GenericContract()
     {
@@ -736,9 +756,10 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC005 diagnostic for the generic contract
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC005" && d.GetMessage().Contains("IGenericService"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC005" && d.GetMessage().Contains("IGenericService"));
     }
 
+    [Scenario("Diagnostic PKDEC002 InitOnlyProperty")]
     [Fact]
     public void Diagnostic_PKDEC002_InitOnlyProperty()
     {
@@ -762,13 +783,14 @@ public class DecoratorGeneratorTests
         // Should have PKDEC002 diagnostic for the init-only property
         // Init setters are incompatible with the decorator pattern
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Name"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Name"));
 
         // Generation should be skipped when PKDEC002 (error) is reported
         var generatedSources = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
-        Assert.Empty(generatedSources);
+        ScenarioExpect.Empty(generatedSources);
     }
 
+    [Scenario("GenerateDecoratorForAbstractClass WithInternalProtectedMembers")]
     [Fact]
     public void GenerateDecoratorForAbstractClass_WithInternalProtectedMembers()
     {
@@ -790,7 +812,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content contains correct accessibility
         var generatedSource = result.Results
@@ -798,16 +820,17 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_ServiceBase.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public override", generatedSource);
-        Assert.Contains("PublicMethod", generatedSource);
-        Assert.Contains("protected internal override", generatedSource);
-        Assert.Contains("ProtectedInternalMethod", generatedSource);
+        ScenarioExpect.Contains("public override", generatedSource);
+        ScenarioExpect.Contains("PublicMethod", generatedSource);
+        ScenarioExpect.Contains("protected internal override", generatedSource);
+        ScenarioExpect.Contains("ProtectedInternalMethod", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Diagnostic PKDEC002 GenericMethod")]
     [Fact]
     public void Diagnostic_PKDEC002_GenericMethod()
     {
@@ -829,13 +852,14 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC002 diagnostic for the generic method
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Generic method"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Generic method"));
 
         // Generation should be skipped when PKDEC002 (error) is reported
         var generatedSources = result.Results.SelectMany(r => r.GeneratedSources).ToArray();
-        Assert.Empty(generatedSources);
+        ScenarioExpect.Empty(generatedSources);
     }
 
+    [Scenario("GenerateDecoratorForInterface IgnoresStaticMembers")]
     [Fact]
     public void GenerateDecoratorForInterface_IgnoresStaticMembers()
     {
@@ -859,7 +883,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics for static members
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content contains only instance members
         var generatedSource = result.Results
@@ -867,16 +891,17 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IService.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("InstanceMethod", generatedSource);
-        Assert.Contains("InstanceProperty", generatedSource);
-        Assert.DoesNotContain("StaticMethod", generatedSource);
-        Assert.DoesNotContain("StaticProperty", generatedSource);
+        ScenarioExpect.Contains("InstanceMethod", generatedSource);
+        ScenarioExpect.Contains("InstanceProperty", generatedSource);
+        ScenarioExpect.DoesNotContain("StaticMethod", generatedSource);
+        ScenarioExpect.DoesNotContain("StaticProperty", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Diagnostic PKDEC004 PropertyWithProtectedSetter")]
     [Fact]
     public void Diagnostic_PKDEC004_PropertyWithProtectedSetter()
     {
@@ -898,9 +923,10 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC004 diagnostic for the property with protected setter
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC004" && d.GetMessage().Contains("Name"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC004" && d.GetMessage().Contains("Name"));
     }
 
+    [Scenario("GenerateDecoratorForInterface SupportsParamsModifier")]
     [Fact]
     public void GenerateDecoratorForInterface_SupportsParamsModifier()
     {
@@ -921,7 +947,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content preserves params modifier
         var generatedSource = result.Results
@@ -929,14 +955,15 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IService.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("params", generatedSource);
-        Assert.Contains("params string[] items", generatedSource);
+        ScenarioExpect.Contains("params", generatedSource);
+        ScenarioExpect.Contains("params string[] items", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForAbstractClass InheritsVirtualMembers")]
     [Fact]
     public void GenerateDecoratorForAbstractClass_InheritsVirtualMembers()
     {
@@ -962,7 +989,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content includes both base and derived methods
         var generatedSource = result.Results
@@ -970,14 +997,15 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_DerivedClass.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("BaseMethod", generatedSource);
-        Assert.Contains("DerivedMethod", generatedSource);
+        ScenarioExpect.Contains("BaseMethod", generatedSource);
+        ScenarioExpect.Contains("DerivedMethod", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Diagnostic PKDEC006 NestedType")]
     [Fact]
     public void Diagnostic_PKDEC006_NestedType()
     {
@@ -1002,9 +1030,10 @@ public class DecoratorGeneratorTests
 
         // Should have PKDEC006 diagnostic for nested type
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC006");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC006");
     }
 
+    [Scenario("GenerateDecoratorForInterface SupportsRefReturns")]
     [Fact]
     public void GenerateDecoratorForInterface_SupportsRefReturns()
     {
@@ -1026,7 +1055,7 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify generated content includes ref/ref readonly modifiers
         var generatedSource = result.Results
@@ -1034,14 +1063,15 @@ public class DecoratorGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IRefService.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("ref int GetRef()", generatedSource);
-        Assert.Contains("ref readonly int GetRefReadonly()", generatedSource);
+        ScenarioExpect.Contains("ref int GetRef()", generatedSource);
+        ScenarioExpect.Contains("ref readonly int GetRefReadonly()", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateDecoratorForAbstractClass PreservesAccessibilityRefsAndAccessors")]
     [Fact]
     public void GenerateDecoratorForAbstractClass_PreservesAccessibilityRefsAndAccessors()
     {
@@ -1070,30 +1100,31 @@ public class DecoratorGeneratorTests
         var gen = new DecoratorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.DoesNotContain(r.Diagnostics, d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKDEC004" && d.GetMessage().Contains("ProtectedOperation"));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.DoesNotContain(r.Diagnostics, d => d.Severity == DiagnosticSeverity.Error));
+        ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKDEC004" && d.GetMessage().Contains("ProtectedOperation"));
 
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "TestNamespace_RepositoryBase.Decorator.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public abstract partial class RepositoryBaseDecoratorBase", generatedSource);
-        Assert.Contains("override string Name", generatedSource);
-        Assert.Contains("internal set => Inner.Name = value;", generatedSource);
-        Assert.Contains("override int Version", generatedSource);
-        Assert.Contains("set => Inner.Version = value;", generatedSource);
-        Assert.Contains("public override void Copy(ref int source, out int destination, in bool enabled)", generatedSource);
-        Assert.Contains("Inner.Copy(ref source, out destination, in enabled);", generatedSource);
-        Assert.Contains("public override ref int GetCurrent()", generatedSource);
-        Assert.Contains("=> ref Inner.GetCurrent();", generatedSource);
-        Assert.Contains("public sealed override string Snapshot()", generatedSource);
-        Assert.Contains("RepositoryBaseDecorators", generatedSource);
+        ScenarioExpect.Contains("public abstract partial class RepositoryBaseDecoratorBase", generatedSource);
+        ScenarioExpect.Contains("override string Name", generatedSource);
+        ScenarioExpect.Contains("internal set => Inner.Name = value;", generatedSource);
+        ScenarioExpect.Contains("override int Version", generatedSource);
+        ScenarioExpect.Contains("set => Inner.Version = value;", generatedSource);
+        ScenarioExpect.Contains("public override void Copy(ref int source, out int destination, in bool enabled)", generatedSource);
+        ScenarioExpect.Contains("Inner.Copy(ref source, out destination, in enabled);", generatedSource);
+        ScenarioExpect.Contains("public override ref int GetCurrent()", generatedSource);
+        ScenarioExpect.Contains("=> ref Inner.GetCurrent();", generatedSource);
+        ScenarioExpect.Contains("public sealed override string Snapshot()", generatedSource);
+        ScenarioExpect.Contains("RepositoryBaseDecorators", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("DecoratorDiagnostics ForIndexerInitPropertyFieldAndNestedType")]
     [Fact]
     public void DecoratorDiagnostics_ForIndexerInitPropertyFieldAndNestedType()
     {
@@ -1123,10 +1154,10 @@ public class DecoratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Indexer"));
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Init-only property"));
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Changed"));
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Field"));
-        Assert.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("NestedType"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Indexer"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Init-only property"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Changed"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("Field"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKDEC002" && d.GetMessage().Contains("NestedType"));
     }
 }

--- a/test/PatternKit.Generators.Tests/DispatcherGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/DispatcherGeneratorTests.cs
@@ -1,9 +1,11 @@
 using Microsoft.CodeAnalysis;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class DispatcherGeneratorTests
 {
+    [Scenario("GeneratesDispatcherWithoutDiagnostics")]
     [Fact]
     public void GeneratesDispatcherWithoutDiagnostics()
     {
@@ -23,19 +25,20 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated expected files
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("AppDispatcher.g.cs", names);
-        Assert.Contains("AppDispatcher.Builder.g.cs", names);
-        Assert.Contains("AppDispatcher.Contracts.g.cs", names);
+        ScenarioExpect.Contains("AppDispatcher.g.cs", names);
+        ScenarioExpect.Contains("AppDispatcher.Builder.g.cs", names);
+        ScenarioExpect.Contains("AppDispatcher.Contracts.g.cs", names);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GeneratedCodeHasNoPatternKitDependency")]
     [Fact]
     public void GeneratedCodeHasNoPatternKitDependency()
     {
@@ -57,11 +60,12 @@ public class DispatcherGeneratorTests
         // Check that generated source doesn't reference PatternKit
         foreach (var text in run.Results.SelectMany(result => result.GeneratedSources.Select(generated => generated.SourceText.ToString())))
         {
-            Assert.DoesNotContain("using PatternKit", text);
-            Assert.DoesNotContain("PatternKit.", text);
+            ScenarioExpect.DoesNotContain("using PatternKit", text);
+            ScenarioExpect.DoesNotContain("PatternKit.", text);
         }
     }
 
+    [Scenario("CommandRegistration HappyPath")]
     [Fact]
     public void CommandRegistration_HappyPath()
     {
@@ -101,12 +105,12 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Load and run the demo
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -115,9 +119,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Echo: Hello", result);
+        ScenarioExpect.Equal("Echo: Hello", result);
     }
 
+    [Scenario("NotificationRegistration MultipleHandlers")]
     [Fact]
     public void NotificationRegistration_MultipleHandlers()
     {
@@ -161,12 +166,12 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Load and run
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -175,9 +180,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Email: alice|Audit: alice", result);
+        ScenarioExpect.Equal("Email: alice|Audit: alice", result);
     }
 
+    [Scenario("NotificationRegistration ZeroHandlers NoOp")]
     [Fact]
     public void NotificationRegistration_ZeroHandlers_NoOp()
     {
@@ -213,12 +219,12 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Load and run
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -227,9 +233,10 @@ public class DispatcherGeneratorTests
         var task = (Task<bool>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 
+    [Scenario("CommandPipeline PreAndPost")]
     [Fact]
     public void CommandPipeline_PreAndPost()
     {
@@ -275,12 +282,12 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Load and run
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -289,9 +296,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Pre|Handler|Post:10", result);
+        ScenarioExpect.Equal("Pre|Handler|Post:10", result);
     }
 
+    [Scenario("MissingCommandHandler ThrowsException")]
     [Fact]
     public void MissingCommandHandler_ThrowsException()
     {
@@ -336,12 +344,12 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Load and run
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -350,9 +358,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("ExpectedException", result);
+        ScenarioExpect.Equal("ExpectedException", result);
     }
 
+    [Scenario("StreamRegistration LazyEnumeration")]
     [Fact]
     public void StreamRegistration_LazyEnumeration()
     {
@@ -406,12 +415,12 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Load and run
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -420,9 +429,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("1,2,3,4,5", result);
+        ScenarioExpect.Equal("1,2,3,4,5", result);
     }
 
+    [Scenario("ContractsFile DefinesInterfaces")]
     [Fact]
     public void ContractsFile_DefinesInterfaces()
     {
@@ -445,17 +455,18 @@ public class DispatcherGeneratorTests
             .SelectMany(r => r.GeneratedSources)
             .FirstOrDefault(gs => gs.HintName == "AppDispatcher.Contracts.g.cs");
 
-        Assert.NotNull(contractsFile);
+        ScenarioExpect.NotNull(contractsFile);
 
         var text = contractsFile.SourceText.ToString();
-        Assert.Contains("interface ICommandHandler<TRequest, TResponse>", text);
-        Assert.Contains("interface INotificationHandler<TNotification>", text);
-        Assert.Contains("interface IStreamHandler<TRequest, TItem>", text);
-        Assert.Contains("delegate ValueTask<TResponse> CommandNext<TResponse>", text);
+        ScenarioExpect.Contains("interface ICommandHandler<TRequest, TResponse>", text);
+        ScenarioExpect.Contains("interface INotificationHandler<TNotification>", text);
+        ScenarioExpect.Contains("interface IStreamHandler<TRequest, TItem>", text);
+        ScenarioExpect.Contains("delegate ValueTask<TResponse> CommandNext<TResponse>", text);
     }
 
     #region Around Middleware Tests
 
+    [Scenario("AroundMiddleware SingleBehavior WrapsHandler")]
     [Fact]
     public void AroundMiddleware_SingleBehavior_WrapsHandler()
     {
@@ -511,11 +522,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -524,9 +535,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Around:Before|Handler:5|Around:After:10|Final:10", result);
+        ScenarioExpect.Equal("Around:Before|Handler:5|Around:After:10|Final:10", result);
     }
 
+    [Scenario("AroundMiddleware MultipleBehaviors ComposesInOrder")]
     [Fact]
     public void AroundMiddleware_MultipleBehaviors_ComposesInOrder()
     {
@@ -588,11 +600,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -603,9 +615,10 @@ public class DispatcherGeneratorTests
 
         // Order: 1 (outer) wraps 2 (inner)
         // Execution: Around1:Before -> Around2:Before -> Handler -> Around2:After -> Around1:After
-        Assert.Equal("Around1:Before|Around2:Before|Handler|Around2:After|Around1:After", result);
+        ScenarioExpect.Equal("Around1:Before|Around2:Before|Handler|Around2:After|Around1:After", result);
     }
 
+    [Scenario("AroundMiddleware ModifiesRequestAndResponse VerifiesNesting")]
     [Fact]
     public void AroundMiddleware_ModifiesRequestAndResponse_VerifiesNesting()
     {
@@ -658,11 +671,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -672,9 +685,10 @@ public class DispatcherGeneratorTests
         var result = task.Result;
 
         // Flow: 5 -> handler(5) -> inner(*2=10) -> outer(+10=20)
-        Assert.Equal(20, result);
+        ScenarioExpect.Equal(20, result);
     }
 
+    [Scenario("AroundMiddleware WithPreAndPost ExecutesInCorrectOrder")]
     [Fact]
     public void AroundMiddleware_WithPreAndPost_ExecutesInCorrectOrder()
     {
@@ -731,11 +745,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -745,13 +759,14 @@ public class DispatcherGeneratorTests
         var result = task.Result;
 
         // Expected: Pre -> Around Before -> Handler -> Around After -> Post
-        Assert.Equal("Pre|Around:Before|Handler|Around:After|Post", result);
+        ScenarioExpect.Equal("Pre|Around:Before|Handler|Around:After|Post", result);
     }
 
     #endregion
 
     #region OnError Handling Tests
 
+    [Scenario("OnError HandlerThrows ExecutesErrorHandler")]
     [Fact]
     public void OnError_HandlerThrows_ExecutesErrorHandler()
     {
@@ -813,11 +828,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -826,9 +841,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Handler:Throwing|OnError:TestError|Caught", result);
+        ScenarioExpect.Equal("Handler:Throwing|OnError:TestError|Caught", result);
     }
 
+    [Scenario("OnError PrePostAndOnError ExecutesCorrectly")]
     [Fact]
     public void OnError_PrePostAndOnError_ExecutesCorrectly()
     {
@@ -884,11 +900,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -898,13 +914,14 @@ public class DispatcherGeneratorTests
         var result = task.Result;
 
         // Pre runs, handler throws, OnError runs, Post does NOT run
-        Assert.Equal("Pre|OnError|Caught", result);
+        ScenarioExpect.Equal("Pre|OnError|Caught", result);
     }
 
     #endregion
 
     #region Stream Pipeline Tests
 
+    [Scenario("StreamPipeline PreHook ExecutesBeforeStream")]
     [Fact]
     public void StreamPipeline_PreHook_ExecutesBeforeStream()
     {
@@ -962,11 +979,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -975,13 +992,14 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("PreStream|Item:1|Item:2|Item:3", result);
+        ScenarioExpect.Equal("PreStream|Item:1|Item:2|Item:3", result);
     }
 
     #endregion
 
     #region Object Overload Tests
 
+    [Scenario("ObjectOverloads Send DispatchesCorrectly")]
     [Fact]
     public void ObjectOverloads_Send_DispatchesCorrectly()
     {
@@ -1030,11 +1048,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -1043,9 +1061,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Result:50", result);
+        ScenarioExpect.Equal("Result:50", result);
     }
 
+    [Scenario("ObjectOverloads Publish DispatchesCorrectly")]
     [Fact]
     public void ObjectOverloads_Publish_DispatchesCorrectly()
     {
@@ -1097,11 +1116,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -1110,9 +1129,10 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Handler:Test", result);
+        ScenarioExpect.Equal("Handler:Test", result);
     }
 
+    [Scenario("ObjectOverloads Stream DispatchesCorrectly")]
     [Fact]
     public void ObjectOverloads_Stream_DispatchesCorrectly()
     {
@@ -1180,11 +1200,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -1196,15 +1216,16 @@ public class DispatcherGeneratorTests
         // Should either be the expected result or an error message
         if (result.StartsWith("ERROR:"))
         {
-            Assert.Fail($"Test threw exception: {result}");
+            ScenarioExpect.Fail($"Test threw exception: {result}");
         }
-        Assert.Equal("10,11,12,13,14", result);
+        ScenarioExpect.Equal("10,11,12,13,14", result);
     }
 
     #endregion
 
     #region Module System Tests
 
+    [Scenario("ModuleSystem AddModule RegistersHandlers")]
     [Fact]
     public void ModuleSystem_AddModule_RegistersHandlers()
     {
@@ -1253,11 +1274,11 @@ public class DispatcherGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success);
+        ScenarioExpect.True(emitResult.Success);
 
         pe.Seek(0, SeekOrigin.Begin);
         var asm = System.Reflection.Assembly.Load(pe.ToArray());
@@ -1266,7 +1287,7 @@ public class DispatcherGeneratorTests
         var task = (Task<string>)run!.Invoke(null, null)!;
         var result = task.Result;
 
-        Assert.Equal("Module:Hello", result);
+        ScenarioExpect.Equal("Module:Hello", result);
     }
 
     #endregion

--- a/test/PatternKit.Generators.Tests/FacadeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/FacadeGeneratorTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using PatternKit.Common;
 using PatternKit.Creational.Builder;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -12,6 +13,7 @@ public class FacadeGeneratorTests
 
     #region Contract-First Tests
 
+    [Scenario("ContractFirst Interface Generates Implementation")]
     [Fact]
     public void ContractFirst_Interface_Generates_Implementation()
     {
@@ -51,14 +53,15 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
-        Assert.Contains(run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName),
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+        ScenarioExpect.Contains(run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName),
             name => name.Contains("BillingFacadeImpl"));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ContractFirst PartialClass Generates Implementation")]
     [Fact]
     public void ContractFirst_PartialClass_Generates_Implementation()
     {
@@ -98,11 +101,12 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ContractFirst AsyncMethods WithValueTask")]
     [Fact]
     public void ContractFirst_AsyncMethods_WithValueTask()
     {
@@ -137,11 +141,12 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ContractFirst CancellationToken Support")]
     [Fact]
     public void ContractFirst_CancellationToken_Support()
     {
@@ -177,11 +182,12 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ContractFirst MultipleSubsystemDependencies")]
     [Fact]
     public void ContractFirst_MultipleSubsystemDependencies()
     {
@@ -234,29 +240,30 @@ public class FacadeGeneratorTests
         // Note: Generator may report PKFCD004 for dependency-injected methods
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
         var hasFatalErrors = diagnostics.Any(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error && d.Id != "PKFCD004");
-        Assert.False(hasFatalErrors);
+        ScenarioExpect.False(hasFatalErrors);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify the generated facade has a constructor with dependencies
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
         var facadeType = asm.GetType("PatternKit.Examples.OrderFacadeImpl");
-        Assert.NotNull(facadeType);
+        ScenarioExpect.NotNull(facadeType);
 
         var ctor = facadeType!.GetConstructors()[0];
         var parameters = ctor.GetParameters();
-        Assert.Equal(2, parameters.Length);
-        Assert.Contains(parameters, p => p.ParameterType.Name == "InventoryService");
-        Assert.Contains(parameters, p => p.ParameterType.Name == "PaymentService");
+        ScenarioExpect.Equal(2, parameters.Length);
+        ScenarioExpect.Contains(parameters, p => p.ParameterType.Name == "InventoryService");
+        ScenarioExpect.Contains(parameters, p => p.ParameterType.Name == "PaymentService");
     }
 
+    [Scenario("ContractFirst ExecutionRouting Works")]
     [Fact]
     public void ContractFirst_ExecutionRouting_Works()
     {
@@ -298,12 +305,12 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -311,13 +318,14 @@ public class FacadeGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null);
 
-        Assert.True((bool)result!);
+        ScenarioExpect.True((bool)result!);
     }
 
     #endregion
 
     #region Host-First Tests
 
+    [Scenario("HostFirst StaticClass WithFacadeExpose")]
     [Fact]
     public void HostFirst_StaticClass_WithFacadeExpose()
     {
@@ -351,14 +359,15 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
-        Assert.Contains(run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName),
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+        ScenarioExpect.Contains(run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName),
             name => name.Contains("ShippingFacade"));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("HostFirst GeneratedFacadeTypeName")]
     [Fact]
     public void HostFirst_GeneratedFacadeTypeName()
     {
@@ -386,16 +395,17 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Default name should be ProductCatalogFacade
-        Assert.Contains(run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName),
+        ScenarioExpect.Contains(run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName),
             name => name.Contains("ProductCatalogFacade"));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("HostFirst DependencyInjection InConstructor")]
     [Fact]
     public void HostFirst_DependencyInjection_InConstructor()
     {
@@ -428,26 +438,27 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
         var facadeType = asm.GetType("PatternKit.Examples.DataFacade");
-        Assert.NotNull(facadeType);
+        ScenarioExpect.NotNull(facadeType);
 
         // Verify constructor takes DatabaseService
         var ctor = facadeType!.GetConstructors()[0];
-        Assert.Single(ctor.GetParameters());
-        Assert.Equal("DatabaseService", ctor.GetParameters()[0].ParameterType.Name);
+        ScenarioExpect.Single(ctor.GetParameters());
+        ScenarioExpect.Equal("DatabaseService", ctor.GetParameters()[0].ParameterType.Name);
     }
 
+    [Scenario("HostFirst PreservesNullableReturnAnnotations")]
     [Fact]
     public void HostFirst_PreservesNullableReturnAnnotations()
     {
@@ -482,16 +493,17 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
-        var generatedSource = Assert.Single(
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+        var generatedSource = ScenarioExpect.Single(
             run.Results.SelectMany(r => r.GeneratedSources),
             gs => gs.HintName.Contains("BillingFacade")).SourceText.ToString();
-        Assert.Contains("public global::PatternKit.Examples.Invoice? GetInvoice", generatedSource);
+        ScenarioExpect.Contains("public global::PatternKit.Examples.Invoice? GetInvoice", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("HostFirst StaticToInstance Transformation")]
     [Fact]
     public void HostFirst_StaticToInstance_Transformation()
     {
@@ -538,12 +550,12 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -551,13 +563,14 @@ public class FacadeGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("OK", result);
+        ScenarioExpect.Equal("OK", result);
     }
 
     #endregion
 
     #region Diagnostics Tests
 
+    [Scenario("Diagnostic PKFCD001 NonPartialType")]
     [Fact]
     public void Diagnostic_PKFCD001_NonPartialType()
     {
@@ -582,10 +595,11 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKFCD001");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("must be declared as partial"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFCD001");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("must be declared as partial"));
     }
 
+    [Scenario("Diagnostic PKFCD002 MissingMapping")]
     [Fact]
     public void Diagnostic_PKFCD002_MissingMapping()
     {
@@ -610,10 +624,11 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKFCD002");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("has no corresponding method marked with [FacadeMap]"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFCD002");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("has no corresponding method marked with [FacadeMap]"));
     }
 
+    [Scenario("Diagnostic PKFCD004 SignatureMismatch")]
     [Fact]
     public void Diagnostic_PKFCD004_SignatureMismatch()
     {
@@ -644,10 +659,11 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKFCD004");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("signature does not match"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFCD004");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("signature does not match"));
     }
 
+    [Scenario("Diagnostic PKFCD006 AsyncGenerationDisabled")]
     [Fact]
     public void Diagnostic_PKFCD006_AsyncGenerationDisabled()
     {
@@ -683,14 +699,15 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKFCD006");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("GenerateAsync is disabled"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFCD006");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("GenerateAsync is disabled"));
     }
 
     #endregion
 
     #region Integration Tests
 
+    [Scenario("Integration BillingFacade ContractFirst FullScenario")]
     [Fact]
     public void Integration_BillingFacade_ContractFirst_FullScenario()
     {
@@ -753,27 +770,28 @@ public class FacadeGeneratorTests
         // Note: Generator may report PKFCD004 for dependency-injected methods
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
         var hasFatalErrors = diagnostics.Any(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error && d.Id != "PKFCD004");
-        Assert.False(hasFatalErrors);
+        ScenarioExpect.False(hasFatalErrors);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify the facade compiles and has the expected structure
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
         var facadeType = asm.GetType("PatternKit.Examples.Billing.BillingFacadeImpl");
-        Assert.NotNull(facadeType);
+        ScenarioExpect.NotNull(facadeType);
 
         // Verify it has a constructor with the three dependencies
         var ctor = facadeType!.GetConstructors()[0];
-        Assert.Equal(3, ctor.GetParameters().Length);
+        ScenarioExpect.Equal(3, ctor.GetParameters().Length);
     }
 
+    [Scenario("Integration ShippingFacade HostFirst FullScenario")]
     [Fact]
     public void Integration_ShippingFacade_HostFirst_FullScenario()
     {
@@ -838,14 +856,14 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -853,9 +871,10 @@ public class FacadeGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("37.5,1-2 days", result);
+        ScenarioExpect.Equal("37.5,1-2 days", result);
     }
 
+    [Scenario("Integration DeterministicOrdering")]
     [Fact]
     public void Integration_DeterministicOrdering()
     {
@@ -897,10 +916,10 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSources = run.Results.SelectMany(r => r.GeneratedSources).ToList();
-        Assert.NotEmpty(generatedSources);
+        ScenarioExpect.NotEmpty(generatedSources);
 
         var generatedSource = generatedSources.First().SourceText.ToString();
 
@@ -910,15 +929,16 @@ public class FacadeGeneratorTests
         var mikeIndex = generatedSource.IndexOf("void Mike()");
         var zebraIndex = generatedSource.IndexOf("void Zebra()");
 
-        Assert.True(alphaIndex < charlieIndex);
-        Assert.True(charlieIndex < mikeIndex);
-        Assert.True(mikeIndex < zebraIndex);
+        ScenarioExpect.True(alphaIndex < charlieIndex);
+        ScenarioExpect.True(charlieIndex < mikeIndex);
+        ScenarioExpect.True(mikeIndex < zebraIndex);
     }
 
     #endregion
 
     #region Edge Cases Tests
 
+    [Scenario("EdgeCase EmptyFacade")]
     [Fact]
     public void EdgeCase_EmptyFacade()
     {
@@ -942,11 +962,12 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // Should generate successfully with no diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("EdgeCase FacadeIgnore Attribute")]
     [Fact]
     public void EdgeCase_FacadeIgnore_Attribute()
     {
@@ -981,12 +1002,13 @@ public class FacadeGeneratorTests
 
         // Should not report missing mapping for IgnoredMethod (using Ignore policy)
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.DoesNotContain(diagnostics, d => d.Id == "PKFCD002" && d.GetMessage().Contains("IgnoredMethod"));
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Id == "PKFCD002" && d.GetMessage().Contains("IgnoredMethod"));
 
         // Note: Interface will fail compilation since method isn't implemented
         // This is expected behavior - FacadeIgnore skips generation but doesn't affect the interface contract
     }
 
+    [Scenario("EdgeCase OptionalMethodNames")]
     [Fact]
     public void EdgeCase_OptionalMethodNames()
     {
@@ -1023,14 +1045,14 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -1038,9 +1060,10 @@ public class FacadeGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("default,custom", result);
+        ScenarioExpect.Equal("default,custom", result);
     }
 
+    [Scenario("EdgeCase ComplexReturnTypes")]
     [Fact]
     public void EdgeCase_ComplexReturnTypes()
     {
@@ -1087,14 +1110,14 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -1102,9 +1125,10 @@ public class FacadeGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null);
 
-        Assert.True((bool)result!);
+        ScenarioExpect.True((bool)result!);
     }
 
+    [Scenario("EdgeCase RefParameters")]
     [Fact]
     public void EdgeCase_RefParameters()
     {
@@ -1147,14 +1171,14 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -1162,9 +1186,10 @@ public class FacadeGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null);
 
-        Assert.True((bool)result!);
+        ScenarioExpect.True((bool)result!);
     }
 
+    [Scenario("EdgeCase SignatureMatching WithoutExplicitMemberName")]
     [Fact]
     public void EdgeCase_SignatureMatching_WithoutExplicitMemberName()
     {
@@ -1197,7 +1222,7 @@ public class FacadeGeneratorTests
 
         // Note: Signature auto-matching may have issues in the generator
         // Just verify it compiles without errors in generator diagnostics
-        Assert.All(run.Results, r => Assert.True(
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(
             r.Diagnostics.Length == 0 ||
             r.Diagnostics.All(d => d.Id != "PKFCD002"))); // No missing mapping error if it matched
 
@@ -1206,9 +1231,10 @@ public class FacadeGeneratorTests
         var hasCompileErrors = emit.Diagnostics.Any(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
 
         // Test passes if either: no generator diagnostics (matched) or compile succeeds
-        Assert.True(run.Results.All(r => r.Diagnostics.Length == 0) || !hasCompileErrors);
+        ScenarioExpect.True(run.Results.All(r => r.Diagnostics.Length == 0) || !hasCompileErrors);
     }
 
+    [Scenario("EdgeCase MultipleNamespaces")]
     [Fact]
     public void EdgeCase_MultipleNamespaces()
     {
@@ -1252,23 +1278,24 @@ public class FacadeGeneratorTests
         // Note: Generator may report PKFCD004 for dependency-injected methods
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
         var hasFatalErrors = diagnostics.Any(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error && d.Id != "PKFCD004");
-        Assert.False(hasFatalErrors);
+        ScenarioExpect.False(hasFatalErrors);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify the facade type was generated in the correct namespace
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
         var facadeType = asm.GetType("PatternKit.Examples.Facades.MultiNsFacadeImpl");
-        Assert.NotNull(facadeType);
+        ScenarioExpect.NotNull(facadeType);
     }
 
+    [Scenario("Diagnostic PKFCD003 DuplicateMappings")]
     [Fact]
     public void Diagnostic_PKFCD003_DuplicateMappings()
     {
@@ -1302,10 +1329,11 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKFCD003");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("has multiple methods marked with [FacadeMap]"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFCD003");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("has multiple methods marked with [FacadeMap]"));
     }
 
+    [Scenario("Diagnostic PKFCD005 TypeNameConflict")]
     [Fact]
     public void Diagnostic_PKFCD005_TypeNameConflict()
     {
@@ -1337,14 +1365,15 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKFCD005");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("conflicts with an existing type"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFCD005");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("conflicts with an existing type"));
     }
 
     #endregion
 
     #region Auto-Facade Mode Tests
 
+    [Scenario("AutoFacade SimpleExternalType GeneratesAllMembers")]
     [Fact]
     public void AutoFacade_SimpleExternalType_GeneratesAllMembers()
     {
@@ -1371,15 +1400,16 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("void Method1()", generatedSource);
-        Assert.Contains("int Method2(string arg)", generatedSource);
-        Assert.Contains("_target.Method1()", generatedSource);
-        Assert.Contains("return _target.Method2(arg)", generatedSource);
+        ScenarioExpect.Contains("void Method1()", generatedSource);
+        ScenarioExpect.Contains("int Method2(string arg)", generatedSource);
+        ScenarioExpect.Contains("_target.Method1()", generatedSource);
+        ScenarioExpect.Contains("return _target.Method2(arg)", generatedSource);
     }
 
+    [Scenario("AutoFacade WithInclude OnlyGeneratesSpecifiedMembers")]
     [Fact]
     public void AutoFacade_WithInclude_OnlyGeneratesSpecifiedMembers()
     {
@@ -1407,14 +1437,15 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("void Method1()", generatedSource);
-        Assert.Contains("void Method3()", generatedSource);
-        Assert.DoesNotContain("void Method2()", generatedSource);
+        ScenarioExpect.Contains("void Method1()", generatedSource);
+        ScenarioExpect.Contains("void Method3()", generatedSource);
+        ScenarioExpect.DoesNotContain("void Method2()", generatedSource);
     }
 
+    [Scenario("AutoFacade WithExclude GeneratesAllExceptExcluded")]
     [Fact]
     public void AutoFacade_WithExclude_GeneratesAllExceptExcluded()
     {
@@ -1442,14 +1473,15 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("void Method1()", generatedSource);
-        Assert.Contains("void Method3()", generatedSource);
-        Assert.DoesNotContain("void Method2()", generatedSource);
+        ScenarioExpect.Contains("void Method1()", generatedSource);
+        ScenarioExpect.Contains("void Method3()", generatedSource);
+        ScenarioExpect.DoesNotContain("void Method2()", generatedSource);
     }
 
+    [Scenario("AutoFacade WithMemberPrefix AppliesPrefix")]
     [Fact]
     public void AutoFacade_WithMemberPrefix_AppliesPrefix()
     {
@@ -1475,13 +1507,14 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("void ExternalLog(string message)", generatedSource);
-        Assert.DoesNotContain("void Log(string message)", generatedSource);
+        ScenarioExpect.Contains("void ExternalLog(string message)", generatedSource);
+        ScenarioExpect.DoesNotContain("void Log(string message)", generatedSource);
     }
 
+    [Scenario("AutoFacade MultipleAttributes GeneratesComposite")]
     [Fact]
     public void AutoFacade_MultipleAttributes_GeneratesComposite()
     {
@@ -1514,12 +1547,13 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("void L1Log1(string msg)", generatedSource);
-        Assert.Contains("void L2Log2(string msg)", generatedSource);
-        Assert.Contains("_logger1.Log1(msg)", generatedSource);
-        Assert.Contains("_logger2.Log2(msg)", generatedSource);
+        ScenarioExpect.Contains("void L1Log1(string msg)", generatedSource);
+        ScenarioExpect.Contains("void L2Log2(string msg)", generatedSource);
+        ScenarioExpect.Contains("_logger1.Log1(msg)", generatedSource);
+        ScenarioExpect.Contains("_logger2.Log2(msg)", generatedSource);
     }
 
+    [Scenario("AutoFacade GenericMethods PreservesTypeParameters")]
     [Fact]
     public void AutoFacade_GenericMethods_PreservesTypeParameters()
     {
@@ -1546,10 +1580,11 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("void Log<TState>(TState state)", generatedSource);
-        Assert.Contains("where TState : class", generatedSource);
+        ScenarioExpect.Contains("void Log<TState>(TState state)", generatedSource);
+        ScenarioExpect.Contains("where TState : class", generatedSource);
     }
 
+    [Scenario("AutoFacade InvalidTargetType ReportsDiagnostic")]
     [Fact]
     public void AutoFacade_InvalidTargetType_ReportsDiagnostic()
     {
@@ -1571,9 +1606,10 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         var diagnostics = run.Results[0].Diagnostics;
-        Assert.Contains(diagnostics, d => d.Id == "PKFAC001");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFAC001");
     }
 
+    [Scenario("AutoFacade BothIncludeAndExclude ReportsDiagnostic")]
     [Fact]
     public void AutoFacade_BothIncludeAndExclude_ReportsDiagnostic()
     {
@@ -1604,9 +1640,10 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         var diagnostics = run.Results[0].Diagnostics;
-        Assert.Contains(diagnostics, d => d.Id == "PKFAC002");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFAC002");
     }
 
+    [Scenario("AutoFacade IncludeNonExistentMember ReportsDiagnostic")]
     [Fact]
     public void AutoFacade_IncludeNonExistentMember_ReportsDiagnostic()
     {
@@ -1634,9 +1671,10 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         var diagnostics = run.Results[0].Diagnostics;
-        Assert.Contains(diagnostics, d => d.Id == "PKFAC004" && d.GetMessage().Contains("NonExistent"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFAC004" && d.GetMessage().Contains("NonExistent"));
     }
 
+    [Scenario("AutoFacade RefOutInParameters ForwardsCorrectly")]
     [Fact]
     public void AutoFacade_RefOutInParameters_ForwardsCorrectly()
     {
@@ -1664,17 +1702,18 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("void MethodWithRef(ref int value)", generatedSource);
-        Assert.Contains("void MethodWithOut(out string result)", generatedSource);
-        Assert.Contains("void MethodWithIn(in double value)", generatedSource);
-        Assert.Contains("_target.MethodWithRef(ref value)", generatedSource);
-        Assert.Contains("_target.MethodWithOut(out result)", generatedSource);
-        Assert.Contains("_target.MethodWithIn(in value)", generatedSource);
+        ScenarioExpect.Contains("void MethodWithRef(ref int value)", generatedSource);
+        ScenarioExpect.Contains("void MethodWithOut(out string result)", generatedSource);
+        ScenarioExpect.Contains("void MethodWithIn(in double value)", generatedSource);
+        ScenarioExpect.Contains("_target.MethodWithRef(ref value)", generatedSource);
+        ScenarioExpect.Contains("_target.MethodWithOut(out result)", generatedSource);
+        ScenarioExpect.Contains("_target.MethodWithIn(in value)", generatedSource);
     }
 
+    [Scenario("AutoFacade OnNonInterface ReportsDiagnostic")]
     [Fact]
     public void AutoFacade_OnNonInterface_ReportsDiagnostic()
     {
@@ -1701,9 +1740,10 @@ public class FacadeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         var diagnostics = run.Results[0].Diagnostics;
-        Assert.Contains(diagnostics, d => d.Id == "PKFAC005");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKFAC005");
     }
 
+    [Scenario("AutoFacade InterfaceWithMultipleLeadingI OnlyRemovesFirstI")]
     [Fact]
     public void AutoFacade_InterfaceWithMultipleLeadingI_OnlyRemovesFirstI()
     {
@@ -1729,13 +1769,14 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Should generate IIMyFacadeImpl (only first I removed from IIMyFacade)
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("public sealed class IMyFacadeImpl : IIMyFacade", generatedSource);
+        ScenarioExpect.Contains("public sealed class IMyFacadeImpl : IIMyFacade", generatedSource);
     }
 
+    [Scenario("AutoFacade FieldNameWithoutUnderscore UsesThisQualifier")]
     [Fact]
     public void AutoFacade_FieldNameWithoutUnderscore_UsesThisQualifier()
     {
@@ -1761,15 +1802,16 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results[0].GeneratedSources[0].SourceText.ToString();
         // Field name is "myTarget", parameter name is also "myTarget", so should use "this." qualifier
-        Assert.Contains("private readonly global::TestNs.IExternal myTarget;", generatedSource);
-        Assert.Contains("public MyFacadeImpl(global::TestNs.IExternal myTarget)", generatedSource);
-        Assert.Contains("this.myTarget = myTarget ?? throw new System.ArgumentNullException(nameof(myTarget));", generatedSource);
+        ScenarioExpect.Contains("private readonly global::TestNs.IExternal myTarget;", generatedSource);
+        ScenarioExpect.Contains("public MyFacadeImpl(global::TestNs.IExternal myTarget)", generatedSource);
+        ScenarioExpect.Contains("this.myTarget = myTarget ?? throw new System.ArgumentNullException(nameof(myTarget));", generatedSource);
     }
 
+    [Scenario("ContractFirst MissingMapIgnore CoversAsyncDefaultReturnBranches")]
     [Fact]
     public void ContractFirst_MissingMapIgnore_CoversAsyncDefaultReturnBranches()
     {
@@ -1799,19 +1841,20 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
-        Assert.Contains("ValueTask.FromResult<string>(default!)", generatedSource);
-        Assert.Contains("Task.FromResult<int>(default!)", generatedSource);
-        Assert.Contains("ValueTask.CompletedTask", generatedSource);
-        Assert.Contains("Task.CompletedTask", generatedSource);
-        Assert.Contains("return default!;", generatedSource);
+        ScenarioExpect.Contains("ValueTask.FromResult<string>(default!)", generatedSource);
+        ScenarioExpect.Contains("Task.FromResult<int>(default!)", generatedSource);
+        ScenarioExpect.Contains("ValueTask.CompletedTask", generatedSource);
+        ScenarioExpect.Contains("Task.CompletedTask", generatedSource);
+        ScenarioExpect.Contains("return default!;", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("HostFirst GenericConstraintsAndDependencyNameCollisions GenerateCompilableFacade")]
     [Fact]
     public void HostFirst_GenericConstraintsAndDependencyNameCollisions_GenerateCompilableFacade()
     {
@@ -1866,24 +1909,25 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generatedSource = run.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
-        Assert.Contains("where T : class, new()", generatedSource);
-        Assert.Contains("where T : notnull, global::System.IComparable<T>", generatedSource);
-        Assert.Contains("where TNumber : unmanaged", generatedSource);
-        Assert.Contains("private readonly global::TestNs.IService _service;", generatedSource);
-        Assert.Contains("private readonly global::TestNs.Request _request;", generatedSource);
-        Assert.Contains("private readonly global::TestNs.Alpha.IClient _client;", generatedSource);
-        Assert.Contains("private readonly global::TestNs.Beta.IClient _client1;", generatedSource);
-        Assert.Contains("T value", generatedSource);
-        Assert.Contains("TNumber value", generatedSource);
-        Assert.Contains("Choose", generatedSource);
+        ScenarioExpect.Contains("where T : class, new()", generatedSource);
+        ScenarioExpect.Contains("where T : notnull, global::System.IComparable<T>", generatedSource);
+        ScenarioExpect.Contains("where TNumber : unmanaged", generatedSource);
+        ScenarioExpect.Contains("private readonly global::TestNs.IService _service;", generatedSource);
+        ScenarioExpect.Contains("private readonly global::TestNs.Request _request;", generatedSource);
+        ScenarioExpect.Contains("private readonly global::TestNs.Alpha.IClient _client;", generatedSource);
+        ScenarioExpect.Contains("private readonly global::TestNs.Beta.IClient _client1;", generatedSource);
+        ScenarioExpect.Contains("T value", generatedSource);
+        ScenarioExpect.Contains("TNumber value", generatedSource);
+        ScenarioExpect.Contains("Choose", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("AutoFacade NoPublicMethods ReportsDiagnostic")]
     [Fact]
     public void AutoFacade_NoPublicMethods_ReportsDiagnostic()
     {
@@ -1909,7 +1953,7 @@ public class FacadeGeneratorTests
         var gen = new FacadeGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        Assert.Contains(run.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKFAC003");
+        ScenarioExpect.Contains(run.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKFAC003");
     }
 
     #endregion

--- a/test/PatternKit.Generators.Tests/FactoriesGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/FactoriesGeneratorTests.cs
@@ -1,11 +1,13 @@
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using PatternKit.Generators.Factories;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class FactoriesGeneratorTests
 {
+    [Scenario("FactoryMethod Generates Sync Create And TryCreate")]
     [Fact]
     public void FactoryMethod_Generates_Sync_Create_And_TryCreate()
     {
@@ -42,21 +44,22 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
-        Assert.Contains("MimeFactory.FactoryMethod.g.cs",
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.Contains("MimeFactory.FactoryMethod.g.cs",
             run.Results.SelectMany(r => r.GeneratedSources).Select(g => g.HintName));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var emit = updated.Emit(pe, pdb);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
         pe.Position = 0;
         pdb.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
         var runResult = asm.GetType("Demo.Runner")!.GetMethod("Run")!.Invoke(null, null);
-        Assert.Equal("application/json|True|application/json|False|application/octet-stream", runResult);
+        ScenarioExpect.Equal("application/json|True|application/json|False|application/octet-stream", runResult);
     }
 
+    [Scenario("FactoryMethod Async Methods Use ValueTask")]
     [Fact]
     public async Task FactoryMethod_Async_Methods_Use_ValueTask()
     {
@@ -84,13 +87,13 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
         var hintNames = run.Results.SelectMany(r => r.GeneratedSources).Select(g => g.HintName).ToArray();
-        Assert.Contains("NumberNames.FactoryMethod.g.cs", hintNames);
+        ScenarioExpect.Contains("NumberNames.FactoryMethod.g.cs", hintNames);
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
@@ -99,13 +102,14 @@ public class FactoriesGeneratorTests
         var tryCreateAsync = type.GetMethod("TryCreateAsync")!;
 
         var task = (ValueTask<string>)createAsync.Invoke(null, new object?[] { 1 })!;
-        Assert.Equal("one", await task);
+        ScenarioExpect.Equal("one", await task);
 
         var tuple = await ((ValueTask<(bool Success, string Result)>)tryCreateAsync.Invoke(null, [2])!);
-        Assert.False(tuple.Success);
-        Assert.Equal("other", tuple.Result);
+        ScenarioExpect.False(tuple.Success);
+        ScenarioExpect.Equal("other", tuple.Result);
     }
 
+    [Scenario("FactoryClass Generates Create And TryCreate")]
     [Fact]
     public void FactoryClass_Generates_Create_And_TryCreate()
     {
@@ -131,14 +135,14 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
-        Assert.Contains("MessageFactory.FactoryClass.g.cs",
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.Contains("MessageFactory.FactoryClass.g.cs",
             run.Results.SelectMany(r => r.GeneratedSources).Select(g => g.HintName));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var emit = updated.Emit(pe, pdb);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         pe.Position = 0;
         pdb.Position = 0;
@@ -147,14 +151,15 @@ public class FactoriesGeneratorTests
         dynamic factory = Activator.CreateInstance(factoryType)!;
 
         var email = factoryType.GetMethod("Create")!.Invoke(factory, new object?[] { "email" });
-        Assert.Equal("Demo.Email", email!.GetType().FullName);
+        ScenarioExpect.Equal("Demo.Email", email!.GetType().FullName);
 
         var args = new object?[] { "sms", null };
         var success = (bool)factoryType.GetMethod("TryCreate")!.Invoke(factory, args)!;
-        Assert.True(success);
-        Assert.Equal("Demo.Sms", args[1]!.GetType().FullName);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("Demo.Sms", args[1]!.GetType().FullName);
     }
 
+    [Scenario("FactoryClass Emits Enum Keys And Overloads")]
     [Fact]
     public void FactoryClass_Emits_Enum_Keys_And_Overloads()
     {
@@ -180,12 +185,12 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var emit = updated.Emit(pe, pdb);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         pe.Position = 0;
         pdb.Position = 0;
@@ -200,16 +205,17 @@ public class FactoriesGeneratorTests
 
         var createEnum = factoryType.GetMethod("Create", new[] { enumType })!;
         var email = createEnum.Invoke(factory, new[] { emailKey });
-        Assert.Equal("Demo.Email", email!.GetType().FullName);
+        ScenarioExpect.Equal("Demo.Email", email!.GetType().FullName);
 
         var tryCreateEnum = factoryType.GetMethods()
             .Single(m => m.Name == "TryCreate" && m.GetParameters()[0].ParameterType == enumType);
         object?[] args = [smsKey, null];
         var success = (bool)tryCreateEnum.Invoke(factory, args)!;
-        Assert.True(success);
-        Assert.Equal("Demo.Sms", args[1]!.GetType().FullName);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("Demo.Sms", args[1]!.GetType().FullName);
     }
 
+    [Scenario("FactoryMethod Requires Static Partial")]
     [Fact]
     public void FactoryMethod_Requires_Static_Partial()
     {
@@ -234,9 +240,10 @@ public class FactoriesGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diags = run.Results.Single().Diagnostics;
-        Assert.Contains(diags, d => d.Id == "PKKF001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKKF001");
     }
 
+    [Scenario("FactoryMethod Detects Signature Mismatch And Duplicate Keys")]
     [Fact]
     public void FactoryMethod_Detects_Signature_Mismatch_And_Duplicate_Keys()
     {
@@ -267,10 +274,11 @@ public class FactoriesGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diags = run.Results.Single().Diagnostics;
-        Assert.Contains(diags, d => d.Id == "PKKF002");
-        Assert.Contains(diags, d => d.Id == "PKKF003");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKKF002");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKKF003");
     }
 
+    [Scenario("FactoryMethod Rejects NonStatic Methods")]
     [Fact]
     public void FactoryMethod_Rejects_NonStatic_Methods()
     {
@@ -295,9 +303,10 @@ public class FactoriesGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diags = run.Results.Single().Diagnostics;
-        Assert.Contains(diags, d => d.Id == "PKKF006");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKKF006");
     }
 
+    [Scenario("FactoryMethod Honors String Case Sensitivity")]
     [Fact]
     public void FactoryMethod_Honors_String_Case_Sensitivity()
     {
@@ -330,18 +339,19 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var runResult = asm.GetType("Demo.Runner")!.GetMethod("Run")!.Invoke(null, null);
-        Assert.Equal("False|<null>", runResult);
+        ScenarioExpect.Equal("False|<null>", runResult);
     }
 
+    [Scenario("FactoryClass Requires Interface Or Abstract Base")]
     [Fact]
     public void FactoryClass_Requires_Interface_Or_Abstract_Base()
     {
@@ -362,9 +372,10 @@ public class FactoriesGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diags = run.Results.Single().Diagnostics;
-        Assert.Contains(diags, d => d.Id == "PKCF001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKCF001");
     }
 
+    [Scenario("FactoryClass Detects Duplicate Keys And Invalid Types")]
     [Fact]
     public void FactoryClass_Detects_Duplicate_Keys_And_Invalid_Types()
     {
@@ -394,10 +405,11 @@ public class FactoriesGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diags = run.Results.Single().Diagnostics;
-        Assert.Contains(diags, d => d.Id == "PKCF004");
-        Assert.Contains(diags, d => d.Id == "PKCF005");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKCF004");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKCF005");
     }
 
+    [Scenario("FactoryClass Flags Missing Ctor")]
     [Fact]
     public void FactoryClass_Flags_Missing_Ctor()
     {
@@ -424,9 +436,10 @@ public class FactoriesGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diags = run.Results.Single().Diagnostics;
-        Assert.Contains(diags, d => d.Id == "PKCF006");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKCF006");
     }
 
+    [Scenario("FactoryClass Respects GenerateTryCreate Flag")]
     [Fact]
     public void FactoryClass_Respects_GenerateTryCreate_Flag()
     {
@@ -449,20 +462,21 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var factoryType = asm.GetType("Demo.CommandFactory")!;
         var commandType = asm.GetType("Demo.ICommand")!;
-        Assert.NotNull(factoryType.GetMethod("Create", new[] { typeof(string) }));
-        Assert.Null(factoryType.GetMethod("TryCreate", new[] { typeof(string), commandType.MakeByRefType() }));
+        ScenarioExpect.NotNull(factoryType.GetMethod("Create", new[] { typeof(string) }));
+        ScenarioExpect.Null(factoryType.GetMethod("TryCreate", new[] { typeof(string), commandType.MakeByRefType() }));
     }
 
+    [Scenario("FactoryClass Uses CreateAsync When Available")]
     [Fact]
     public void FactoryClass_Uses_CreateAsync_When_Available()
     {
@@ -492,11 +506,11 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         pe.Position = 0;
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
@@ -505,14 +519,15 @@ public class FactoriesGeneratorTests
 
         var sync = factoryType.GetMethod("Create")!;
         var asyncResult = sync.Invoke(factory, new object?[] { "async" });
-        Assert.Equal("Demo.AsyncService", asyncResult!.GetType().FullName);
+        ScenarioExpect.Equal("Demo.AsyncService", asyncResult!.GetType().FullName);
 
         var createAsync = factoryType.GetMethod("CreateAsync", new[] { typeof(string) })!;
         var vtObj = createAsync.Invoke(factory, new object?[] { "sync" })!;
         var awaited = vtObj.GetAwaiter().GetResult();
-        Assert.Equal("Demo.SyncService", ((object)awaited).GetType().FullName);
+        ScenarioExpect.Equal("Demo.SyncService", ((object)awaited).GetType().FullName);
     }
 
+    [Scenario("FactoryGenerators Work In DI Orchestrator Scenario")]
     [Fact]
     public void FactoryGenerators_Work_In_DI_Orchestrator_Scenario()
     {
@@ -576,13 +591,14 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
 
         using var pe = new MemoryStream();
         var emit = updated.Emit(pe);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("FactoryMethod Async String NoDefault WithParameters EmitsNullAndCaseBranches")]
     [Fact]
     public void FactoryMethod_Async_String_NoDefault_WithParameters_EmitsNullAndCaseBranches()
     {
@@ -607,22 +623,23 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
         var generated = run.Results.SelectMany(r => r.GeneratedSources)
             .Single(g => g.HintName == "FormatterFactory.FactoryMethod.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("if (key is null) throw new global::System.ArgumentNullException", generated);
-        Assert.Contains("StringComparison.OrdinalIgnoreCase", generated);
-        Assert.Contains("ResolveAsync", generated);
-        Assert.Contains("return (false, default!);", generated);
-        Assert.Contains("JsonAsync(payload, indent)", generated);
-        Assert.Contains("XmlAsync(payload, indent)", generated);
+        ScenarioExpect.Contains("if (key is null) throw new global::System.ArgumentNullException", generated);
+        ScenarioExpect.Contains("StringComparison.OrdinalIgnoreCase", generated);
+        ScenarioExpect.Contains("ResolveAsync", generated);
+        ScenarioExpect.Contains("return (false, default!);", generated);
+        ScenarioExpect.Contains("JsonAsync(payload, indent)", generated);
+        ScenarioExpect.Contains("XmlAsync(payload, indent)", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("FactoryMethod Async Numeric NoDefault EmitsSwitchBranches")]
     [Fact]
     public void FactoryMethod_Async_Numeric_NoDefault_EmitsSwitchBranches()
     {
@@ -647,21 +664,22 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
         var generated = run.Results.SelectMany(r => r.GeneratedSources)
             .Single(g => g.HintName == "NumberFactory.FactoryMethod.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("switch (key)", generated);
-        Assert.Contains("case 1:", generated);
-        Assert.Contains("default:", generated);
-        Assert.Contains("throw new global::System.ArgumentOutOfRangeException(nameof(key));", generated);
-        Assert.Contains("return (false, default!);", generated);
+        ScenarioExpect.Contains("switch (key)", generated);
+        ScenarioExpect.Contains("case 1:", generated);
+        ScenarioExpect.Contains("default:", generated);
+        ScenarioExpect.Contains("throw new global::System.ArgumentOutOfRangeException(nameof(key));", generated);
+        ScenarioExpect.Contains("return (false, default!);", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("FactoryClass AsyncEnumKeysAndFactoryMethods CoverCreationBranches")]
     [Fact]
     public void FactoryClass_AsyncEnumKeysAndFactoryMethods_CoverCreationBranches()
     {
@@ -693,22 +711,23 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
         var generated = run.Results.SelectMany(r => r.GeneratedSources)
             .Single(g => g.HintName == "ChannelFactory.FactoryClass.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public global::System.Threading.Tasks.ValueTask<global::Demo.ChannelHandler> CreateAsync(Keys key)", generated);
-        Assert.Contains("TryCreateAsync(Keys key)", generated);
-        Assert.Contains("return CreateAsync(MapKey(key));", generated);
-        Assert.Contains("new global::System.Threading.Tasks.ValueTask<global::Demo.ChannelHandler>", generated);
-        Assert.Contains("SmsHandler.CreateAsync", generated);
-        Assert.Contains("PushHandler.CreateAsync", generated);
+        ScenarioExpect.Contains("public global::System.Threading.Tasks.ValueTask<global::Demo.ChannelHandler> CreateAsync(Keys key)", generated);
+        ScenarioExpect.Contains("TryCreateAsync(Keys key)", generated);
+        ScenarioExpect.Contains("return CreateAsync(MapKey(key));", generated);
+        ScenarioExpect.Contains("new global::System.Threading.Tasks.ValueTask<global::Demo.ChannelHandler>", generated);
+        ScenarioExpect.Contains("SmsHandler.CreateAsync", generated);
+        ScenarioExpect.Contains("PushHandler.CreateAsync", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("FactoryClass StringKeysGenerateStableEnumNamesAndNullComparers")]
     [Fact]
     public void FactoryClass_StringKeysGenerateStableEnumNamesAndNullComparers()
     {
@@ -734,20 +753,21 @@ public class FactoriesGeneratorTests
         var gen = new FactoriesGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.IsEmpty));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.IsEmpty));
         var generated = run.Results.SelectMany(r => r.GeneratedSources)
             .Single(g => g.HintName == "TransportFactory.FactoryClass.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("Key1Http", generated);
-        Assert.Contains("Key1Http2", generated);
-        Assert.Contains("Key", generated);
-        Assert.Contains("MapKey", generated);
+        ScenarioExpect.Contains("Key1Http", generated);
+        ScenarioExpect.Contains("Key1Http2", generated);
+        ScenarioExpect.Contains("Key", generated);
+        ScenarioExpect.Contains("MapKey", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("InternalHelpers FormatKeysAsyncReturnsAndArguments")]
     [Fact]
     public void InternalHelpers_FormatKeysAsyncReturnsAndArguments()
     {
@@ -804,51 +824,51 @@ public class FactoriesGeneratorTests
                 static method => method.Name,
                 static method => method.GetAttributes().Single().ConstructorArguments.Single());
 
-        Assert.Equal("\"hello-world\"", InvokeFactoryHelper<string>("ToLiteral", constants["StringKey"]));
-        Assert.Equal("true", InvokeFactoryHelper<string>("ToLiteral", constants["BoolKey"]));
-        Assert.Equal("42", InvokeFactoryHelper<string>("ToLiteral", constants["NumberKey"]));
-        Assert.Equal("global::Demo.Channel.Email", InvokeFactoryHelper<string>("ToLiteral", constants["EnumKey"]));
+        ScenarioExpect.Equal("\"hello-world\"", InvokeFactoryHelper<string>("ToLiteral", constants["StringKey"]));
+        ScenarioExpect.Equal("true", InvokeFactoryHelper<string>("ToLiteral", constants["BoolKey"]));
+        ScenarioExpect.Equal("42", InvokeFactoryHelper<string>("ToLiteral", constants["NumberKey"]));
+        ScenarioExpect.Equal("global::Demo.Channel.Email", InvokeFactoryHelper<string>("ToLiteral", constants["EnumKey"]));
 
-        Assert.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, stringType, constants["StringKey"]));
-        Assert.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, boolType, constants["BoolKey"]));
-        Assert.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, intType, constants["NumberKey"]));
-        Assert.False(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, stringType, constants["NumberKey"]));
-        Assert.True(InvokeFactoryHelper<bool>("NeedsNullCheck", stringType));
-        Assert.False(InvokeFactoryHelper<bool>("NeedsNullCheck", intType));
-        Assert.True(InvokeFactoryHelper<bool>("IsStringType", stringType));
+        ScenarioExpect.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, stringType, constants["StringKey"]));
+        ScenarioExpect.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, boolType, constants["BoolKey"]));
+        ScenarioExpect.True(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, intType, constants["NumberKey"]));
+        ScenarioExpect.False(InvokeFactoryHelper<bool>("IsKeyCompatible", compilation, stringType, constants["NumberKey"]));
+        ScenarioExpect.True(InvokeFactoryHelper<bool>("NeedsNullCheck", stringType));
+        ScenarioExpect.False(InvokeFactoryHelper<bool>("NeedsNullCheck", intType));
+        ScenarioExpect.True(InvokeFactoryHelper<bool>("IsStringType", stringType));
 
         var existing = new HashSet<string>(StringComparer.Ordinal);
-        Assert.Equal("HelloWorld", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["StringKey"], stringType, existing));
-        Assert.Equal("True", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["BoolKey"], boolType, existing));
-        Assert.Equal("Key42", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["NumberKey"], intType, existing));
-        Assert.Equal("Email", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["EnumKey"], constants["EnumKey"].Type!, existing));
-        Assert.Equal("HelloWorld2", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["StringKey"], stringType, existing));
+        ScenarioExpect.Equal("HelloWorld", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["StringKey"], stringType, existing));
+        ScenarioExpect.Equal("True", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["BoolKey"], boolType, existing));
+        ScenarioExpect.Equal("Key42", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["NumberKey"], intType, existing));
+        ScenarioExpect.Equal("Email", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["EnumKey"], constants["EnumKey"].Type!, existing));
+        ScenarioExpect.Equal("HelloWorld2", InvokeFactoryHelper<string>("BuildEnumMemberName", constants["StringKey"], stringType, existing));
 
-        Assert.True(InvokeFactoryHelper<bool>("Implements", email, message));
-        Assert.True(InvokeFactoryHelper<bool>("Implements", email, messageBase));
-        Assert.False(InvokeFactoryHelper<bool>("Implements", other, message));
-        Assert.Equal("MessageFactory", InvokeFactoryHelper<string>("BuildDefaultFactoryName", message));
-        Assert.Equal("MessageBaseFactory", InvokeFactoryHelper<string>("BuildDefaultFactoryName", messageBase));
+        ScenarioExpect.True(InvokeFactoryHelper<bool>("Implements", email, message));
+        ScenarioExpect.True(InvokeFactoryHelper<bool>("Implements", email, messageBase));
+        ScenarioExpect.False(InvokeFactoryHelper<bool>("Implements", other, message));
+        ScenarioExpect.Equal("MessageFactory", InvokeFactoryHelper<string>("BuildDefaultFactoryName", message));
+        ScenarioExpect.Equal("MessageBaseFactory", InvokeFactoryHelper<string>("BuildDefaultFactoryName", messageBase));
 
         var taskMethod = (IMethodSymbol)signatureSamples.GetMembers("TaskResult").Single();
         var taskSignature = InvokeFactoryHelper<object>("BuildSignature", taskMethod, compilation);
         var parameterArray = (System.Collections.Immutable.ImmutableArray<IParameterSymbol>)taskSignature.GetType().GetProperty("Parameters")!.GetValue(taskSignature)!;
-        Assert.Contains("ref int count", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
-        Assert.Contains("in string name", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
-        Assert.Contains("out bool ok", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
-        Assert.Equal("ref count, in name, out ok", InvokeFactoryHelper<string>("BuildArgumentList", parameterArray));
+        ScenarioExpect.Contains("ref int count", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
+        ScenarioExpect.Contains("in string name", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
+        ScenarioExpect.Contains("out bool ok", InvokeFactoryHelper<string>("BuildParameterList", parameterArray));
+        ScenarioExpect.Equal("ref count, in name, out ok", InvokeFactoryHelper<string>("BuildArgumentList", parameterArray));
 
         var asyncKindType = typeof(FactoriesGenerator).GetNestedType("AsyncKind", System.Reflection.BindingFlags.NonPublic)!;
         var sync = Enum.Parse(asyncKindType, "Sync");
         var task = Enum.Parse(asyncKindType, "Task");
         var valueTask = Enum.Parse(asyncKindType, "ValueTask");
-        Assert.Equal("return invocation();", InvokeFactoryHelper<string>("BuildAsyncReturn", valueTask, "string", "invocation()"));
-        Assert.Equal("return new global::System.Threading.Tasks.ValueTask<string>(invocation());", InvokeFactoryHelper<string>("BuildAsyncReturn", task, "string", "invocation()"));
-        Assert.Equal("return global::System.Threading.Tasks.ValueTask.FromResult<string>(invocation());", InvokeFactoryHelper<string>("BuildAsyncReturn", sync, "string", "invocation()"));
-        Assert.Equal("invocation()", InvokeFactoryHelper<string>("BuildSyncValue", sync, "invocation()"));
-        Assert.Equal("invocation().GetAwaiter().GetResult()", InvokeFactoryHelper<string>("BuildSyncValue", task, "invocation()"));
-        Assert.Equal("invocation()", InvokeFactoryHelper<string>("BuildAwaitedValue", sync, "invocation()"));
-        Assert.Equal("await invocation()", InvokeFactoryHelper<string>("BuildAwaitedValue", valueTask, "invocation()"));
+        ScenarioExpect.Equal("return invocation();", InvokeFactoryHelper<string>("BuildAsyncReturn", valueTask, "string", "invocation()"));
+        ScenarioExpect.Equal("return new global::System.Threading.Tasks.ValueTask<string>(invocation());", InvokeFactoryHelper<string>("BuildAsyncReturn", task, "string", "invocation()"));
+        ScenarioExpect.Equal("return global::System.Threading.Tasks.ValueTask.FromResult<string>(invocation());", InvokeFactoryHelper<string>("BuildAsyncReturn", sync, "string", "invocation()"));
+        ScenarioExpect.Equal("invocation()", InvokeFactoryHelper<string>("BuildSyncValue", sync, "invocation()"));
+        ScenarioExpect.Equal("invocation().GetAwaiter().GetResult()", InvokeFactoryHelper<string>("BuildSyncValue", task, "invocation()"));
+        ScenarioExpect.Equal("invocation()", InvokeFactoryHelper<string>("BuildAwaitedValue", sync, "invocation()"));
+        ScenarioExpect.Equal("await invocation()", InvokeFactoryHelper<string>("BuildAwaitedValue", valueTask, "invocation()"));
     }
 
     private static T InvokeFactoryHelper<T>(string name, params object?[] args)

--- a/test/PatternKit.Generators.Tests/FlyweightGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/FlyweightGeneratorTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Generators.Flyweight;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class FlyweightGeneratorTests
 {
+    [Scenario("GeneratesFlyweightCacheWithLru")]
     [Fact]
     public void GeneratesFlyweightCacheWithLru()
     {
@@ -24,17 +26,18 @@ public class FlyweightGeneratorTests
         var gen = new FlyweightGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Glyph.Flyweight.g.cs").SourceText.ToString();
-        Assert.Contains("public sealed partial class GlyphCache", generated);
-        Assert.Contains("public global::TestNamespace.Glyph Get(string key)", generated);
-        Assert.Contains("public bool TryGet(string key, out global::TestNamespace.Glyph value)", generated);
-        Assert.Contains("private void Trim()", generated);
+        ScenarioExpect.Contains("public sealed partial class GlyphCache", generated);
+        ScenarioExpect.Contains("public global::TestNamespace.Glyph Get(string key)", generated);
+        ScenarioExpect.Contains("public bool TryGet(string key, out global::TestNamespace.Glyph value)", generated);
+        ScenarioExpect.Contains("private void Trim()", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsMissingFactory")]
     [Fact]
     public void ReportsMissingFactory()
     {
@@ -52,9 +55,10 @@ public class FlyweightGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKFLY002");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKFLY002");
     }
 
+    [Scenario("ReportsInvalidLruConfiguration")]
     [Fact]
     public void ReportsInvalidLruConfiguration()
     {
@@ -76,9 +80,10 @@ public class FlyweightGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKFLY006");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKFLY006");
     }
 
+    [Scenario("ReportsNonPartialAndNonStaticFactory")]
     [Fact]
     public void ReportsNonPartialAndNonStaticFactory()
     {
@@ -107,7 +112,7 @@ public class FlyweightGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diags = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diags, d => d.Id == "PKFLY001");
-        Assert.Contains(diags, d => d.Id == "PKFLY004");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKFLY001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKFLY004");
     }
 }

--- a/test/PatternKit.Generators.Tests/IteratorGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/IteratorGeneratorTests.cs
@@ -1,9 +1,11 @@
 using PatternKit.Generators.Iterator;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class IteratorGeneratorTests
 {
+    [Scenario("GeneratesIteratorMembers")]
     [Fact]
     public void GeneratesIteratorMembers()
     {
@@ -30,15 +32,16 @@ public class IteratorGeneratorTests
         var gen = new IteratorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single(s => s.HintName == "Counter.Iterator.g.cs").SourceText.ToString();
-        Assert.Contains("public bool TryMoveNext(out int item)", generated);
-        Assert.Contains("public struct Enumerator", generated);
+        ScenarioExpect.Contains("public bool TryMoveNext(out int item)", generated);
+        ScenarioExpect.Contains("public struct Enumerator", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsMissingStep")]
     [Fact]
     public void ReportsMissingStep()
     {
@@ -56,9 +59,10 @@ public class IteratorGeneratorTests
         var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ReportsMissingStep));
         var gen = new IteratorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
-        Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKIT002");
+        ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == "PKIT002");
     }
 
+    [Scenario("ReportsNonPartialAndBadStepSignature")]
     [Fact]
     public void ReportsNonPartialAndBadStepSignature()
     {
@@ -91,7 +95,7 @@ public class IteratorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKIT001");
-        Assert.Contains(diagnostics, d => d.Id == "PKIT004");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKIT001");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKIT004");
     }
 }

--- a/test/PatternKit.Generators.Tests/MementoGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/MementoGeneratorTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.CodeAnalysis;
 using PatternKit.Common;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class MementoGeneratorTests
 {
+    [Scenario("GenerateMementoForClass")]
     [Fact]
     public void GenerateMementoForClass()
     {
@@ -26,17 +28,18 @@ public class MementoGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Memento struct is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Document.Memento.g.cs", names);
+        ScenarioExpect.Contains("Document.Memento.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateMementoForRecordClass")]
     [Fact]
     public void GenerateMementoForRecordClass()
     {
@@ -54,17 +57,18 @@ public class MementoGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Memento struct is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("EditorState.Memento.g.cs", names);
+        ScenarioExpect.Contains("EditorState.Memento.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateMementoForRecordStruct")]
     [Fact]
     public void GenerateMementoForRecordStruct()
     {
@@ -82,17 +86,18 @@ public class MementoGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Memento struct is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Point.Memento.g.cs", names);
+        ScenarioExpect.Contains("Point.Memento.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateMementoForStruct")]
     [Fact]
     public void GenerateMementoForStruct()
     {
@@ -114,17 +119,18 @@ public class MementoGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Memento struct is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Counter.Memento.g.cs", names);
+        ScenarioExpect.Contains("Counter.Memento.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenNotPartial")]
     [Fact]
     public void ErrorWhenNotPartial()
     {
@@ -146,9 +152,10 @@ public class MementoGeneratorTests
 
         // PKMEM001 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKMEM001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKMEM001");
     }
 
+    [Scenario("GenerateCaretakerWhenRequested")]
     [Fact]
     public void GenerateCaretakerWhenRequested()
     {
@@ -167,14 +174,15 @@ public class MementoGeneratorTests
 
         // Memento and caretaker are generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("EditorState.Memento.g.cs", names);
-        Assert.Contains("EditorState.History.g.cs", names);
+        ScenarioExpect.Contains("EditorState.Memento.g.cs", names);
+        ScenarioExpect.Contains("EditorState.History.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("MemberExclusionWithIgnore")]
     [Fact]
     public void MemberExclusionWithIgnore()
     {
@@ -201,14 +209,15 @@ public class MementoGeneratorTests
             .SelectMany(r => r.GeneratedSources)
             .FirstOrDefault(gs => gs.HintName.Contains("Memento.g.cs"));
 
-        Assert.NotEqual(default, mementoSourceResult);
+        ScenarioExpect.NotEqual(default, mementoSourceResult);
         var mementoSource = mementoSourceResult.SourceText.ToString();
 
         // Memento includes Text but not InternalId
-        Assert.Contains("string Text", mementoSource); // Type might be "string" or "global::System.String"
-        Assert.DoesNotContain("InternalId", mementoSource);
+        ScenarioExpect.Contains("string Text", mementoSource); // Type might be "string" or "global::System.String"
+        ScenarioExpect.DoesNotContain("InternalId", mementoSource);
     }
 
+    [Scenario("ExplicitInclusionMode")]
     [Fact]
     public void ExplicitInclusionMode()
     {
@@ -235,14 +244,15 @@ public class MementoGeneratorTests
             .SelectMany(r => r.GeneratedSources)
             .FirstOrDefault(gs => gs.HintName.Contains("Memento.g.cs"));
 
-        Assert.NotEqual(default, mementoSourceResult);
+        ScenarioExpect.NotEqual(default, mementoSourceResult);
         var mementoSource = mementoSourceResult.SourceText.ToString();
 
         // Memento includes Text but not InternalData
-        Assert.Contains("string Text", mementoSource); // Type might be "string" or "global::System.String"
-        Assert.DoesNotContain("InternalData", mementoSource);
+        ScenarioExpect.Contains("string Text", mementoSource); // Type might be "string" or "global::System.String"
+        ScenarioExpect.DoesNotContain("InternalData", mementoSource);
     }
 
+    [Scenario("WarningForMutableReferenceCapture")]
     [Fact]
     public void WarningForMutableReferenceCapture()
     {
@@ -266,9 +276,10 @@ public class MementoGeneratorTests
 
         // PKMEM003 warning is reported for List<string>
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKMEM003" && d.GetMessage().Contains("Tags"));
+        ScenarioExpect.Contains(diags, d => d.Id == "PKMEM003" && d.GetMessage().Contains("Tags"));
     }
 
+    [Scenario("GeneratedMementoHasCaptureAndRestore")]
     [Fact]
     public void GeneratedMementoHasCaptureAndRestore()
     {
@@ -289,14 +300,15 @@ public class MementoGeneratorTests
             .SelectMany(r => r.GeneratedSources)
             .FirstOrDefault(gs => gs.HintName.Contains("Memento.g.cs"));
 
-        Assert.NotEqual(default, mementoSourceResult);
+        ScenarioExpect.NotEqual(default, mementoSourceResult);
         var mementoSource = mementoSourceResult.SourceText.ToString();
 
         // Verify Capture and RestoreNew methods exist
-        Assert.Contains("public static EditorStateMemento Capture", mementoSource);
-        Assert.Contains("public global::TestNamespace.EditorState RestoreNew()", mementoSource);
+        ScenarioExpect.Contains("public static EditorStateMemento Capture", mementoSource);
+        ScenarioExpect.Contains("public global::TestNamespace.EditorState RestoreNew()", mementoSource);
     }
 
+    [Scenario("GeneratedCaretakerHasUndoRedo")]
     [Fact]
     public void GeneratedCaretakerHasUndoRedo()
     {
@@ -317,17 +329,18 @@ public class MementoGeneratorTests
             .SelectMany(r => r.GeneratedSources)
             .FirstOrDefault(gs => gs.HintName.Contains("History.g.cs"));
 
-        Assert.NotEqual(default, caretakerSourceResult);
+        ScenarioExpect.NotEqual(default, caretakerSourceResult);
         var caretakerSource = caretakerSourceResult.SourceText.ToString();
 
         // Verify caretaker has undo/redo functionality
-        Assert.Contains("public bool Undo()", caretakerSource);
-        Assert.Contains("public bool Redo()", caretakerSource);
-        Assert.Contains("public void Capture", caretakerSource);
-        Assert.Contains("public bool CanUndo", caretakerSource);
-        Assert.Contains("public bool CanRedo", caretakerSource);
+        ScenarioExpect.Contains("public bool Undo()", caretakerSource);
+        ScenarioExpect.Contains("public bool Redo()", caretakerSource);
+        ScenarioExpect.Contains("public void Capture", caretakerSource);
+        ScenarioExpect.Contains("public bool CanUndo", caretakerSource);
+        ScenarioExpect.Contains("public bool CanRedo", caretakerSource);
     }
 
+    [Scenario("GeneratedMementoIncludesVersion")]
     [Fact]
     public void GeneratedMementoIncludesVersion()
     {
@@ -351,13 +364,14 @@ public class MementoGeneratorTests
             .SelectMany(r => r.GeneratedSources)
             .FirstOrDefault(gs => gs.HintName.Contains("Memento.g.cs"));
 
-        Assert.NotEqual(default, mementoSourceResult);
+        ScenarioExpect.NotEqual(default, mementoSourceResult);
         var mementoSource = mementoSourceResult.SourceText.ToString();
 
         // Verify MementoVersion property exists
-        Assert.Contains("public int MementoVersion", mementoSource);
+        ScenarioExpect.Contains("public int MementoVersion", mementoSource);
     }
 
+    [Scenario("CaretakerRespectsCapacity")]
     [Fact]
     public void CaretakerRespectsCapacity()
     {
@@ -378,11 +392,11 @@ public class MementoGeneratorTests
             .SelectMany(r => r.GeneratedSources)
             .FirstOrDefault(gs => gs.HintName.Contains("History.g.cs"));
 
-        Assert.NotEqual(default, caretakerSourceResult);
+        ScenarioExpect.NotEqual(default, caretakerSourceResult);
         var caretakerSource = caretakerSourceResult.SourceText.ToString();
 
         // Verify capacity setting (using regex for flexibility)
-        Assert.Matches(@"private\s+const\s+int\s+MaxCapacity\s*=\s*50", caretakerSource);
-        Assert.Matches(@"if\s*\(\s*_states\.Count\s*>\s*MaxCapacity\s*\)", caretakerSource);
+        ScenarioExpect.Matches(@"private\s+const\s+int\s+MaxCapacity\s*=\s*50", caretakerSource);
+        ScenarioExpect.Matches(@"if\s*\(\s*_states\.Count\s*>\s*MaxCapacity\s*\)", caretakerSource);
     }
 }

--- a/test/PatternKit.Generators.Tests/ObserverGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ObserverGeneratorTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using System.Runtime.Loader;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -18,6 +19,7 @@ public class ObserverGeneratorTests
         }
         """;
 
+    [Scenario("Generates Observer Without Diagnostics")]
     [Fact]
     public void Generates_Observer_Without_Diagnostics()
     {
@@ -29,18 +31,19 @@ public class ObserverGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated expected file
         var sources = run.Results.SelectMany(r => r.GeneratedSources).ToArray();
-        Assert.Single(sources);
-        Assert.Contains("Observer.g.cs", sources[0].HintName);
+        ScenarioExpect.Single(sources);
+        ScenarioExpect.Contains("Observer.g.cs", sources[0].HintName);
 
         // The updated compilation should compile
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Reports Error When Type Not Partial")]
     [Fact]
     public void Reports_Error_When_Type_Not_Partial()
     {
@@ -61,9 +64,10 @@ public class ObserverGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKOBS001");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKOBS001");
     }
 
+    [Scenario("Escaped Type Name Generates Compilable Source")]
     [Fact]
     public void Escaped_Type_Name_Generates_Compilable_Source()
     {
@@ -86,9 +90,10 @@ public class ObserverGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Subscribe And Publish Works")]
     [Fact]
     public void Subscribe_And_Publish_Works()
     {
@@ -119,13 +124,13 @@ public class ObserverGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Load and invoke Demo.Run
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
 
         pe.Position = 0;
         pdb.Position = 0;
@@ -135,13 +140,13 @@ public class ObserverGeneratorTests
         {
             var asm = alc.LoadFromStream(pe, pdb);
             var demoType = asm.GetType("PatternKit.Examples.Generators.Demo");
-            Assert.NotNull(demoType);
+            ScenarioExpect.NotNull(demoType);
 
             var runMethod = demoType.GetMethod("Run");
-            Assert.NotNull(runMethod);
+            ScenarioExpect.NotNull(runMethod);
 
             var result = (string)runMethod.Invoke(null, null)!;
-            Assert.Equal("Handler1:23.5|Handler2:23.5", result);
+            ScenarioExpect.Equal("Handler1:23.5|Handler2:23.5", result);
         }
         finally
         {
@@ -149,6 +154,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Dispose Removes Subscription")]
     [Fact]
     public void Dispose_Removes_Subscription()
     {
@@ -182,7 +188,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -194,7 +200,7 @@ public class ObserverGeneratorTests
             var result = (string)runMethod!.Invoke(null, null)!;
             
             // After first publish: both handlers; after second: only H2
-            Assert.Equal("H1:10|H2:10|H2:20", result);
+            ScenarioExpect.Equal("H1:10|H2:10|H2:20", result);
         }
         finally
         {
@@ -202,6 +208,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Registration Order Preserved")]
     [Fact]
     public void Registration_Order_Preserved()
     {
@@ -234,7 +241,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -244,7 +251,7 @@ public class ObserverGeneratorTests
             var demoType = asm.GetType("PatternKit.Examples.Generators.Demo");
             var runMethod = demoType!.GetMethod("Run");
             var result = (string)runMethod!.Invoke(null, null)!;
-            Assert.Equal("ABC", result);
+            ScenarioExpect.Equal("ABC", result);
         }
         finally
         {
@@ -252,6 +259,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Async Subscribe And PublishAsync Works")]
     [Fact]
     public void Async_Subscribe_And_PublishAsync_Works()
     {
@@ -285,11 +293,11 @@ public class ObserverGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -302,7 +310,7 @@ public class ObserverGeneratorTests
             if (!task.Wait(TimeSpan.FromSeconds(30)))
                 throw new TimeoutException("Demo.Run() did not complete within 30 seconds.");
             var result = task.Result;
-            Assert.Equal("AsyncHandler:42", result);
+            ScenarioExpect.Equal("AsyncHandler:42", result);
         }
         finally
         {
@@ -310,6 +318,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Exception Policy Continue Does Not Stop Execution")]
     [Fact]
     public void Exception_Policy_Continue_Does_Not_Stop_Execution()
     {
@@ -356,7 +365,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -368,7 +377,7 @@ public class ObserverGeneratorTests
             var result = (string)runMethod!.Invoke(null, null)!;
             
             // All three handlers should execute (H1, exception, H3)
-            Assert.Equal("H1|H3", result);
+            ScenarioExpect.Equal("H1|H3", result);
         }
         finally
         {
@@ -376,6 +385,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Exception Policy Stop Throws First Exception")]
     [Fact]
     public void Exception_Policy_Stop_Throws_First_Exception()
     {
@@ -423,7 +433,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -433,7 +443,7 @@ public class ObserverGeneratorTests
             var demoType = asm.GetType("PatternKit.Examples.Generators.Demo");
             var runMethod = demoType!.GetMethod("Run");
             var result = (string)runMethod!.Invoke(null, null)!;
-            Assert.Equal("Oops", result);
+            ScenarioExpect.Equal("Oops", result);
         }
         finally
         {
@@ -441,6 +451,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Exception Policy Aggregate Throws AggregateException")]
     [Fact]
     public void Exception_Policy_Aggregate_Throws_AggregateException()
     {
@@ -487,7 +498,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -497,7 +508,7 @@ public class ObserverGeneratorTests
             var demoType = asm.GetType("PatternKit.Examples.Generators.Demo");
             var runMethod = demoType!.GetMethod("Run");
             var result = (string)runMethod!.Invoke(null, null)!;
-            Assert.Equal("2:Error1:Error2", result);
+            ScenarioExpect.Equal("2:Error1:Error2", result);
         }
         finally
         {
@@ -505,6 +516,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Struct Types Are Not Supported")]
     [Fact]
     public void Struct_Types_Are_Not_Supported()
     {
@@ -530,9 +542,10 @@ public class ObserverGeneratorTests
 
         // Should report PKOBS003 diagnostic for struct types
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKOBS003" && d.GetMessage().Contains("Struct observer types are not currently supported"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKOBS003" && d.GetMessage().Contains("Struct observer types are not currently supported"));
     }
 
+    [Scenario("Supports Record Class")]
     [Fact]
     public void Supports_Record_Class()
     {
@@ -571,9 +584,10 @@ public class ObserverGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Record Struct Types Are Not Supported")]
     [Fact]
     public void Record_Struct_Types_Are_Not_Supported()
     {
@@ -599,9 +613,10 @@ public class ObserverGeneratorTests
 
         // Should report PKOBS003 diagnostic for record struct types
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKOBS003" && d.GetMessage().Contains("Struct observer types are not currently supported"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKOBS003" && d.GetMessage().Contains("Struct observer types are not currently supported"));
     }
 
+    [Scenario("Mixed Sync And Async Handlers Both Invoked")]
     [Fact]
     public void Mixed_Sync_And_Async_Handlers_Both_Invoked()
     {
@@ -646,7 +661,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -661,8 +676,8 @@ public class ObserverGeneratorTests
             var result = task.Result;
             
             // Both handlers should have been invoked
-            Assert.Contains("Sync", result);
-            Assert.Contains("Async", result);
+            ScenarioExpect.Contains("Sync", result);
+            ScenarioExpect.Contains("Async", result);
         }
         finally
         {
@@ -670,6 +685,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Stop Policy Observes Fire And Forget Async Exceptions")]
     [Fact]
     public void Stop_Policy_Observes_Fire_And_Forget_Async_Exceptions()
     {
@@ -721,7 +737,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -732,7 +748,7 @@ public class ObserverGeneratorTests
             var runMethod = demoType!.GetMethod("Run");
             var task = (System.Threading.Tasks.Task<string>)runMethod!.Invoke(null, null)!;
             task.Wait();
-            Assert.Equal("AsyncOops", task.Result);
+            ScenarioExpect.Equal("AsyncOops", task.Result);
         }
         finally
         {
@@ -740,6 +756,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("SingleThreadedFast Threading Policy Works")]
     [Fact]
     public void SingleThreadedFast_Threading_Policy_Works()
     {
@@ -781,7 +798,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -792,7 +809,7 @@ public class ObserverGeneratorTests
             var runMethod = demoType!.GetMethod("Run");
             var result = (string)runMethod!.Invoke(null, null)!;
             
-            Assert.Equal("Handler1:23.5|Handler2:23.5", result);
+            ScenarioExpect.Equal("Handler1:23.5|Handler2:23.5", result);
         }
         finally
         {
@@ -800,6 +817,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Concurrent Undefined Uses Removable Concurrent Dictionary")]
     [Fact]
     public void Concurrent_Undefined_Uses_Removable_Concurrent_Dictionary()
     {
@@ -826,15 +844,16 @@ public class ObserverGeneratorTests
         var gen = new Observer.ObserverGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        var generatedSource = Assert.Single(run.Results.SelectMany(r => r.GeneratedSources)).SourceText.ToString();
-        Assert.Contains("System.Collections.Concurrent.ConcurrentDictionary<int, Subscription>", generatedSource);
-        Assert.Contains("state.Subscriptions?.TryRemove(_id, out _);", generatedSource);
-        Assert.DoesNotContain("ConcurrentBag<Subscription>", generatedSource);
+        var generatedSource = ScenarioExpect.Single(run.Results.SelectMany(r => r.GeneratedSources)).SourceText.ToString();
+        ScenarioExpect.Contains("System.Collections.Concurrent.ConcurrentDictionary<int, Subscription>", generatedSource);
+        ScenarioExpect.Contains("state.Subscriptions?.TryRemove(_id, out _);", generatedSource);
+        ScenarioExpect.DoesNotContain("ConcurrentBag<Subscription>", generatedSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Concurrent RegistrationOrder Threading Policy Works")]
     [Fact]
     public void Concurrent_RegistrationOrder_Threading_Policy_Works()
     {
@@ -879,7 +898,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -891,7 +910,7 @@ public class ObserverGeneratorTests
             var result = (string)runMethod!.Invoke(null, null)!;
             
             // With RegistrationOrder, order should be preserved
-            Assert.Equal("Handler1:23.5|Handler2:23.5", result);
+            ScenarioExpect.Equal("Handler1:23.5|Handler2:23.5", result);
         }
         finally
         {
@@ -899,6 +918,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Concurrent Undefined Threading Policy Works")]
     [Fact]
     public void Concurrent_Undefined_Threading_Policy_Works()
     {
@@ -943,7 +963,7 @@ public class ObserverGeneratorTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+        ScenarioExpect.True(emitResult.Success, $"Compilation failed: {string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
         pe.Position = 0;
 
         var alc = new AssemblyLoadContext("ObserverTest", isCollectible: true);
@@ -955,8 +975,8 @@ public class ObserverGeneratorTests
             var result = (string)runMethod!.Invoke(null, null)!;
             
             // With Undefined order, both handlers should still be invoked (order not guaranteed)
-            Assert.Contains("Handler1:23.5", result);
-            Assert.Contains("Handler2:23.5", result);
+            ScenarioExpect.Contains("Handler1:23.5", result);
+            ScenarioExpect.Contains("Handler2:23.5", result);
         }
         finally
         {
@@ -964,6 +984,7 @@ public class ObserverGeneratorTests
         }
     }
 
+    [Scenario("Reports Invalid Config For Generic Nested And Struct Observers")]
     [Fact]
     public void Reports_Invalid_Config_For_Generic_Nested_And_Struct_Observers()
     {
@@ -1001,12 +1022,13 @@ public class ObserverGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Equal(3, diagnostics.Count(d => d.Id == "PKOBS003"));
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Generic observer types"));
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Nested observer types"));
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Struct observer types"));
+        ScenarioExpect.Equal(3, diagnostics.Count(d => d.Id == "PKOBS003"));
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("Generic observer types"));
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("Nested observer types"));
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("Struct observer types"));
     }
 
+    [Scenario("ForceAsync Internal Record Uses Configured Source Shape")]
     [Fact]
     public void ForceAsync_Internal_Record_Uses_Configured_Source_Shape()
     {
@@ -1034,18 +1056,18 @@ public class ObserverGeneratorTests
         var gen = new Observer.ObserverGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generated = run.Results
             .SelectMany(r => r.GeneratedSources)
             .Single()
             .SourceText.ToString();
 
-        Assert.Contains("internal partial record class DomainEvent", generated);
-        Assert.Contains("PublishAsync", generated);
-        Assert.DoesNotContain("lock (_lock)", generated);
+        ScenarioExpect.Contains("internal partial record class DomainEvent", generated);
+        ScenarioExpect.Contains("PublishAsync", generated);
+        ScenarioExpect.DoesNotContain("lock (_lock)", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 }

--- a/test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj
+++ b/test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj
@@ -37,6 +37,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="..\ScenarioExpect.cs" Link="ScenarioExpect.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 

--- a/test/PatternKit.Generators.Tests/PrototypeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/PrototypeGeneratorTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.CodeAnalysis;
 using PatternKit.Common;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class PrototypeGeneratorTests
 {
+    [Scenario("GenerateCloneForClass")]
     [Fact]
     public void GenerateCloneForClass()
     {
@@ -26,17 +28,18 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Clone method is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Person.Prototype.g.cs", names);
+        ScenarioExpect.Contains("Person.Prototype.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateCloneForRecordClass")]
     [Fact]
     public void GenerateCloneForRecordClass()
     {
@@ -54,24 +57,25 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Clone method is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Person.Prototype.g.cs", names);
+        ScenarioExpect.Contains("Person.Prototype.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Records get "Duplicate" method by default
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Person.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Duplicate()", generatedSource);
+        ScenarioExpect.Contains("Duplicate()", generatedSource);
     }
 
+    [Scenario("GenerateCloneForRecordStruct")]
     [Fact]
     public void GenerateCloneForRecordStruct()
     {
@@ -89,24 +93,25 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Clone method is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Point.Prototype.g.cs", names);
+        ScenarioExpect.Contains("Point.Prototype.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Records get "Duplicate" method by default
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Point.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Duplicate()", generatedSource);
+        ScenarioExpect.Contains("Duplicate()", generatedSource);
     }
 
+    [Scenario("GenerateCloneForStruct")]
     [Fact]
     public void GenerateCloneForStruct()
     {
@@ -129,17 +134,18 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Clone method is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Vector.Prototype.g.cs", names);
+        ScenarioExpect.Contains("Vector.Prototype.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorIfNotPartial")]
     [Fact]
     public void ErrorIfNotPartial()
     {
@@ -161,9 +167,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO001 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO001");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO001");
     }
 
+    [Scenario("GenerateCloneWithCustomMethodName")]
     [Fact]
     public void GenerateCloneWithCustomMethodName()
     {
@@ -184,25 +191,26 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Clone method is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("Item.Prototype.g.cs", names);
+        ScenarioExpect.Contains("Item.Prototype.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that the custom method name is used
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Item.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Duplicate()", generatedSource);
-        Assert.DoesNotContain("Clone()", generatedSource);
+        ScenarioExpect.Contains("Duplicate()", generatedSource);
+        ScenarioExpect.DoesNotContain("Clone()", generatedSource);
     }
 
+    [Scenario("GenerateCloneWithIgnoreAttribute")]
     [Fact]
     public void GenerateCloneWithIgnoreAttribute()
     {
@@ -226,21 +234,22 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that Password is not cloned
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "User.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Username", generatedSource);
-        Assert.DoesNotContain("Password", generatedSource);
+        ScenarioExpect.Contains("Username", generatedSource);
+        ScenarioExpect.DoesNotContain("Password", generatedSource);
     }
 
+    [Scenario("GenerateCloneWithExplicitInclude")]
     [Fact]
     public void GenerateCloneWithExplicitInclude()
     {
@@ -264,21 +273,22 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that only ApiKey is cloned
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Config.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("ApiKey", generatedSource);
-        Assert.DoesNotContain("Internal", generatedSource);
+        ScenarioExpect.Contains("ApiKey", generatedSource);
+        ScenarioExpect.DoesNotContain("Internal", generatedSource);
     }
 
+    [Scenario("WarnOnMutableReferenceType")]
     [Fact]
     public void WarnOnMutableReferenceType()
     {
@@ -301,9 +311,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO003 warning for mutable reference type
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO003" && d.Severity == DiagnosticSeverity.Warning);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO003" && d.Severity == DiagnosticSeverity.Warning);
     }
 
+    [Scenario("ErrorOnCloneStrategyWithoutMechanism")]
     [Fact]
     public void ErrorOnCloneStrategyWithoutMechanism()
     {
@@ -331,9 +342,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO004 error for missing clone mechanism
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO004" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO004" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("ErrorOnCustomStrategyWithoutPartialMethod")]
     [Fact]
     public void ErrorOnCustomStrategyWithoutPartialMethod()
     {
@@ -361,9 +373,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO005 error for missing custom hook
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO005" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO005" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("WarnOnAttributeMisuseIncludeInIncludeAllMode")]
     [Fact]
     public void WarnOnAttributeMisuseIncludeInIncludeAllMode()
     {
@@ -386,9 +399,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO006 warning for attribute misuse
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO006" && d.Severity == DiagnosticSeverity.Warning);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO006" && d.Severity == DiagnosticSeverity.Warning);
     }
 
+    [Scenario("WarnOnAttributeMisuseIgnoreInExplicitMode")]
     [Fact]
     public void WarnOnAttributeMisuseIgnoreInExplicitMode()
     {
@@ -411,9 +425,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO006 warning for attribute misuse
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO006" && d.Severity == DiagnosticSeverity.Warning);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO006" && d.Severity == DiagnosticSeverity.Warning);
     }
 
+    [Scenario("ErrorOnDeepCopyStrategy")]
     [Fact]
     public void ErrorOnDeepCopyStrategy()
     {
@@ -441,9 +456,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO007 error for DeepCopy not implemented
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO007" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO007" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("GenerateCloneWithShallowCopyStrategy")]
     [Fact]
     public void GenerateCloneWithShallowCopyStrategy()
     {
@@ -466,20 +482,21 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No errors
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that new List<string> is created (using fully qualified name)
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Container.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("new global::System.Collections.Generic.List<string>(this.Items)", generatedSource);
+        ScenarioExpect.Contains("new global::System.Collections.Generic.List<string>(this.Items)", generatedSource);
     }
 
+    [Scenario("GenerateCloneWithCloneStrategyUsingICloneable")]
     [Fact]
     public void GenerateCloneWithCloneStrategyUsingICloneable()
     {
@@ -508,20 +525,21 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No errors
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that Clone() is called
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Container.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Clone()", generatedSource);
+        ScenarioExpect.Contains("Clone()", generatedSource);
     }
 
+    [Scenario("GenerateCloneWithCloneStrategyUsingCloneMethod")]
     [Fact]
     public void GenerateCloneWithCloneStrategyUsingCloneMethod()
     {
@@ -549,20 +567,21 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No errors
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that Clone() is called
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Container.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Clone()", generatedSource);
+        ScenarioExpect.Contains("Clone()", generatedSource);
     }
 
+    [Scenario("GenerateCloneWithCloneStrategyUsingCopyConstructor")]
     [Fact]
     public void GenerateCloneWithCloneStrategyUsingCopyConstructor()
     {
@@ -595,20 +614,21 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No errors
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that copy constructor is called
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Container.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("new global::TestNamespace.DataWithCopyCtor(this.Data)", generatedSource);
+        ScenarioExpect.Contains("new global::TestNamespace.DataWithCopyCtor(this.Data)", generatedSource);
     }
 
+    [Scenario("GenerateCloneWithCloneStrategyForListCollection")]
     [Fact]
     public void GenerateCloneWithCloneStrategyForListCollection()
     {
@@ -631,20 +651,21 @@ public class PrototypeGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No errors
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Check that List copy constructor is used (using fully qualified name)
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Container.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("new global::System.Collections.Generic.List<string>(this.Items)", generatedSource);
+        ScenarioExpect.Contains("new global::System.Collections.Generic.List<string>(this.Items)", generatedSource);
     }
 
+    [Scenario("ErrorOnNoConstructionPath")]
     [Fact]
     public void ErrorOnNoConstructionPath()
     {
@@ -671,9 +692,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO002 error for no construction path
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO002" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO002" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("ErrorOnGenericType")]
     [Fact]
     public void ErrorOnGenericType()
     {
@@ -695,9 +717,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO008 error for generic type
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO008" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO008" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("ErrorOnNestedType")]
     [Fact]
     public void ErrorOnNestedType()
     {
@@ -722,9 +745,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO009 error for nested type
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO009" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO009" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("ErrorOnStaticCloneMethod")]
     [Fact]
     public void ErrorOnStaticCloneMethod()
     {
@@ -758,9 +782,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO004 error because static Clone() is not a valid mechanism
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO004" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO004" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("SucceedWithPrivateParameterlessConstructor")]
     [Fact]
     public void SucceedWithPrivateParameterlessConstructor()
     {
@@ -788,13 +813,14 @@ public class PrototypeGeneratorTests
 
         // Should succeed - private parameterless constructor is accessible from generated code
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.DoesNotContain(diagnostics, d => d.Id == "PKPRO002");
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Id == "PKPRO002");
 
         // Compilation should succeed
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("SucceedWithInitOnlyPropertiesOnClass")]
     [Fact]
     public void SucceedWithInitOnlyPropertiesOnClass()
     {
@@ -817,21 +843,22 @@ public class PrototypeGeneratorTests
 
         // Should succeed - init-only properties can be set in object initializers
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 
         // Compilation should succeed
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify init-only properties are cloned
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "ImmutableData.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Name = this.Name", generatedSource);
-        Assert.Contains("Value = this.Value", generatedSource);
+        ScenarioExpect.Contains("Name = this.Name", generatedSource);
+        ScenarioExpect.Contains("Value = this.Value", generatedSource);
     }
 
+    [Scenario("SucceedWithInitOnlyPropertiesWithCopyConstructor")]
     [Fact]
     public void SucceedWithInitOnlyPropertiesWithCopyConstructor()
     {
@@ -862,20 +889,21 @@ public class PrototypeGeneratorTests
 
         // Should succeed - copy constructor handles init-only properties
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 
         // Compilation should succeed
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify copy constructor is used
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "DataWithCtor.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("new global::TestNamespace.DataWithCtor(this)", generatedSource);
+        ScenarioExpect.Contains("new global::TestNamespace.DataWithCtor(this)", generatedSource);
     }
 
+    [Scenario("ErrorOnAbstractClass")]
     [Fact]
     public void ErrorOnAbstractClass()
     {
@@ -897,9 +925,10 @@ public class PrototypeGeneratorTests
 
         // Should have PKPRO010 error for abstract type
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRO010" && d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRO010" && d.Severity == DiagnosticSeverity.Error);
     }
 
+    [Scenario("SucceedWithCustomStrategy")]
     [Fact]
     public void SucceedWithCustomStrategy()
     {
@@ -937,21 +966,22 @@ public class PrototypeGeneratorTests
 
         // Should succeed - custom partial method is provided
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.DoesNotContain(diagnostics, d => d.Id == "PKPRO005");
-        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Id == "PKPRO005");
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 
         // Compilation should succeed
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify custom method is called
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Container.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("CloneData(this.Data)", generatedSource);
+        ScenarioExpect.Contains("CloneData(this.Data)", generatedSource);
     }
 
+    [Scenario("SucceedWithDeepWhenPossibleMode")]
     [Fact]
     public void SucceedWithDeepWhenPossibleMode()
     {
@@ -989,20 +1019,20 @@ public class PrototypeGeneratorTests
 
         // Should succeed - DeepWhenPossible mode clones what it can
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
         // No warnings in DeepWhenPossible mode
-        Assert.DoesNotContain(diagnostics, d => d.Id == "PKPRO003");
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Id == "PKPRO003");
 
         // Compilation should succeed
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify cloneable uses Clone() and non-cloneable uses by-reference
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Container.Prototype.g.cs")
             .SourceText.ToString();
-        Assert.Contains("Cloneable.Clone()", generatedSource);
-        Assert.Contains("this.NonCloneable", generatedSource);
+        ScenarioExpect.Contains("Cloneable.Clone()", generatedSource);
+        ScenarioExpect.Contains("this.NonCloneable", generatedSource);
     }
 }

--- a/test/PatternKit.Generators.Tests/ProxyGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ProxyGeneratorTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.CodeAnalysis;
 using System.IO;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class ProxyGeneratorTests
 {
+    [Scenario("GenerateProxyForInterface BasicContract")]
     [Fact]
     public void GenerateProxyForInterface_BasicContract()
     {
@@ -26,12 +28,12 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Proxy class is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace_IUserService.Proxy.g.cs", names);
-        Assert.Contains("TestNamespace_IUserService.Proxy.Interceptor.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace_IUserService.Proxy.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace_IUserService.Proxy.Interceptor.g.cs", names);
 
         // Verify proxy class content
         var proxySource = result.Results
@@ -39,12 +41,12 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IUserService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("UserServiceProxy", proxySource);
-        Assert.Contains("IUserService", proxySource);
-        Assert.Contains("_inner", proxySource);
-        Assert.Contains("_interceptor", proxySource);
-        Assert.Contains("GetUser", proxySource);
-        Assert.Contains("DeleteUser", proxySource);
+        ScenarioExpect.Contains("UserServiceProxy", proxySource);
+        ScenarioExpect.Contains("IUserService", proxySource);
+        ScenarioExpect.Contains("_inner", proxySource);
+        ScenarioExpect.Contains("_interceptor", proxySource);
+        ScenarioExpect.Contains("GetUser", proxySource);
+        ScenarioExpect.Contains("DeleteUser", proxySource);
 
         // Verify interceptor interface content
         var interceptorSource = result.Results
@@ -52,18 +54,19 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IUserService.Proxy.Interceptor.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("IUserServiceInterceptor", interceptorSource);
-        Assert.Contains("void Before(MethodContext context)", interceptorSource);
-        Assert.Contains("void After(MethodContext context)", interceptorSource);
-        Assert.Contains("void OnException(MethodContext context", interceptorSource);
-        Assert.Contains("GetUserMethodContext", interceptorSource);
-        Assert.Contains("DeleteUserMethodContext", interceptorSource);
+        ScenarioExpect.Contains("IUserServiceInterceptor", interceptorSource);
+        ScenarioExpect.Contains("void Before(MethodContext context)", interceptorSource);
+        ScenarioExpect.Contains("void After(MethodContext context)", interceptorSource);
+        ScenarioExpect.Contains("void OnException(MethodContext context", interceptorSource);
+        ScenarioExpect.Contains("GetUserMethodContext", interceptorSource);
+        ScenarioExpect.Contains("DeleteUserMethodContext", interceptorSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxyForInterface WithAsyncMethods")]
     [Fact]
     public void GenerateProxyForInterface_WithAsyncMethods()
     {
@@ -87,7 +90,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify simple delegation (no interceptor)
         var proxySource = result.Results
@@ -95,15 +98,16 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IAsyncUserService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("return _inner.GetUserAsync", proxySource);
-        Assert.Contains("_inner.DeleteUserAsync", proxySource);
-        Assert.DoesNotContain("_interceptor", proxySource);
+        ScenarioExpect.Contains("return _inner.GetUserAsync", proxySource);
+        ScenarioExpect.Contains("_inner.DeleteUserAsync", proxySource);
+        ScenarioExpect.DoesNotContain("_interceptor", proxySource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxyForInterface NoInterceptor")]
     [Fact]
     public void GenerateProxyForInterface_NoInterceptor()
     {
@@ -124,12 +128,12 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Only proxy class is generated, no interceptor interface
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace_ISimpleService.Proxy.g.cs", names);
-        Assert.DoesNotContain("TestNamespace_ISimpleService.Proxy.Interceptor.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace_ISimpleService.Proxy.g.cs", names);
+        ScenarioExpect.DoesNotContain("TestNamespace_ISimpleService.Proxy.Interceptor.g.cs", names);
 
         // Verify proxy class has no interceptor field
         var proxySource = result.Results
@@ -137,14 +141,15 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_ISimpleService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.DoesNotContain("_interceptor", proxySource);
-        Assert.Contains("_inner.GetValue()", proxySource);
+        ScenarioExpect.DoesNotContain("_interceptor", proxySource);
+        ScenarioExpect.Contains("_inner.GetValue()", proxySource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxyForInterface PipelineMode")]
     [Fact]
     public void GenerateProxyForInterface_PipelineMode()
     {
@@ -165,7 +170,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify proxy class uses pipeline (IReadOnlyList)
         var proxySource = result.Results
@@ -173,15 +178,16 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IPipelineService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("IReadOnlyList", proxySource);
-        Assert.Contains("_interceptors", proxySource);
-        Assert.Contains("for (int __i = 0; __i < _interceptors", proxySource);
+        ScenarioExpect.Contains("IReadOnlyList", proxySource);
+        ScenarioExpect.Contains("_interceptors", proxySource);
+        ScenarioExpect.Contains("for (int __i = 0; __i < _interceptors", proxySource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxyForInterface WithProperties")]
     [Fact]
     public void GenerateProxyForInterface_WithProperties()
     {
@@ -204,7 +210,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify proxy forwards properties
         var proxySource = result.Results
@@ -212,19 +218,20 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IPropertyService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("Name", proxySource);
-        Assert.Contains("Count", proxySource);
-        Assert.Contains("Description", proxySource);
-        Assert.Contains("get => _inner.Name", proxySource);
-        Assert.Contains("set => _inner.Name = value", proxySource);
-        Assert.Contains("get => _inner.Count", proxySource);
-        Assert.Contains("set => _inner.Description = value", proxySource);
+        ScenarioExpect.Contains("Name", proxySource);
+        ScenarioExpect.Contains("Count", proxySource);
+        ScenarioExpect.Contains("Description", proxySource);
+        ScenarioExpect.Contains("get => _inner.Name", proxySource);
+        ScenarioExpect.Contains("set => _inner.Name = value", proxySource);
+        ScenarioExpect.Contains("get => _inner.Count", proxySource);
+        ScenarioExpect.Contains("set => _inner.Description = value", proxySource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxyForInterface MustBePartial")]
     [Fact]
     public void GenerateProxyForInterface_MustBePartial()
     {
@@ -246,10 +253,11 @@ public class ProxyGeneratorTests
 
         // Generator diagnostic for missing partial
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX001");
-        Assert.Contains(diagnostics, d => d.GetMessage().Contains("partial"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX001");
+        ScenarioExpect.Contains(diagnostics, d => d.GetMessage().Contains("partial"));
     }
 
+    [Scenario("GenerateProxyForInterface ProxyIgnoreAttribute")]
     [Fact]
     public void GenerateProxyForInterface_ProxyIgnoreAttribute()
     {
@@ -282,7 +290,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify proxy does not include ignored method
         var proxySource = result.Results
@@ -290,14 +298,15 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IServiceWithIgnore.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("GetValue", proxySource);
-        Assert.DoesNotContain("LegacyMethod", proxySource);
+        ScenarioExpect.Contains("GetValue", proxySource);
+        ScenarioExpect.DoesNotContain("LegacyMethod", proxySource);
 
         // Compilation succeeds (because user provided partial implementation)
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxyForInterface CustomProxyTypeName")]
     [Fact]
     public void GenerateProxyForInterface_CustomProxyTypeName()
     {
@@ -318,7 +327,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify custom proxy type name is used in class declaration
         var proxySource = result.Results
@@ -326,14 +335,15 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IUserService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("class CustomUserServiceProxy", proxySource);
-        Assert.Contains("public CustomUserServiceProxy(", proxySource);
+        ScenarioExpect.Contains("class CustomUserServiceProxy", proxySource);
+        ScenarioExpect.Contains("public CustomUserServiceProxy(", proxySource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxyForAbstractClass OnlyProxiesVirtualMembers")]
     [Fact]
     public void GenerateProxyForAbstractClass_OnlyProxiesVirtualMembers()
     {
@@ -356,11 +366,11 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Check that files were generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains(names, n => n.Contains("UserServiceBase"));
+        ScenarioExpect.Contains(names, n => n.Contains("UserServiceBase"));
 
         // Verify proxy class content - look for the proxy file
         var proxySource = result.Results
@@ -369,14 +379,15 @@ public class ProxyGeneratorTests
             .Select(gs => gs.SourceText.ToString())
             .FirstOrDefault();
 
-        Assert.NotNull(proxySource);
-        Assert.Contains("UserServiceBaseProxy", proxySource);
-        Assert.Contains("UserServiceBase", proxySource);
-        Assert.Contains("GetUser", proxySource);
-        Assert.Contains("UpdateUser", proxySource);
-        Assert.DoesNotContain("NonVirtualMethod", proxySource);
+        ScenarioExpect.NotNull(proxySource);
+        ScenarioExpect.Contains("UserServiceBaseProxy", proxySource);
+        ScenarioExpect.Contains("UserServiceBase", proxySource);
+        ScenarioExpect.Contains("GetUser", proxySource);
+        ScenarioExpect.Contains("UpdateUser", proxySource);
+        ScenarioExpect.DoesNotContain("NonVirtualMethod", proxySource);
     }
 
+    [Scenario("GenerateProxy ProtectedMember GeneratesWarning")]
     [Fact]
     public void GenerateProxy_ProtectedMember_GeneratesWarning()
     {
@@ -399,9 +410,10 @@ public class ProxyGeneratorTests
 
         // Should generate PKPRX003 diagnostic for protected member
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("GetProtectedUser"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("GetProtectedUser"));
     }
 
+    [Scenario("GenerateProxy InaccessibleMember GeneratesError")]
     [Fact]
     public void GenerateProxy_InaccessibleMember_GeneratesError()
     {
@@ -429,9 +441,10 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // Should still generate for the accessible parts
-        Assert.NotEmpty(result.Results.SelectMany(r => r.GeneratedSources));
+        ScenarioExpect.NotEmpty(result.Results.SelectMany(r => r.GeneratedSources));
     }
 
+    [Scenario("GenerateProxy NameConflict GeneratesError")]
     [Fact]
     public void GenerateProxy_NameConflict_GeneratesError()
     {
@@ -459,9 +472,10 @@ public class ProxyGeneratorTests
 
         // Should generate PKPRX004 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX004");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX004");
     }
 
+    [Scenario("GenerateProxy ExceptionPolicySwallow")]
     [Fact]
     public void GenerateProxy_ExceptionPolicySwallow()
     {
@@ -482,7 +496,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -490,10 +504,11 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Verify exception is NOT rethrown (Swallow policy)
-        Assert.Contains("catch", proxySource);
-        Assert.DoesNotContain("throw;", proxySource);
+        ScenarioExpect.Contains("catch", proxySource);
+        ScenarioExpect.DoesNotContain("throw;", proxySource);
     }
 
+    [Scenario("GenerateProxy WithRefInParameters")]
     [Fact]
     public void GenerateProxy_WithRefInParameters()
     {
@@ -514,19 +529,20 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "TestNamespace_IUserService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("ref int id", proxySource);
-        Assert.Contains("in string name", proxySource);
-        Assert.Contains("ref id", proxySource); // ref forwarded
-        Assert.Contains("in name", proxySource); // in forwarded
+        ScenarioExpect.Contains("ref int id", proxySource);
+        ScenarioExpect.Contains("in string name", proxySource);
+        ScenarioExpect.Contains("ref id", proxySource); // ref forwarded
+        ScenarioExpect.Contains("in name", proxySource); // in forwarded
     }
 
+    [Scenario("GenerateProxy WithOutParameters")]
     [Fact]
     public void GenerateProxy_WithOutParameters()
     {
@@ -547,18 +563,19 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "TestNamespace_IUserService.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("out string name", proxySource);
-        Assert.Contains("out name", proxySource); // out forwarded
-        Assert.Contains("default", proxySource); // default used in context
+        ScenarioExpect.Contains("out string name", proxySource);
+        ScenarioExpect.Contains("out name", proxySource); // out forwarded
+        ScenarioExpect.Contains("default", proxySource); // default used in context
     }
 
+    [Scenario("GenerateProxy GenericMethod GeneratesError")]
     [Fact]
     public void GenerateProxy_GenericMethod_GeneratesError()
     {
@@ -580,9 +597,10 @@ public class ProxyGeneratorTests
 
         // Should generate PKPRX002 diagnostic for generic method
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Generic method"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Generic method"));
     }
 
+    [Scenario("GenerateProxy Event GeneratesError")]
     [Fact]
     public void GenerateProxy_Event_GeneratesError()
     {
@@ -606,9 +624,10 @@ public class ProxyGeneratorTests
 
         // Should generate PKPRX002 diagnostic for event
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Event"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Event"));
     }
 
+    [Scenario("GenerateProxy NestedType GeneratesError")]
     [Fact]
     public void GenerateProxy_NestedType_GeneratesError()
     {
@@ -634,9 +653,10 @@ public class ProxyGeneratorTests
         // Nested types are not supported - should not generate or should error
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
         // Either no generation or specific error
-        Assert.True(diagnostics.Length > 0 || result.Results.SelectMany(r => r.GeneratedSources).Count() == 0);
+        ScenarioExpect.True(diagnostics.Length > 0 || result.Results.SelectMany(r => r.GeneratedSources).Count() == 0);
     }
 
+    [Scenario("GenerateProxy PipelineModeWithExceptions")]
     [Fact]
     public void GenerateProxy_PipelineModeWithExceptions()
     {
@@ -658,7 +678,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -666,21 +686,22 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Verify pipeline with list of interceptors
-        Assert.Contains("IReadOnlyList", proxySource);
-        Assert.Contains("_interceptors", proxySource);
+        ScenarioExpect.Contains("IReadOnlyList", proxySource);
+        ScenarioExpect.Contains("_interceptors", proxySource);
 
         // Verify Before loop (ascending)
-        Assert.Contains("for (int __i = 0; __i < _interceptors!.Count; __i++)", proxySource);
-        Assert.Contains("_interceptors[__i].Before", proxySource);
+        ScenarioExpect.Contains("for (int __i = 0; __i < _interceptors!.Count; __i++)", proxySource);
+        ScenarioExpect.Contains("_interceptors[__i].Before", proxySource);
 
         // Verify After loop (descending)
-        Assert.Contains("for (int __i = _interceptors!.Count - 1; __i >= 0; __i--)", proxySource);
-        Assert.Contains("_interceptors[__i].After", proxySource);
+        ScenarioExpect.Contains("for (int __i = _interceptors!.Count - 1; __i >= 0; __i--)", proxySource);
+        ScenarioExpect.Contains("_interceptors[__i].After", proxySource);
 
         // Verify OnException loop (descending)
-        Assert.Contains("_interceptors[__i].OnException", proxySource);
+        ScenarioExpect.Contains("_interceptors[__i].OnException", proxySource);
     }
 
+    [Scenario("GenerateProxy ParameterNameConflictsWithReservedNames")]
     [Fact]
     public void GenerateProxy_ParameterNameConflictsWithReservedNames()
     {
@@ -701,7 +722,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var interceptorSource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -709,14 +730,15 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Verify parameters are renamed to avoid conflicts
-        Assert.Contains("Arg_MethodName", interceptorSource);
-        Assert.Contains("Arg_Result", interceptorSource);
+        ScenarioExpect.Contains("Arg_MethodName", interceptorSource);
+        ScenarioExpect.Contains("Arg_Result", interceptorSource);
 
         // Compilation should succeed
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxy RefReturningMethodWithCancellationToken")]
     [Fact]
     public void GenerateProxy_RefReturningMethodWithCancellationToken()
     {
@@ -738,7 +760,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -750,9 +772,10 @@ public class ProxyGeneratorTests
             .Where(l => l.Contains("GetValueRef") && l.Contains("public"))
             .ToArray();
 
-        Assert.All(methodLines, line => Assert.DoesNotContain("async", line));
+        ScenarioExpect.All(methodLines, line => ScenarioExpect.DoesNotContain("async", line));
     }
 
+    [Scenario("GenerateProxy NonAbstractClass GeneratesError")]
     [Fact]
     public void GenerateProxy_NonAbstractClass_GeneratesError()
     {
@@ -774,9 +797,10 @@ public class ProxyGeneratorTests
 
         // Should generate PKPRX002 diagnostic for non-abstract class
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Non-abstract class"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Non-abstract class"));
     }
 
+    [Scenario("GenerateProxy GenericContract GeneratesError")]
     [Fact]
     public void GenerateProxy_GenericContract_GeneratesError()
     {
@@ -798,9 +822,10 @@ public class ProxyGeneratorTests
 
         // Should generate PKPRX002 diagnostic for generic type
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Generic type"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Generic type"));
     }
 
+    [Scenario("GenerateProxy PartialRecord IsSupported")]
     [Fact]
     public void GenerateProxy_PartialRecord_IsSupported()
     {
@@ -822,9 +847,10 @@ public class ProxyGeneratorTests
 
         // Record declarations should be handled (though unusual, syntax allows it)
         // Should either generate or error appropriately
-        Assert.NotNull(result);
+        ScenarioExpect.NotNull(result);
     }
 
+    [Scenario("GenerateProxy ForceAsyncTrue GeneratesAsyncInterceptors")]
     [Fact]
     public void GenerateProxy_ForceAsyncTrue_GeneratesAsyncInterceptors()
     {
@@ -845,7 +871,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var interceptorSource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -854,12 +880,13 @@ public class ProxyGeneratorTests
             .FirstOrDefault();
 
         // Should generate async interceptor methods even for sync-only contract
-        Assert.NotNull(interceptorSource);
-        Assert.Contains("BeforeAsync", interceptorSource);
-        Assert.Contains("AfterAsync", interceptorSource);
-        Assert.Contains("OnExceptionAsync", interceptorSource);
+        ScenarioExpect.NotNull(interceptorSource);
+        ScenarioExpect.Contains("BeforeAsync", interceptorSource);
+        ScenarioExpect.Contains("AfterAsync", interceptorSource);
+        ScenarioExpect.Contains("OnExceptionAsync", interceptorSource);
     }
 
+    [Scenario("GenerateProxy CustomProxyTypeNameViaAttribute")]
     [Fact]
     public void GenerateProxy_CustomProxyTypeNameViaAttribute()
     {
@@ -880,17 +907,18 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName.Contains("Proxy.g.cs") && !gs.HintName.Contains("Interceptor"))
             .SourceText.ToString();
 
-        Assert.Contains("class MyCustomProxy", proxySource);
-        Assert.Contains("public MyCustomProxy(", proxySource);
+        ScenarioExpect.Contains("class MyCustomProxy", proxySource);
+        ScenarioExpect.Contains("public MyCustomProxy(", proxySource);
     }
 
+    [Scenario("GenerateProxy WithDefaultParameters")]
     [Fact]
     public void GenerateProxy_WithDefaultParameters()
     {
@@ -911,7 +939,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -919,11 +947,12 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Verify default parameters are preserved
-        Assert.Contains("string? name = null", proxySource);
-        Assert.Contains("int age = 18", proxySource);
-        Assert.Contains("bool active = true", proxySource);
+        ScenarioExpect.Contains("string? name = null", proxySource);
+        ScenarioExpect.Contains("int age = 18", proxySource);
+        ScenarioExpect.Contains("bool active = true", proxySource);
     }
 
+    [Scenario("GenerateProxy InterfaceWithIPrefix GeneratesCorrectName")]
     [Fact]
     public void GenerateProxy_InterfaceWithIPrefix_GeneratesCorrectName()
     {
@@ -944,7 +973,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -952,10 +981,11 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Should strip I prefix: IMyService -> MyServiceProxy
-        Assert.Contains("class MyServiceProxy", proxySource);
-        Assert.DoesNotContain("class IMyServiceProxy", proxySource);
+        ScenarioExpect.Contains("class MyServiceProxy", proxySource);
+        ScenarioExpect.DoesNotContain("class IMyServiceProxy", proxySource);
     }
 
+    [Scenario("GenerateProxy InterfaceWithoutIPrefix GeneratesCorrectName")]
     [Fact]
     public void GenerateProxy_InterfaceWithoutIPrefix_GeneratesCorrectName()
     {
@@ -976,7 +1006,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -984,9 +1014,10 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Should not strip prefix: UserService -> UserServiceProxy
-        Assert.Contains("class UserServiceProxy", proxySource);
+        ScenarioExpect.Contains("class UserServiceProxy", proxySource);
     }
 
+    [Scenario("GenerateProxy WithNullableReferenceTypes")]
     [Fact]
     public void GenerateProxy_WithNullableReferenceTypes()
     {
@@ -1009,7 +1040,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -1017,10 +1048,11 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Verify nullable annotations are preserved
-        Assert.Contains("string? GetUser", proxySource);
-        Assert.Contains("string GetRequiredUser", proxySource);
+        ScenarioExpect.Contains("string? GetUser", proxySource);
+        ScenarioExpect.Contains("string GetRequiredUser", proxySource);
     }
 
+    [Scenario("GenerateProxy VoidAsyncMethods")]
     [Fact]
     public void GenerateProxy_VoidAsyncMethods()
     {
@@ -1043,7 +1075,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -1051,12 +1083,13 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Verify Task and ValueTask without <T> are handled
-        Assert.Contains("Task UpdateUserAsync", proxySource);
-        Assert.Contains("ValueTask DeleteUserAsync", proxySource);
-        Assert.Contains("await", proxySource);
-        Assert.Contains("ConfigureAwait(false)", proxySource);
+        ScenarioExpect.Contains("Task UpdateUserAsync", proxySource);
+        ScenarioExpect.Contains("ValueTask DeleteUserAsync", proxySource);
+        ScenarioExpect.Contains("await", proxySource);
+        ScenarioExpect.Contains("ConfigureAwait(false)", proxySource);
     }
 
+    [Scenario("GenerateProxy MultiplePropertiesWithGettersAndSetters")]
     [Fact]
     public void GenerateProxy_MultiplePropertiesWithGettersAndSetters()
     {
@@ -1079,7 +1112,7 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -1087,15 +1120,16 @@ public class ProxyGeneratorTests
             .SourceText.ToString();
 
         // Verify all property accessors are forwarded
-        Assert.Contains("string Name", proxySource);
-        Assert.Contains("int Age", proxySource);
-        Assert.Contains("bool IsActive", proxySource);
-        Assert.Contains("get => _inner.Name", proxySource);
-        Assert.Contains("set => _inner.Name = value", proxySource);
-        Assert.Contains("get => _inner.Age", proxySource);
-        Assert.Contains("set => _inner.IsActive = value", proxySource);
+        ScenarioExpect.Contains("string Name", proxySource);
+        ScenarioExpect.Contains("int Age", proxySource);
+        ScenarioExpect.Contains("bool IsActive", proxySource);
+        ScenarioExpect.Contains("get => _inner.Name", proxySource);
+        ScenarioExpect.Contains("set => _inner.Name = value", proxySource);
+        ScenarioExpect.Contains("get => _inner.Age", proxySource);
+        ScenarioExpect.Contains("set => _inner.IsActive = value", proxySource);
     }
 
+    [Scenario("GenerateProxy DisabledAsyncBaseInterfaceAndEscapedDefaults CoverBranches")]
     [Fact]
     public void GenerateProxy_DisabledAsyncBaseInterfaceAndEscapedDefaults_CoverBranches()
     {
@@ -1141,19 +1175,20 @@ public class ProxyGeneratorTests
             .First(gs => gs.HintName == "TestNamespace_IWarnsForAsync.Proxy.Interceptor.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("FromBase", proxySource);
-        Assert.Contains("string escaped = \"line\\nquote\\\"slash\\\\tab\\t\"", proxySource);
-        Assert.Contains("char quote = '\\''", proxySource);
-        Assert.Contains("float ratio = 1.5f", proxySource);
-        Assert.Contains("double score = 2.25d", proxySource);
-        Assert.Contains("decimal money = 3.75m", proxySource);
-        Assert.Contains("Mode mode = global::TestNamespace.Mode.Fast", proxySource);
-        Assert.Contains("BeforeAsync", interceptorSource);
+        ScenarioExpect.Contains("FromBase", proxySource);
+        ScenarioExpect.Contains("string escaped = \"line\\nquote\\\"slash\\\\tab\\t\"", proxySource);
+        ScenarioExpect.Contains("char quote = '\\''", proxySource);
+        ScenarioExpect.Contains("float ratio = 1.5f", proxySource);
+        ScenarioExpect.Contains("double score = 2.25d", proxySource);
+        ScenarioExpect.Contains("decimal money = 3.75m", proxySource);
+        ScenarioExpect.Contains("Mode mode = global::TestNamespace.Mode.Fast", proxySource);
+        ScenarioExpect.Contains("BeforeAsync", interceptorSource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxy IndexerProperty ReportsUnsupportedMember")]
     [Fact]
     public void GenerateProxy_IndexerProperty_ReportsUnsupportedMember()
     {
@@ -1175,9 +1210,10 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Indexer"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX002" && d.GetMessage().Contains("Indexer"));
     }
 
+    [Scenario("GenerateProxy AsyncPipelineWithVoidTasksAndRefs CoversAsyncEmission")]
     [Fact]
     public void GenerateProxy_AsyncPipelineWithVoidTasksAndRefs_CoversAsyncEmission()
     {
@@ -1200,24 +1236,25 @@ public class ProxyGeneratorTests
         var gen = new ProxyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "Worker.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("for (int __i = 0; __i < _interceptors!.Count; __i++)", proxySource);
-        Assert.Contains("for (int __i = _interceptors!.Count - 1; __i >= 0; __i--)", proxySource);
-        Assert.Contains("_inner.Copy(ref source, out destination, in enabled);", proxySource);
-        Assert.Contains("await __task.ConfigureAwait(false);", proxySource);
-        Assert.Contains("var __result = await __task.ConfigureAwait(false);", proxySource);
-        Assert.Contains("return default!;", proxySource);
-        Assert.Contains("WorkerProxy", proxySource);
+        ScenarioExpect.Contains("for (int __i = 0; __i < _interceptors!.Count; __i++)", proxySource);
+        ScenarioExpect.Contains("for (int __i = _interceptors!.Count - 1; __i >= 0; __i--)", proxySource);
+        ScenarioExpect.Contains("_inner.Copy(ref source, out destination, in enabled);", proxySource);
+        ScenarioExpect.Contains("await __task.ConfigureAwait(false);", proxySource);
+        ScenarioExpect.Contains("var __result = await __task.ConfigureAwait(false);", proxySource);
+        ScenarioExpect.Contains("return default!;", proxySource);
+        ScenarioExpect.Contains("WorkerProxy", proxySource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxy AbstractRecordAndAccessibility CoversRecordAndProtectedBranches")]
     [Fact]
     public void GenerateProxy_AbstractRecordAndAccessibility_CoversRecordAndProtectedBranches()
     {
@@ -1241,17 +1278,18 @@ public class ProxyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("ProtectedOnly"));
-        Assert.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("ProtectedProperty"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("ProtectedOnly"));
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKPRX003" && d.GetMessage().Contains("ProtectedProperty"));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .First(gs => gs.HintName == "TestNamespace_AbstractRecordService.Proxy.g.cs")
             .SourceText.ToString();
-        Assert.Contains("class AbstractRecordProxy", proxySource);
-        Assert.Contains("PublicGet", proxySource);
+        ScenarioExpect.Contains("class AbstractRecordProxy", proxySource);
+        ScenarioExpect.Contains("PublicGet", proxySource);
     }
 
+    [Scenario("GenerateProxy NoInterceptorMode CoversPureDelegationRefsPropertiesAndStatics")]
     [Fact]
     public void GenerateProxy_NoInterceptorMode_CoversPureDelegationRefsPropertiesAndStatics()
     {
@@ -1278,28 +1316,29 @@ public class ProxyGeneratorTests
         var gen = new ProxyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var proxySource = result.Results
             .SelectMany(r => r.GeneratedSources)
             .Single(gs => gs.HintName == "TestNamespace_WorkerContract.Proxy.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("Name", proxySource);
-        Assert.Contains("get => _inner.Name;", proxySource);
-        Assert.Contains("set => _inner.Name = value;", proxySource);
-        Assert.Contains("Version", proxySource);
-        Assert.Contains("_inner.Copy(ref source, out destination, in enabled);", proxySource);
-        Assert.Contains("return _inner.Calculate(value);", proxySource);
-        Assert.Contains("return _inner.Virtual(value);", proxySource);
-        Assert.DoesNotContain("Concrete", proxySource);
-        Assert.DoesNotContain("StaticValue", proxySource);
-        Assert.DoesNotContain("Interceptor", proxySource);
+        ScenarioExpect.Contains("Name", proxySource);
+        ScenarioExpect.Contains("get => _inner.Name;", proxySource);
+        ScenarioExpect.Contains("set => _inner.Name = value;", proxySource);
+        ScenarioExpect.Contains("Version", proxySource);
+        ScenarioExpect.Contains("_inner.Copy(ref source, out destination, in enabled);", proxySource);
+        ScenarioExpect.Contains("return _inner.Calculate(value);", proxySource);
+        ScenarioExpect.Contains("return _inner.Virtual(value);", proxySource);
+        ScenarioExpect.DoesNotContain("Concrete", proxySource);
+        ScenarioExpect.DoesNotContain("StaticValue", proxySource);
+        ScenarioExpect.DoesNotContain("Interceptor", proxySource);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateProxy InterfaceWithIgnoredOnlyMembers SkipsGeneration")]
     [Fact]
     public void GenerateProxy_InterfaceWithIgnoredOnlyMembers_SkipsGeneration()
     {
@@ -1320,7 +1359,7 @@ public class ProxyGeneratorTests
         var gen = new ProxyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
-        Assert.Empty(result.Results.SelectMany(r => r.GeneratedSources));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+        ScenarioExpect.Empty(result.Results.SelectMany(r => r.GeneratedSources));
     }
 }

--- a/test/PatternKit.Generators.Tests/RoutingSlipGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/RoutingSlipGeneratorTests.cs
@@ -1,11 +1,13 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using PatternKit.Generators.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public sealed class RoutingSlipGeneratorTests
 {
+    [Scenario("GeneratesSyncRoutingSlipFactory")]
     [Fact]
     public void GeneratesSyncRoutingSlipFactory()
     {
@@ -43,17 +45,18 @@ public sealed class RoutingSlipGeneratorTests
         var gen = new RoutingSlipGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
-        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
-        Assert.Equal("OrderSlip.RoutingSlip.g.cs", generated.HintName);
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        ScenarioExpect.Equal("OrderSlip.RoutingSlip.g.cs", generated.HintName);
         var text = generated.SourceText.ToString();
-        Assert.Contains(".Step(\"validate\", Validate)", text);
-        Assert.Contains(".Step(\"ship\", Ship)", text);
+        ScenarioExpect.Contains(".Step(\"validate\", Validate)", text);
+        ScenarioExpect.Contains(".Step(\"ship\", Ship)", text);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GeneratesAsyncRoutingSlipFactory")]
     [Fact]
     public void GeneratesAsyncRoutingSlipFactory()
     {
@@ -89,14 +92,15 @@ public sealed class RoutingSlipGeneratorTests
         var gen = new RoutingSlipGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
-        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
-        Assert.Contains("AsyncRoutingSlip<global::MyApp.Order>", generated.SourceText.ToString());
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        ScenarioExpect.Contains("AsyncRoutingSlip<global::MyApp.Order>", generated.SourceText.ToString());
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsDiagnosticForNonPartialSlip")]
     [Fact]
     public void ReportsDiagnosticForNonPartialSlip()
     {
@@ -120,10 +124,11 @@ public sealed class RoutingSlipGeneratorTests
         var gen = new RoutingSlipGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKRS001", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKRS001", diagnostic.Id);
     }
 
+    [Scenario("ReportsDiagnosticForMissingSteps")]
     [Fact]
     public void ReportsDiagnosticForMissingSteps()
     {
@@ -142,10 +147,11 @@ public sealed class RoutingSlipGeneratorTests
         var gen = new RoutingSlipGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKRS002", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKRS002", diagnostic.Id);
     }
 
+    [Scenario("ReportsDiagnosticForInvalidStepSignature")]
     [Fact]
     public void ReportsDiagnosticForInvalidStepSignature()
     {
@@ -169,8 +175,8 @@ public sealed class RoutingSlipGeneratorTests
         var gen = new RoutingSlipGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        var diagnostic = Assert.Single(run.Results.SelectMany(result => result.Diagnostics));
-        Assert.Equal("PKRS003", diagnostic.Id);
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKRS003", diagnostic.Id);
     }
 
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)

--- a/test/PatternKit.Generators.Tests/SagaGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/SagaGeneratorTests.cs
@@ -1,11 +1,13 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using PatternKit.Generators.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public sealed class SagaGeneratorTests
 {
+    [Scenario("GeneratesSyncSagaFactory")]
     [Fact]
     public void GeneratesSyncSagaFactory()
     {
@@ -50,18 +52,19 @@ public sealed class SagaGeneratorTests
         var gen = new SagaGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
-        var generated = Assert.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
         var text = generated.SourceText.ToString();
-        Assert.Equal("OrderSaga.Saga.g.cs", generated.HintName);
-        Assert.Contains(".On<global::MyApp.Started>().Then(Start)", text);
-        Assert.Contains(".On<global::MyApp.Paid>().Then(Pay)", text);
-        Assert.Contains(".CompleteWhen(IsComplete)", text);
+        ScenarioExpect.Equal("OrderSaga.Saga.g.cs", generated.HintName);
+        ScenarioExpect.Contains(".On<global::MyApp.Started>().Then(Start)", text);
+        ScenarioExpect.Contains(".On<global::MyApp.Paid>().Then(Pay)", text);
+        ScenarioExpect.Contains(".CompleteWhen(IsComplete)", text);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GeneratesAsyncSagaFactory")]
     [Fact]
     public void GeneratesAsyncSagaFactory()
     {
@@ -89,13 +92,14 @@ public sealed class SagaGeneratorTests
         var gen = new SagaGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, result => Assert.Empty(result.Diagnostics));
-        Assert.Contains("AsyncSaga<global::MyApp.OrderState>", Assert.Single(run.Results.SelectMany(result => result.GeneratedSources)).SourceText.ToString());
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        ScenarioExpect.Contains("AsyncSaga<global::MyApp.OrderState>", ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources)).SourceText.ToString());
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ReportsDiagnosticForNonPartialSaga")]
     [Fact]
     public void ReportsDiagnosticForNonPartialSaga()
     {
@@ -120,9 +124,10 @@ public sealed class SagaGeneratorTests
         var gen = new SagaGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        Assert.Equal("PKSG001", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+        ScenarioExpect.Equal("PKSG001", ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
     }
 
+    [Scenario("ReportsDiagnosticForMissingSteps")]
     [Fact]
     public void ReportsDiagnosticForMissingSteps()
     {
@@ -141,9 +146,10 @@ public sealed class SagaGeneratorTests
         var gen = new SagaGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        Assert.Equal("PKSG002", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+        ScenarioExpect.Equal("PKSG002", ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
     }
 
+    [Scenario("ReportsDiagnosticForInvalidStepSignature")]
     [Fact]
     public void ReportsDiagnosticForInvalidStepSignature()
     {
@@ -168,9 +174,10 @@ public sealed class SagaGeneratorTests
         var gen = new SagaGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        Assert.Equal("PKSG003", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+        ScenarioExpect.Equal("PKSG003", ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
     }
 
+    [Scenario("ReportsDiagnosticForInvalidCompletionSignature")]
     [Fact]
     public void ReportsDiagnosticForInvalidCompletionSignature()
     {
@@ -198,7 +205,7 @@ public sealed class SagaGeneratorTests
         var gen = new SagaGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
-        Assert.Equal("PKSG004", Assert.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
+        ScenarioExpect.Equal("PKSG004", ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics)).Id);
     }
 
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)

--- a/test/PatternKit.Generators.Tests/SingletonGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/SingletonGeneratorTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.CodeAnalysis;
 using PatternKit.Generators.Singleton;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class SingletonGeneratorTests
 {
+    [Scenario("GenerateEagerSingleton")]
     [Fact]
     public void GenerateEagerSingleton()
     {
@@ -25,11 +27,11 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Singleton file is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.AppClock.Singleton.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.AppClock.Singleton.g.cs", names);
 
         // Generated code contains expected shape
         var generatedSource = result.Results
@@ -37,12 +39,12 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.AppClock.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("private static readonly AppClock __PatternKit_Instance = new AppClock();", generatedSource);
-        Assert.Contains("public static AppClock Instance => __PatternKit_Instance;", generatedSource);
+        ScenarioExpect.Contains("private static readonly AppClock __PatternKit_Instance = new AppClock();", generatedSource);
+        ScenarioExpect.Contains("public static AppClock Instance => __PatternKit_Instance;", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
     /// <summary>
@@ -51,6 +53,7 @@ public class SingletonGeneratorTests
     /// which validate that multiple threads accessing Instance concurrently receive
     /// the same instance. This test focuses on correct code generation.
     /// </summary>
+    [Scenario("GenerateLazyThreadSafeSingleton")]
     [Fact]
     public void GenerateLazyThreadSafeSingleton()
     {
@@ -71,11 +74,11 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Singleton file is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.ConfigManager.Singleton.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.ConfigManager.Singleton.g.cs", names);
 
         // Generated code contains Lazy<T> pattern
         var generatedSource = result.Results
@@ -83,14 +86,15 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.ConfigManager.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("System.Lazy<ConfigManager>", generatedSource);
-        Assert.Contains("__PatternKit_LazyInstance.Value", generatedSource);
+        ScenarioExpect.Contains("System.Lazy<ConfigManager>", generatedSource);
+        ScenarioExpect.Contains("__PatternKit_LazyInstance.Value", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateLazySingleThreadedSingleton")]
     [Fact]
     public void GenerateLazySingleThreadedSingleton()
     {
@@ -111,7 +115,7 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Generated code contains non-thread-safe pattern
         var generatedSource = result.Results
@@ -119,14 +123,15 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.FastCache.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("__PatternKit_Instance ??=", generatedSource);
-        Assert.Contains("not thread-safe", generatedSource);
+        ScenarioExpect.Contains("__PatternKit_Instance ??=", generatedSource);
+        ScenarioExpect.Contains("not thread-safe", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateSingletonWithCustomFactory")]
     [Fact]
     public void GenerateSingletonWithCustomFactory()
     {
@@ -150,7 +155,7 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Generated code uses factory method
         var generatedSource = result.Results
@@ -158,13 +163,14 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.ServiceLocator.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("Create()", generatedSource);
+        ScenarioExpect.Contains("Create()", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateSingletonForRecordClass")]
     [Fact]
     public void GenerateSingletonForRecordClass()
     {
@@ -185,11 +191,11 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Singleton file is generated
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.AppSettings.Singleton.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.AppSettings.Singleton.g.cs", names);
 
         // Uses record class keyword
         var generatedSource = result.Results
@@ -197,13 +203,14 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.AppSettings.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("partial record class AppSettings", generatedSource);
+        ScenarioExpect.Contains("partial record class AppSettings", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateSingletonWithCustomPropertyName")]
     [Fact]
     public void GenerateSingletonWithCustomPropertyName()
     {
@@ -224,7 +231,7 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Generated code uses custom property name
         var generatedSource = result.Results
@@ -232,13 +239,14 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.Logger.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public static Logger Default =>", generatedSource);
+        ScenarioExpect.Contains("public static Logger Default =>", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenNotPartial")]
     [Fact]
     public void ErrorWhenNotPartial()
     {
@@ -260,9 +268,10 @@ public class SingletonGeneratorTests
 
         // PKSNG001 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG001");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG001");
     }
 
+    [Scenario("ErrorWhenStruct")]
     [Fact]
     public void ErrorWhenStruct()
     {
@@ -283,9 +292,10 @@ public class SingletonGeneratorTests
 
         // PKSNG002 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG002");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG002");
     }
 
+    [Scenario("ErrorWhenNoConstructorOrFactory")]
     [Fact]
     public void ErrorWhenNoConstructorOrFactory()
     {
@@ -307,9 +317,10 @@ public class SingletonGeneratorTests
 
         // PKSNG003 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG003");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG003");
     }
 
+    [Scenario("ErrorWhenMultipleFactories")]
     [Fact]
     public void ErrorWhenMultipleFactories()
     {
@@ -337,9 +348,10 @@ public class SingletonGeneratorTests
 
         // PKSNG004 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG004");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG004");
     }
 
+    [Scenario("WarnWhenPublicConstructor")]
     [Fact]
     public void WarnWhenPublicConstructor()
     {
@@ -361,17 +373,18 @@ public class SingletonGeneratorTests
 
         // PKSNG005 diagnostic is reported (warning)
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG005" && d.Severity == DiagnosticSeverity.Warning);
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG005" && d.Severity == DiagnosticSeverity.Warning);
 
         // Still generates code despite warning
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.PublicCtorSingleton.Singleton.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.PublicCtorSingleton.Singleton.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenNameConflict")]
     [Fact]
     public void ErrorWhenNameConflict()
     {
@@ -395,9 +408,10 @@ public class SingletonGeneratorTests
 
         // PKSNG006 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG006");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG006");
     }
 
+    [Scenario("GenerateSingletonInGlobalNamespace")]
     [Fact]
     public void GenerateSingletonInGlobalNamespace()
     {
@@ -416,7 +430,7 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Generated code has no namespace
         var generatedSource = result.Results
@@ -424,13 +438,14 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "GlobalSingleton.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.DoesNotContain("namespace", generatedSource);
+        ScenarioExpect.DoesNotContain("namespace", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("EagerSingleton Compiles")]
     [Fact]
     public void EagerSingleton_Compiles()
     {
@@ -463,13 +478,14 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("LazySingleton Compiles")]
     [Fact]
     public void LazySingleton_Compiles()
     {
@@ -502,13 +518,14 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenGenericType")]
     [Fact]
     public void ErrorWhenGenericType()
     {
@@ -530,9 +547,10 @@ public class SingletonGeneratorTests
 
         // PKSNG007 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG007");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG007");
     }
 
+    [Scenario("ErrorWhenNestedType")]
     [Fact]
     public void ErrorWhenNestedType()
     {
@@ -557,9 +575,10 @@ public class SingletonGeneratorTests
 
         // PKSNG008 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG008");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG008");
     }
 
+    [Scenario("ErrorWhenAbstractType")]
     [Fact]
     public void ErrorWhenAbstractType()
     {
@@ -581,9 +600,10 @@ public class SingletonGeneratorTests
 
         // PKSNG010 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG010");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG010");
     }
 
+    [Scenario("AllowAbstractTypeWithFactory")]
     [Fact]
     public void AllowAbstractTypeWithFactory()
     {
@@ -610,7 +630,7 @@ public class SingletonGeneratorTests
 
         // No PKSNG010 - abstract type is allowed with factory
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.DoesNotContain(diags, d => d.Id == "PKSNG010");
+        ScenarioExpect.DoesNotContain(diags, d => d.Id == "PKSNG010");
 
         // Generated code uses factory method
         var generatedSource = result.Results
@@ -618,13 +638,14 @@ public class SingletonGeneratorTests
             .First(gs => gs.HintName == "TestNamespace.AbstractWithFactory.Singleton.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("Create()", generatedSource);
+        ScenarioExpect.Contains("Create()", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenReservedKeywordPropertyName")]
     [Fact]
     public void ErrorWhenReservedKeywordPropertyName()
     {
@@ -646,9 +667,10 @@ public class SingletonGeneratorTests
 
         // PKSNG009 diagnostic is reported
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG009");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG009");
     }
 
+    [Scenario("AllowVerbatimKeywordPropertyName")]
     [Fact]
     public void AllowVerbatimKeywordPropertyName()
     {
@@ -669,13 +691,14 @@ public class SingletonGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ErrorWhenInheritedMemberConflict")]
     [Fact]
     public void ErrorWhenInheritedMemberConflict()
     {
@@ -702,9 +725,10 @@ public class SingletonGeneratorTests
 
         // PKSNG006 diagnostic is reported for inherited member conflict
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG006");
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG006");
     }
 
+    [Scenario("IgnoreGenericFactoryMethods")]
     [Fact]
     public void IgnoreGenericFactoryMethods()
     {
@@ -730,7 +754,7 @@ public class SingletonGeneratorTests
 
         // Should still generate using the parameterless constructor
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.GenericFactorySingleton.Singleton.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.GenericFactorySingleton.Singleton.g.cs", names);
 
         var generatedSource = result.Results
             .SelectMany(r => r.GeneratedSources)
@@ -738,14 +762,15 @@ public class SingletonGeneratorTests
             .SourceText.ToString();
 
         // Should use constructor, not factory
-        Assert.Contains("new GenericFactorySingleton()", generatedSource);
-        Assert.DoesNotContain("Create()", generatedSource);
+        ScenarioExpect.Contains("new GenericFactorySingleton()", generatedSource);
+        ScenarioExpect.DoesNotContain("Create()", generatedSource);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("WarnWhenImplicitPublicConstructor")]
     [Fact]
     public void WarnWhenImplicitPublicConstructor()
     {
@@ -767,14 +792,14 @@ public class SingletonGeneratorTests
 
         // PKSNG005 diagnostic is reported (warning) for implicit public ctor
         var diags = result.Results.SelectMany(r => r.Diagnostics);
-        Assert.Contains(diags, d => d.Id == "PKSNG005" && d.Severity == DiagnosticSeverity.Warning);
+        ScenarioExpect.Contains(diags, d => d.Id == "PKSNG005" && d.Severity == DiagnosticSeverity.Warning);
 
         // Still generates code despite warning
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("TestNamespace.ImplicitCtorSingleton.Singleton.g.cs", names);
+        ScenarioExpect.Contains("TestNamespace.ImplicitCtorSingleton.Singleton.g.cs", names);
 
         // Compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 }

--- a/test/PatternKit.Generators.Tests/StateMachineGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/StateMachineGeneratorTests.cs
@@ -1,9 +1,11 @@
 using Microsoft.CodeAnalysis;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
 public class StateMachineGeneratorTests
 {
+    [Scenario("BasicStateMachine Class GeneratesCorrectly")]
     [Fact]
     public void BasicStateMachine_Class_GeneratesCorrectly()
     {
@@ -34,23 +36,24 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated the expected file
         var names = result.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("OrderFlow.StateMachine.g.cs", names);
+        ScenarioExpect.Contains("OrderFlow.StateMachine.g.cs", names);
 
         // Verify the generated source contains expected members
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("public global::PatternKit.Examples.OrderState State { get; private set; }", generatedSource);
-        Assert.Contains("public bool CanFire(global::PatternKit.Examples.OrderTrigger trigger)", generatedSource);
-        Assert.Contains("public void Fire(global::PatternKit.Examples.OrderTrigger trigger)", generatedSource);
+        ScenarioExpect.Contains("public global::PatternKit.Examples.OrderState State { get; private set; }", generatedSource);
+        ScenarioExpect.Contains("public bool CanFire(global::PatternKit.Examples.OrderTrigger trigger)", generatedSource);
+        ScenarioExpect.Contains("public void Fire(global::PatternKit.Examples.OrderTrigger trigger)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("BasicStateMachine Struct GeneratesCorrectly")]
     [Fact]
     public void BasicStateMachine_Struct_GeneratesCorrectly()
     {
@@ -78,17 +81,18 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify struct keyword is used
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("partial struct LightSwitch", generatedSource);
+        ScenarioExpect.Contains("partial struct LightSwitch", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("BasicStateMachine RecordClass GeneratesCorrectly")]
     [Fact]
     public void BasicStateMachine_RecordClass_GeneratesCorrectly()
     {
@@ -116,17 +120,18 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify record class keyword is used
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("partial record class Door", generatedSource);
+        ScenarioExpect.Contains("partial record class Door", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("BasicStateMachine RecordStruct GeneratesCorrectly")]
     [Fact]
     public void BasicStateMachine_RecordStruct_GeneratesCorrectly()
     {
@@ -154,17 +159,18 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify record struct keyword is used
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("partial record struct Window", generatedSource);
+        ScenarioExpect.Contains("partial record struct Window", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("AsyncStateMachine WithValueTask GeneratesCorrectly")]
     [Fact]
     public void AsyncStateMachine_WithValueTask_GeneratesCorrectly()
     {
@@ -200,18 +206,19 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify async methods are generated
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("public async global::System.Threading.Tasks.ValueTask FireAsync(global::PatternKit.Examples.OrderTrigger trigger, global::System.Threading.CancellationToken cancellationToken = default)", generatedSource);
-        Assert.Contains("await OnSubmitAsync(cancellationToken)", generatedSource);
+        ScenarioExpect.Contains("public async global::System.Threading.Tasks.ValueTask FireAsync(global::PatternKit.Examples.OrderTrigger trigger, global::System.Threading.CancellationToken cancellationToken = default)", generatedSource);
+        ScenarioExpect.Contains("await OnSubmitAsync(cancellationToken)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StateMachineWithGuards GeneratesCorrectly")]
     [Fact]
     public void StateMachineWithGuards_GeneratesCorrectly()
     {
@@ -245,19 +252,20 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify guards are called
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("CanSubmit()", generatedSource);
-        Assert.Contains("CanPay()", generatedSource);
-        Assert.Contains("if (!CanSubmit())", generatedSource);
+        ScenarioExpect.Contains("CanSubmit()", generatedSource);
+        ScenarioExpect.Contains("CanPay()", generatedSource);
+        ScenarioExpect.Contains("if (!CanSubmit())", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StateMachineWithAsyncGuards GeneratesCorrectly")]
     [Fact]
     public void StateMachineWithAsyncGuards_GeneratesCorrectly()
     {
@@ -291,17 +299,18 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify async guards are called
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("await CanSubmitAsync(cancellationToken)", generatedSource);
+        ScenarioExpect.Contains("await CanSubmitAsync(cancellationToken)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StateMachineWithEntryHooks GeneratesCorrectly")]
     [Fact]
     public void StateMachineWithEntryHooks_GeneratesCorrectly()
     {
@@ -335,23 +344,24 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify entry hooks are called after state update
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("OnEnterSubmitted()", generatedSource);
-        Assert.Contains("OnEnterPaid()", generatedSource);
+        ScenarioExpect.Contains("OnEnterSubmitted()", generatedSource);
+        ScenarioExpect.Contains("OnEnterPaid()", generatedSource);
         
         // Verify State is updated before entry hooks
         var submitIndex = generatedSource.IndexOf("State = global::PatternKit.Examples.OrderState.Submitted");
         var entrySubmittedIndex = generatedSource.IndexOf("OnEnterSubmitted()");
-        Assert.True(submitIndex < entrySubmittedIndex, "State should be updated before entry hook is called");
+        ScenarioExpect.True(submitIndex < entrySubmittedIndex, "State should be updated before entry hook is called");
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StateMachineWithExitHooks GeneratesCorrectly")]
     [Fact]
     public void StateMachineWithExitHooks_GeneratesCorrectly()
     {
@@ -385,23 +395,24 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify exit hooks are called
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("OnExitDraft()", generatedSource);
-        Assert.Contains("OnExitSubmitted()", generatedSource);
+        ScenarioExpect.Contains("OnExitDraft()", generatedSource);
+        ScenarioExpect.Contains("OnExitSubmitted()", generatedSource);
 
         // Verify exit hooks are called before transition action
         var exitIndex = generatedSource.IndexOf("OnExitDraft()");
         var transitionIndex = generatedSource.IndexOf("OnSubmit()");
-        Assert.True(exitIndex < transitionIndex, "Exit hook should be called before transition action");
+        ScenarioExpect.True(exitIndex < transitionIndex, "Exit hook should be called before transition action");
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StateMachineWithAsyncEntryExitHooks GeneratesCorrectly")]
     [Fact]
     public void StateMachineWithAsyncEntryExitHooks_GeneratesCorrectly()
     {
@@ -440,18 +451,19 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify async entry/exit hooks are awaited
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("await OnExitDraftAsync(cancellationToken)", generatedSource);
-        Assert.Contains("await OnEnterSubmittedAsync(cancellationToken)", generatedSource);
+        ScenarioExpect.Contains("await OnExitDraftAsync(cancellationToken)", generatedSource);
+        ScenarioExpect.Contains("await OnEnterSubmittedAsync(cancellationToken)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StateMachineWithInvalidTriggerPolicy Ignore GeneratesCorrectly")]
     [Fact]
     public void StateMachineWithInvalidTriggerPolicy_Ignore_GeneratesCorrectly()
     {
@@ -476,18 +488,19 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify no exception is thrown for invalid triggers
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.DoesNotContain("throw new global::System.InvalidOperationException", generatedSource);
-        Assert.Contains("return;", generatedSource); // Should just return instead
+        ScenarioExpect.DoesNotContain("throw new global::System.InvalidOperationException", generatedSource);
+        ScenarioExpect.Contains("return;", generatedSource); // Should just return instead
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("StateMachineWithGuardFailurePolicy Ignore GeneratesCorrectly")]
     [Fact]
     public void StateMachineWithGuardFailurePolicy_Ignore_GeneratesCorrectly()
     {
@@ -515,19 +528,20 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify no exception is thrown for guard failures
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
         var guardFailureIndex = generatedSource.IndexOf("if (!CanTransition())");
         var throwIndex = generatedSource.IndexOf("throw new global::System.InvalidOperationException($\"Guard failed", guardFailureIndex);
-        Assert.True(throwIndex == -1, "Should not throw exception on guard failure with Ignore policy");
+        ScenarioExpect.True(throwIndex == -1, "Should not throw exception on guard failure with Ignore policy");
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("NonPartialType ReportsDiagnostic")]
     [Fact]
     public void NonPartialType_ReportsDiagnostic()
     {
@@ -553,9 +567,10 @@ public class StateMachineGeneratorTests
 
         // Should have diagnostic PKST001
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST001");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST001");
     }
 
+    [Scenario("NonEnumStateType ReportsDiagnostic")]
     [Fact]
     public void NonEnumStateType_ReportsDiagnostic()
     {
@@ -579,9 +594,10 @@ public class StateMachineGeneratorTests
 
         // Should have diagnostic PKST002
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST002");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST002");
     }
 
+    [Scenario("NonEnumTriggerType ReportsDiagnostic")]
     [Fact]
     public void NonEnumTriggerType_ReportsDiagnostic()
     {
@@ -605,9 +621,10 @@ public class StateMachineGeneratorTests
 
         // Should have diagnostic PKST003
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST003");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST003");
     }
 
+    [Scenario("DuplicateTransition ReportsDiagnostic")]
     [Fact]
     public void DuplicateTransition_ReportsDiagnostic()
     {
@@ -636,9 +653,10 @@ public class StateMachineGeneratorTests
 
         // Should have diagnostic PKST004
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST004");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST004");
     }
 
+    [Scenario("InvalidTransitionSignature ReportsDiagnostic")]
     [Fact]
     public void InvalidTransitionSignature_ReportsDiagnostic()
     {
@@ -664,9 +682,10 @@ public class StateMachineGeneratorTests
 
         // Should have diagnostic PKST005
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST005");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST005");
     }
 
+    [Scenario("InvalidGuardSignature ReportsDiagnostic")]
     [Fact]
     public void InvalidGuardSignature_ReportsDiagnostic()
     {
@@ -695,9 +714,10 @@ public class StateMachineGeneratorTests
 
         // Should have diagnostic PKST006
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST006");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST006");
     }
 
+    [Scenario("InvalidEntryHookSignature ReportsDiagnostic")]
     [Fact]
     public void InvalidEntryHookSignature_ReportsDiagnostic()
     {
@@ -726,9 +746,10 @@ public class StateMachineGeneratorTests
 
         // Should have diagnostic PKST007
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST007");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST007");
     }
 
+    [Scenario("CompleteOrderFlowExample GeneratesCorrectly")]
     [Fact]
     public void CompleteOrderFlowExample_GeneratesCorrectly()
     {
@@ -778,24 +799,25 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify all expected elements are generated
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("State { get; private set; }", generatedSource);
-        Assert.Contains("CanFire", generatedSource);
-        Assert.Contains("Fire(", generatedSource);
-        Assert.Contains("FireAsync(", generatedSource);
-        Assert.Contains("CanPay()", generatedSource);
-        Assert.Contains("OnExitPaid()", generatedSource);
-        Assert.Contains("OnEnterShipped()", generatedSource);
-        Assert.Contains("await OnPayAsync(cancellationToken)", generatedSource);
+        ScenarioExpect.Contains("State { get; private set; }", generatedSource);
+        ScenarioExpect.Contains("CanFire", generatedSource);
+        ScenarioExpect.Contains("Fire(", generatedSource);
+        ScenarioExpect.Contains("FireAsync(", generatedSource);
+        ScenarioExpect.Contains("CanPay()", generatedSource);
+        ScenarioExpect.Contains("OnExitPaid()", generatedSource);
+        ScenarioExpect.Contains("OnEnterShipped()", generatedSource);
+        ScenarioExpect.Contains("await OnPayAsync(cancellationToken)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("CustomMethodNames GeneratesCorrectly")]
     [Fact]
     public void CustomMethodNames_GeneratesCorrectly()
     {
@@ -823,20 +845,21 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify custom method names are used
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("public bool CanTransition", generatedSource);
-        Assert.Contains("public void Transition", generatedSource);
-        Assert.DoesNotContain("public void Fire(", generatedSource);
-        Assert.DoesNotContain("public bool CanFire", generatedSource);
+        ScenarioExpect.Contains("public bool CanTransition", generatedSource);
+        ScenarioExpect.Contains("public void Transition", generatedSource);
+        ScenarioExpect.DoesNotContain("public void Fire(", generatedSource);
+        ScenarioExpect.DoesNotContain("public bool CanFire", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenerateAsyncFalse WithAsyncMethods ReportsDiagnostic")]
     [Fact]
     public void GenerateAsyncFalse_WithAsyncMethods_ReportsDiagnostic()
     {
@@ -873,25 +896,26 @@ public class StateMachineGeneratorTests
         {
             // Check if code was even generated
             var hasGeneratedCode = result.Results.Any(r => r.GeneratedSources.Length > 0);
-            Assert.True(hasGeneratedCode, "No code was generated");
+            ScenarioExpect.True(hasGeneratedCode, "No code was generated");
             
             // Check compilation diagnostics
             var compDiags = updated.GetDiagnostics().Where(d => d.Id.StartsWith("PKST")).ToArray();
-            Assert.True(compDiags.Length > 0, $"No PKST diagnostics found. Generated code: {result.Results[0].GeneratedSources.Length} files");
+            ScenarioExpect.True(compDiags.Length > 0, $"No PKST diagnostics found. Generated code: {result.Results[0].GeneratedSources.Length} files");
         }
         
-        Assert.Contains(diagnostics, d => d.Id == "PKST008");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST008");
 
         // Verify FireAsync is NOT generated
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.DoesNotContain("FireAsync", generatedSource);
-        Assert.Contains("public void Fire", generatedSource);
+        ScenarioExpect.DoesNotContain("FireAsync", generatedSource);
+        ScenarioExpect.Contains("public void Fire", generatedSource);
 
         // And the updated compilation actually compiles (sync Fire should block on async method)
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GuardWithCancellationToken GeneratesCorrectly")]
     [Fact]
     public void GuardWithCancellationToken_GeneratesCorrectly()
     {
@@ -920,17 +944,18 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify guard is called with CancellationToken.None in CanFire
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("CanTransition(global::System.Threading.CancellationToken.None)", generatedSource);
+        ScenarioExpect.Contains("CanTransition(global::System.Threading.CancellationToken.None)", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("AsyncGuardInCanFire EvaluatesSynchronously")]
     [Fact]
     public void AsyncGuardInCanFire_EvaluatesSynchronously()
     {
@@ -964,17 +989,18 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         // No generator diagnostics
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Verify async guard is evaluated synchronously with GetAwaiter().GetResult()
         var generatedSource = result.Results[0].GeneratedSources[0].SourceText.ToString();
-        Assert.Contains("CanTransitionAsync(global::System.Threading.CancellationToken.None).GetAwaiter().GetResult()", generatedSource);
+        ScenarioExpect.Contains("CanTransitionAsync(global::System.Threading.CancellationToken.None).GetAwaiter().GetResult()", generatedSource);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("GenericType ReportsDiagnostic")]
     [Fact]
     public void GenericType_ReportsDiagnostic()
     {
@@ -1000,9 +1026,10 @@ public class StateMachineGeneratorTests
 
         // Should have PKST009 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST009");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST009");
     }
 
+    [Scenario("NestedType ReportsDiagnostic")]
     [Fact]
     public void NestedType_ReportsDiagnostic()
     {
@@ -1031,9 +1058,10 @@ public class StateMachineGeneratorTests
 
         // Should have PKST010 diagnostic
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST010");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST010");
     }
 
+    [Scenario("AsyncMembersWithGenerateAsyncFalse ReportsDiagnosticAndGeneratesSyncOnly")]
     [Fact]
     public void AsyncMembersWithGenerateAsyncFalse_ReportsDiagnosticAndGeneratesSyncOnly()
     {
@@ -1059,16 +1087,17 @@ public class StateMachineGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
         var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKST008");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKST008");
 
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
-        Assert.Contains("void Move(", generated);
-        Assert.DoesNotContain("FireAsync", generated);
+        ScenarioExpect.Contains("void Move(", generated);
+        ScenarioExpect.DoesNotContain("FireAsync", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("InvalidTransitionGuardAndHookSignatures ReportDiagnostics")]
     [Fact]
     public void InvalidTransitionGuardAndHookSignatures_ReportDiagnostics()
     {
@@ -1126,10 +1155,11 @@ public class StateMachineGeneratorTests
             var comp = RoslynTestHelpers.CreateCompilation(source, assemblyName);
             var gen = new StateMachineGenerator();
             _ = RoslynTestHelpers.Run(comp, gen, out var result, out _);
-            Assert.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == id);
+            ScenarioExpect.Contains(result.Results.SelectMany(r => r.Diagnostics), d => d.Id == id);
         }
     }
 
+    [Scenario("ForceAsyncWithCustomNamesAndIgnorePolicies GeneratesNoOpBranches")]
     [Fact]
     public void ForceAsyncWithCustomNamesAndIgnorePolicies_GeneratesNoOpBranches()
     {
@@ -1172,16 +1202,16 @@ public class StateMachineGeneratorTests
         var gen = new StateMachineGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
 
-        Assert.All(result.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var generated = result.Results.SelectMany(r => r.GeneratedSources).Single().SourceText.ToString();
-        Assert.Contains("void Move(", generated);
-        Assert.Contains("ValueTask MoveAsync", generated);
-        Assert.Contains("bool CanMove", generated);
-        Assert.Contains("LeavingAsync(cancellationToken).ConfigureAwait(false)", generated);
-        Assert.Contains("EnteringAsync(cancellationToken).ConfigureAwait(false)", generated);
+        ScenarioExpect.Contains("void Move(", generated);
+        ScenarioExpect.Contains("ValueTask MoveAsync", generated);
+        ScenarioExpect.Contains("bool CanMove", generated);
+        ScenarioExpect.Contains("LeavingAsync(cancellationToken).ConfigureAwait(false)", generated);
+        ScenarioExpect.Contains("EnteringAsync(cancellationToken).ConfigureAwait(false)", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 }

--- a/test/PatternKit.Generators.Tests/StrategyGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/StrategyGeneratorTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using PatternKit.Common;
 using PatternKit.Creational.Builder;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -29,6 +30,7 @@ public class StrategyGeneratorTests
                                  }
                                  """;
 
+    [Scenario("Generates All Strategies Without Diagnostics")]
     [Fact]
     public void Generates_All_Strategies_Without_Diagnostics()
     {
@@ -46,19 +48,20 @@ public class StrategyGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.True(r.Diagnostics.Length == 0));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.True(r.Diagnostics.Length == 0));
 
         // Confirm we generated expected files
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("OrderRouter.g.cs", names);
-        Assert.Contains("ScoreLabeler.g.cs", names);
-        Assert.Contains("IntParser.g.cs", names);
+        ScenarioExpect.Contains("OrderRouter.g.cs", names);
+        ScenarioExpect.Contains("ScoreLabeler.g.cs", names);
+        ScenarioExpect.Contains("IntParser.g.cs", names);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("OrderRouter Wires Predicate And Action")]
     [Fact]
     public void OrderRouter_Wires_Predicate_And_Action()
     {
@@ -92,13 +95,13 @@ public class StrategyGeneratorTests
         var gen = new StrategyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
-        // (Optional) load & invoke Demo.Run via reflection to assert behavior
+        // (Optional) load & invoke Demo.Run via reflection to verify behavior
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -106,9 +109,10 @@ public class StrategyGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("L:A|D:7|O:@", run);
+        ScenarioExpect.Equal("L:A|D:7|O:@", run);
     }
 
+    [Scenario("IntParser Try Handler Signature Works")]
     [Fact]
     public void IntParser_Try_Handler_Signature_Works()
     {
@@ -136,21 +140,22 @@ public class StrategyGeneratorTests
         var gen = new StrategyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
         var parse = asm.GetType("PatternKit.Examples.Generators.ParseDemo")!
             .GetMethod("Parse")!;
-        Assert.Equal((true, 42), (ValueTuple<bool, int>)parse.Invoke(null, ["42"])!);
-        Assert.Equal((true, 0), (ValueTuple<bool, int>)parse.Invoke(null, ["x"])!);
+        ScenarioExpect.Equal((true, 42), (ValueTuple<bool, int>)parse.Invoke(null, ["42"])!);
+        ScenarioExpect.Equal((true, 0), (ValueTuple<bool, int>)parse.Invoke(null, ["x"])!);
     }
 
+    [Scenario("ScoreLabeler Result Strategy Works")]
     [Fact]
     public void ScoreLabeler_Result_Strategy_Works()
     {
@@ -180,12 +185,12 @@ public class StrategyGeneratorTests
         var gen = new StrategyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -193,9 +198,10 @@ public class StrategyGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("A,B,C,F", run);
+        ScenarioExpect.Equal("A,B,C,F", run);
     }
 
+    [Scenario("TryExecute Returns False When No Match")]
     [Fact]
     public void TryExecute_Returns_False_When_No_Match()
     {
@@ -225,12 +231,12 @@ public class StrategyGeneratorTests
         var gen = new StrategyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -238,9 +244,10 @@ public class StrategyGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("True,False", run);
+        ScenarioExpect.Equal("True,False", run);
     }
 
+    [Scenario("Simple Namespace Strategy Works")]
     [Fact]
     public void Simple_Namespace_Strategy_Works()
     {
@@ -278,15 +285,15 @@ public class StrategyGeneratorTests
             extra: [coreRef, commonRef]);
         var gen = new StrategyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -294,9 +301,10 @@ public class StrategyGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("+5|=0", result);
+        ScenarioExpect.Equal("+5|=0", result);
     }
 
+    [Scenario("TryStrategy When Conditional Chain Works")]
     [Fact]
     public void TryStrategy_When_Conditional_Chain_Works()
     {
@@ -326,12 +334,12 @@ public class StrategyGeneratorTests
         var gen = new StrategyGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -340,13 +348,14 @@ public class StrategyGeneratorTests
 
         // With fallback enabled
         var withFallback = run.Invoke(null, [true]) as string;
-        Assert.Equal("-1", withFallback);
+        ScenarioExpect.Equal("-1", withFallback);
 
         // Without fallback - returns default (null result)
         var withoutFallback = run.Invoke(null, [false]) as string;
-        Assert.Equal("null", withoutFallback);
+        ScenarioExpect.Equal("null", withoutFallback);
     }
 
+    [Scenario("Strategies On Separate Classes Work")]
     [Fact]
     public void Strategies_On_Separate_Classes_Work()
     {
@@ -397,16 +406,16 @@ public class StrategyGeneratorTests
 
         // Should generate both ProcessInt.g.cs and ProcessString.g.cs
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("ProcessInt.g.cs", names);
-        Assert.Contains("ProcessString.g.cs", names);
+        ScenarioExpect.Contains("ProcessInt.g.cs", names);
+        ScenarioExpect.Contains("ProcessString.g.cs", names);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -414,6 +423,6 @@ public class StrategyGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("int:42|str:hello", result);
+        ScenarioExpect.Equal("int:42|str:hello", result);
     }
 }

--- a/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -9,6 +10,7 @@ public class TemplateGeneratorTests
 {
     #region Basic Template Tests
 
+    [Scenario("Generates Basic Template Without Diagnostics")]
     [Fact]
     public void Generates_Basic_Template_Without_Diagnostics()
     {
@@ -44,17 +46,18 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated the expected file
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("ImportWorkflow.Template.g.cs", names);
+        ScenarioExpect.Contains("ImportWorkflow.Template.g.cs", names);
 
         // Verify compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Generated Execute Method Compiles Successfully")]
     [Fact]
     public void Generated_Execute_Method_Compiles_Successfully()
     {
@@ -100,7 +103,7 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Get generated source
         var generatedSource = run.Results
@@ -109,20 +112,21 @@ public class TemplateGeneratorTests
             .SourceText.ToString();
 
         // Verify Execute method exists
-        Assert.Contains("public void Execute(", generatedSource);
-        Assert.Contains("Validate(ctx);", generatedSource);
-        Assert.Contains("Transform(ctx);", generatedSource);
-        Assert.Contains("Persist(ctx);", generatedSource);
+        ScenarioExpect.Contains("public void Execute(", generatedSource);
+        ScenarioExpect.Contains("Validate(ctx);", generatedSource);
+        ScenarioExpect.Contains("Transform(ctx);", generatedSource);
+        ScenarioExpect.Contains("Persist(ctx);", generatedSource);
 
         // Verify compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
     #endregion
 
     #region Hook Tests
 
+    [Scenario("Generates Template With BeforeAll Hook")]
     [Fact]
     public void Generates_Template_With_BeforeAll_Hook()
     {
@@ -167,10 +171,10 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify BeforeAll hook is called first
         var generatedSource = run.Results
@@ -180,9 +184,10 @@ public class TemplateGeneratorTests
 
         var onStartIndex = generatedSource.IndexOf("OnStart(ctx);");
         var validateIndex = generatedSource.IndexOf("Validate(ctx);");
-        Assert.True(onStartIndex < validateIndex, "BeforeAll hook should be called before steps");
+        ScenarioExpect.True(onStartIndex < validateIndex, "BeforeAll hook should be called before steps");
     }
 
+    [Scenario("Generates Template With AfterAll Hook")]
     [Fact]
     public void Generates_Template_With_AfterAll_Hook()
     {
@@ -227,10 +232,10 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify AfterAll hook is called last
         var generatedSource = run.Results
@@ -240,9 +245,10 @@ public class TemplateGeneratorTests
 
         var transformIndex = generatedSource.LastIndexOf("Transform(ctx);");
         var onCompleteIndex = generatedSource.IndexOf("OnComplete(ctx);");
-        Assert.True(transformIndex < onCompleteIndex, "AfterAll hook should be called after steps");
+        ScenarioExpect.True(transformIndex < onCompleteIndex, "AfterAll hook should be called after steps");
     }
 
+    [Scenario("Generates Template With OnError Hook")]
     [Fact]
     public void Generates_Template_With_OnError_Hook()
     {
@@ -289,10 +295,10 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify OnError hook is in try-catch block
         var generatedSource = run.Results
@@ -300,16 +306,17 @@ public class TemplateGeneratorTests
             .First(gs => gs.HintName.Contains("ImportWorkflow"))
             .SourceText.ToString();
 
-        Assert.Contains("try", generatedSource);
-        Assert.Contains("catch (System.Exception ex)", generatedSource);
-        Assert.Contains("OnError(ctx, ex);", generatedSource);
-        Assert.Contains("throw;", generatedSource); // Rethrow policy
+        ScenarioExpect.Contains("try", generatedSource);
+        ScenarioExpect.Contains("catch (System.Exception ex)", generatedSource);
+        ScenarioExpect.Contains("OnError(ctx, ex);", generatedSource);
+        ScenarioExpect.Contains("throw;", generatedSource); // Rethrow policy
     }
 
     #endregion
 
     #region Async Tests
 
+    [Scenario("Generates Async Template With ValueTask")]
     [Fact]
     public void Generates_Async_Template_With_ValueTask()
     {
@@ -358,10 +365,10 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify ExecuteAsync method is generated
         var generatedSource = run.Results
@@ -369,12 +376,13 @@ public class TemplateGeneratorTests
             .First(gs => gs.HintName.Contains("ImportWorkflow"))
             .SourceText.ToString();
 
-        Assert.Contains("public async System.Threading.Tasks.ValueTask ExecuteAsync(", generatedSource);
-        Assert.Contains("await ValidateAsync(ctx, ct).ConfigureAwait(false);", generatedSource);
-        Assert.Contains("Transform(ctx);", generatedSource);
-        Assert.Contains("await PersistAsync(ctx, ct).ConfigureAwait(false);", generatedSource);
+        ScenarioExpect.Contains("public async System.Threading.Tasks.ValueTask ExecuteAsync(", generatedSource);
+        ScenarioExpect.Contains("await ValidateAsync(ctx, ct).ConfigureAwait(false);", generatedSource);
+        ScenarioExpect.Contains("Transform(ctx);", generatedSource);
+        ScenarioExpect.Contains("await PersistAsync(ctx, ct).ConfigureAwait(false);", generatedSource);
     }
 
+    [Scenario("Generates Async Template With ForceAsync")]
     [Fact]
     public void Generates_Async_Template_With_ForceAsync()
     {
@@ -415,10 +423,10 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify ExecuteAsync method is generated even for sync steps
         var generatedSource = run.Results
@@ -426,15 +434,16 @@ public class TemplateGeneratorTests
             .First(gs => gs.HintName.Contains("ImportWorkflow"))
             .SourceText.ToString();
 
-        Assert.Contains("public async System.Threading.Tasks.ValueTask ExecuteAsync(", generatedSource);
-        Assert.Contains("Validate(ctx);", generatedSource);
-        Assert.Contains("Transform(ctx);", generatedSource);
+        ScenarioExpect.Contains("public async System.Threading.Tasks.ValueTask ExecuteAsync(", generatedSource);
+        ScenarioExpect.Contains("Validate(ctx);", generatedSource);
+        ScenarioExpect.Contains("Transform(ctx);", generatedSource);
     }
 
     #endregion
 
     #region Type Target Tests
 
+    [Scenario("Generates Template For Struct")]
     [Fact]
     public void Generates_Template_For_Struct()
     {
@@ -466,12 +475,13 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Generates Template For Record Class")]
     [Fact]
     public void Generates_Template_For_Record_Class()
     {
@@ -503,12 +513,13 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Generates Template For Record Struct")]
     [Fact]
     public void Generates_Template_For_Record_Struct()
     {
@@ -540,16 +551,17 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
     #endregion
 
     #region Diagnostic Tests
 
+    [Scenario("Reports Error When Type Not Partial")]
     [Fact]
     public void Reports_Error_When_Type_Not_Partial()
     {
@@ -576,9 +588,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP001");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP001");
     }
 
+    [Scenario("Reports Error When No Steps")]
     [Fact]
     public void Reports_Error_When_No_Steps()
     {
@@ -603,9 +616,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP002");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP002");
     }
 
+    [Scenario("Reports Error When Duplicate Step Order")]
     [Fact]
     public void Reports_Error_When_Duplicate_Step_Order()
     {
@@ -635,9 +649,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP003");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP003");
     }
 
+    [Scenario("Reports Error When Invalid Step Signature")]
     [Fact]
     public void Reports_Error_When_Invalid_Step_Signature()
     {
@@ -664,9 +679,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP004");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP004");
     }
 
+    [Scenario("Reports Warning When Async Step Missing CancellationToken")]
     [Fact]
     public void Reports_Warning_When_Async_Step_Missing_CancellationToken()
     {
@@ -697,9 +713,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP007");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP007");
     }
 
+    [Scenario("Reports Error When Invalid Hook Signature No Context")]
     [Fact]
     public void Reports_Error_When_Invalid_Hook_Signature_No_Context()
     {
@@ -729,9 +746,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP005");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP005");
     }
 
+    [Scenario("Reports Error When OnError Hook Missing Exception Parameter")]
     [Fact]
     public void Reports_Error_When_OnError_Hook_Missing_Exception_Parameter()
     {
@@ -761,9 +779,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP005");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP005");
     }
 
+    [Scenario("Reports Error When Hook Returns Invalid Type")]
     [Fact]
     public void Reports_Error_When_Hook_Returns_Invalid_Type()
     {
@@ -793,9 +812,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP005");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP005");
     }
 
+    [Scenario("Reports Error When HandleAndContinue With NonOptional Steps")]
     [Fact]
     public void Reports_Error_When_HandleAndContinue_With_NonOptional_Steps()
     {
@@ -825,9 +845,10 @@ public class TemplateGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
 
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKTMP008");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP008");
     }
 
+    [Scenario("Allows HandleAndContinue With All Optional Steps")]
     [Fact]
     public void Allows_HandleAndContinue_With_All_Optional_Steps()
     {
@@ -858,17 +879,18 @@ public class TemplateGeneratorTests
 
         // Should not have PKTMP008 diagnostic
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.DoesNotContain(diagnostics, d => d.Id == "PKTMP008");
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Id == "PKTMP008");
 
         // Should compile successfully
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
     #endregion
 
     #region Custom Method Names
 
+    [Scenario("Generates Template With Custom Method Names")]
     [Fact]
     public void Generates_Template_With_Custom_Method_Names()
     {
@@ -901,10 +923,10 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         // Verify custom method name is used
         var generatedSource = run.Results
@@ -912,10 +934,11 @@ public class TemplateGeneratorTests
             .First(gs => gs.HintName.Contains("ImportWorkflow"))
             .SourceText.ToString();
 
-        Assert.Contains("public void Process(", generatedSource);
-        Assert.DoesNotContain("public void Execute(", generatedSource);
+        ScenarioExpect.Contains("public void Process(", generatedSource);
+        ScenarioExpect.DoesNotContain("public void Execute(", generatedSource);
     }
 
+    [Scenario("Generates Async Template With Mixed Sync Async Hooks And Error Rethrow")]
     [Fact]
     public void Generates_Async_Template_With_Mixed_Sync_Async_Hooks_And_Error_Rethrow()
     {
@@ -968,25 +991,25 @@ public class TemplateGeneratorTests
         var gen = new TemplateGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
         var generated = run.Results
             .SelectMany(r => r.GeneratedSources)
             .Single(gs => gs.HintName == "ImportWorkflow.Template.g.cs")
             .SourceText.ToString();
 
-        Assert.Contains("public async System.Threading.Tasks.ValueTask RunAsync", generated);
-        Assert.Contains("await OpenAsync(ctx, ct).ConfigureAwait(false);", generated);
-        Assert.Contains("TraceOpen(ctx);", generated);
-        Assert.Contains("await ValidateAsync(ctx, ct).ConfigureAwait(false);", generated);
-        Assert.Contains("Transform(ctx);", generated);
-        Assert.Contains("await CloseAsync(ctx, ct).ConfigureAwait(false);", generated);
-        Assert.Contains("TraceClose(ctx);", generated);
-        Assert.Contains("await CaptureErrorAsync(ctx, ex, ct).ConfigureAwait(false);", generated);
-        Assert.Contains("TraceError(ctx, ex);", generated);
-        Assert.Contains("throw;", generated);
+        ScenarioExpect.Contains("public async System.Threading.Tasks.ValueTask RunAsync", generated);
+        ScenarioExpect.Contains("await OpenAsync(ctx, ct).ConfigureAwait(false);", generated);
+        ScenarioExpect.Contains("TraceOpen(ctx);", generated);
+        ScenarioExpect.Contains("await ValidateAsync(ctx, ct).ConfigureAwait(false);", generated);
+        ScenarioExpect.Contains("Transform(ctx);", generated);
+        ScenarioExpect.Contains("await CloseAsync(ctx, ct).ConfigureAwait(false);", generated);
+        ScenarioExpect.Contains("TraceClose(ctx);", generated);
+        ScenarioExpect.Contains("await CaptureErrorAsync(ctx, ex, ct).ConfigureAwait(false);", generated);
+        ScenarioExpect.Contains("TraceError(ctx, ex);", generated);
+        ScenarioExpect.Contains("throw;", generated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
     #endregion

--- a/test/PatternKit.Generators.Tests/VisitorGeneratorComprehensiveTests.cs
+++ b/test/PatternKit.Generators.Tests/VisitorGeneratorComprehensiveTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -40,6 +41,7 @@ public class VisitorGeneratorComprehensiveTests
 
     #region Double-Dispatch Behavioral Tests
 
+    [Scenario("Behavior Accept Performs Double Dispatch To Visit")]
     [Fact]
     public void Behavior_Accept_Performs_Double_Dispatch_To_Visit()
     {
@@ -80,9 +82,10 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.DoubleDispatchTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("Visit(Dog)|Visit(Cat)", result);
+        ScenarioExpect.Equal("Visit(Dog)|Visit(Cat)", result);
     }
 
+    [Scenario("Behavior Most Specific Handler Is Chosen First")]
     [Fact]
     public void Behavior_Most_Specific_Handler_Is_Chosen_First()
     {
@@ -115,9 +118,10 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.PriorityTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("SpecificDog", result);
+        ScenarioExpect.Equal("SpecificDog", result);
     }
 
+    [Scenario("Behavior Default Handler Used When No Specific Match")]
     [Fact]
     public void Behavior_Default_Handler_Used_When_No_Specific_Match()
     {
@@ -149,9 +153,10 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.DefaultTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("Default:Unknown", result);
+        ScenarioExpect.Equal("Default:Unknown", result);
     }
 
+    [Scenario("Behavior Throws Exception When No Handler And No Default")]
     [Fact]
     public void Behavior_Throws_Exception_When_No_Handler_And_No_Default()
     {
@@ -180,17 +185,18 @@ public class VisitorGeneratorComprehensiveTests
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
-        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() =>
+        var ex = ScenarioExpect.Throws<System.Reflection.TargetInvocationException>(() =>
             asm.GetType("Test.NoHandlerTest")!
                 .GetMethod("Run")!.Invoke(null, null));
 
-        Assert.Contains("No handler registered", ex.InnerException!.Message);
+        ScenarioExpect.Contains("No handler registered", ex.InnerException!.Message);
     }
 
     #endregion
 
     #region Action Visitor Behavioral Tests
 
+    [Scenario("Behavior Action Visitor Executes Side Effects Without Return")]
     [Fact]
     public void Behavior_Action_Visitor_Executes_Side_Effects_Without_Return()
     {
@@ -229,9 +235,10 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.ActionTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("Dog:Lab|Cat:False|Animal:Generic", result);
+        ScenarioExpect.Equal("Dog:Lab|Cat:False|Animal:Generic", result);
     }
 
+    [Scenario("Behavior Action Visitor Default Handler Works")]
     [Fact]
     public void Behavior_Action_Visitor_Default_Handler_Works()
     {
@@ -267,13 +274,14 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.ActionDefaultTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("Default:Dog|Default:Cat", result);
+        ScenarioExpect.Equal("Default:Dog|Default:Cat", result);
     }
 
     #endregion
 
     #region Async Visitor Behavioral Tests
 
+    [Scenario("Behavior Async Visitor Supports ValueTask Return Type")]
     [Fact]
     public void Behavior_Async_Visitor_Supports_ValueTask_Return_Type()
     {
@@ -319,9 +327,10 @@ public class VisitorGeneratorComprehensiveTests
         var task = asm.GetType("Test.AsyncTest")!
             .GetMethod("Run")!.Invoke(null, null) as Task<string>;
 
-        Assert.Equal("AsyncDog:Poodle|AsyncCat:True", task!.Result);
+        ScenarioExpect.Equal("AsyncDog:Poodle|AsyncCat:True", task!.Result);
     }
 
+    [Scenario("Behavior Async Action Visitor Performs Async Side Effects")]
     [Fact]
     public void Behavior_Async_Action_Visitor_Performs_Async_Side_Effects()
     {
@@ -366,9 +375,10 @@ public class VisitorGeneratorComprehensiveTests
         var task = asm.GetType("Test.AsyncActionTest")!
             .GetMethod("Run")!.Invoke(null, null) as Task<string>;
 
-        Assert.Equal("AsyncDog:Husky|AsyncCat:False", task!.Result);
+        ScenarioExpect.Equal("AsyncDog:Husky|AsyncCat:False", task!.Result);
     }
 
+    [Scenario("Behavior CancellationToken Propagates Through Async Visitor")]
     [Fact]
     public void Behavior_CancellationToken_Propagates_Through_Async_Visitor()
     {
@@ -415,9 +425,10 @@ public class VisitorGeneratorComprehensiveTests
         var task = asm.GetType("Test.CancellationTest")!
             .GetMethod("Run")!.Invoke(null, null) as Task<string>;
 
-        Assert.Equal("Cancelled", task!.Result);
+        ScenarioExpect.Equal("Cancelled", task!.Result);
     }
 
+    [Scenario("Behavior Async Default Handler Works Correctly")]
     [Fact]
     public void Behavior_Async_Default_Handler_Works_Correctly()
     {
@@ -455,13 +466,14 @@ public class VisitorGeneratorComprehensiveTests
         var task = asm.GetType("Test.AsyncDefaultTest")!
             .GetMethod("Run")!.Invoke(null, null) as Task<string>;
 
-        Assert.Equal("DefaultAsync:Dog|DefaultAsync:Cat", task!.Result);
+        ScenarioExpect.Equal("DefaultAsync:Dog|DefaultAsync:Cat", task!.Result);
     }
 
     #endregion
 
     #region Complex Hierarchy Behavioral Tests
 
+    [Scenario("Behavior Deep Hierarchy Three Levels Handled Correctly")]
     [Fact]
     public void Behavior_Deep_Hierarchy_Three_Levels_Handled_Correctly()
     {
@@ -501,16 +513,17 @@ public class VisitorGeneratorComprehensiveTests
 
         using var pe = new MemoryStream();
         var emitResult = updated.Emit(pe);
-        Assert.True(emitResult.Success, string.Join("\n", emitResult.Diagnostics));
+        ScenarioExpect.True(emitResult.Success, string.Join("\n", emitResult.Diagnostics));
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe);
         var result = asm.GetType("Test.DeepTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("Twig|Branch|Root", result);
+        ScenarioExpect.Equal("Twig|Branch|Root", result);
     }
 
+    [Scenario("Behavior Multiple Siblings In Hierarchy All Visitable")]
     [Fact]
     public void Behavior_Multiple_Siblings_In_Hierarchy_All_Visitable()
     {
@@ -557,13 +570,14 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.SiblingTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("Circle|Square|Triangle", result);
+        ScenarioExpect.Equal("Circle|Square|Triangle", result);
     }
 
     #endregion
 
     #region Type Safety Behavioral Tests
 
+    [Scenario("Behavior Generic When Enforces Type Safety At Compile Time")]
     [Fact]
     public void Behavior_Generic_When_Enforces_Type_Safety_At_Compile_Time()
     {
@@ -588,7 +602,7 @@ public class VisitorGeneratorComprehensiveTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, "Type-safe code should compile");
+        ScenarioExpect.True(emit.Success, "Type-safe code should compile");
 
         using var pe = new MemoryStream();
         updated.Emit(pe);
@@ -597,13 +611,14 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.TypeSafetyTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("TypeSafe", result);
+        ScenarioExpect.Equal("TypeSafe", result);
     }
 
     #endregion
 
     #region Builder Fluency Behavioral Tests
 
+    [Scenario("Behavior Builder Supports Method Chaining")]
     [Fact]
     public void Behavior_Builder_Supports_Method_Chaining()
     {
@@ -630,9 +645,10 @@ public class VisitorGeneratorComprehensiveTests
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, "Chaining code should compile");
+        ScenarioExpect.True(emit.Success, "Chaining code should compile");
     }
 
+    [Scenario("Behavior Multiple Handlers Can Be Registered")]
     [Fact]
     public void Behavior_Multiple_Handlers_Can_Be_Registered()
     {
@@ -671,13 +687,14 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.MultiHandlerTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("3", result);
+        ScenarioExpect.Equal("3", result);
     }
 
     #endregion
 
     #region Edge Cases and Error Behavioral Tests
 
+    [Scenario("Behavior Empty Visitor With Default Only Works")]
     [Fact]
     public void Behavior_Empty_Visitor_With_Default_Only_Works()
     {
@@ -708,9 +725,10 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.EmptyWithDefaultTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("AllDefault", result);
+        ScenarioExpect.Equal("AllDefault", result);
     }
 
+    [Scenario("Behavior Same Type Registered Multiple Times Last Wins")]
     [Fact]
     public void Behavior_Same_Type_Registered_Multiple_Times_Last_Wins()
     {
@@ -742,7 +760,7 @@ public class VisitorGeneratorComprehensiveTests
         var result = asm.GetType("Test.DuplicateTest")!
             .GetMethod("Run")!.Invoke(null, null) as string;
 
-        Assert.Equal("Second", result);
+        ScenarioExpect.Equal("Second", result);
     }
 
     #endregion

--- a/test/PatternKit.Generators.Tests/VisitorGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/VisitorGeneratorTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
+using TinyBDD;
 
 namespace PatternKit.Generators.Tests;
 
@@ -36,6 +37,7 @@ public class VisitorGeneratorTests
                                         }
                                         """;
 
+    [Scenario("Generates Visitor Infrastructure Without Diagnostics")]
     [Fact]
     public void Generates_Visitor_Infrastructure_Without_Diagnostics()
     {
@@ -48,39 +50,40 @@ public class VisitorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated expected files
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
 
         // Interfaces
-        Assert.Contains("IAstNodeVisitor.Interfaces.g.cs", names);
+        ScenarioExpect.Contains("IAstNodeVisitor.Interfaces.g.cs", names);
 
         // Accept methods for each type
-        Assert.Contains("AstNode.Accept.g.cs", names);
-        Assert.Contains("Expression.Accept.g.cs", names);
-        Assert.Contains("Statement.Accept.g.cs", names);
-        Assert.Contains("NumberExpression.Accept.g.cs", names);
-        Assert.Contains("AddExpression.Accept.g.cs", names);
+        ScenarioExpect.Contains("AstNode.Accept.g.cs", names);
+        ScenarioExpect.Contains("Expression.Accept.g.cs", names);
+        ScenarioExpect.Contains("Statement.Accept.g.cs", names);
+        ScenarioExpect.Contains("NumberExpression.Accept.g.cs", names);
+        ScenarioExpect.Contains("AddExpression.Accept.g.cs", names);
 
         var generatedSources = run.Results.SelectMany(r => r.GeneratedSources).ToDictionary(
             gs => gs.HintName,
             gs => gs.SourceText.ToString());
-        Assert.Contains("public TResult Accept<TResult>", generatedSources["AstNode.Accept.g.cs"]);
-        Assert.Contains("public new TResult Accept<TResult>", generatedSources["Expression.Accept.g.cs"]);
-        Assert.Contains("public new System.Threading.Tasks.ValueTask<TResult> AcceptAsync<TResult>", generatedSources["NumberExpression.Accept.g.cs"]);
+        ScenarioExpect.Contains("public TResult Accept<TResult>", generatedSources["AstNode.Accept.g.cs"]);
+        ScenarioExpect.Contains("public new TResult Accept<TResult>", generatedSources["Expression.Accept.g.cs"]);
+        ScenarioExpect.Contains("public new System.Threading.Tasks.ValueTask<TResult> AcceptAsync<TResult>", generatedSources["NumberExpression.Accept.g.cs"]);
 
         // Builders
-        Assert.Contains("AstNodeVisitorBuilder.g.cs", names);
-        Assert.Contains("AstNodeActionVisitorBuilder.g.cs", names);
-        Assert.Contains("AstNodeAsyncVisitorBuilder.g.cs", names);
-        Assert.Contains("AstNodeAsyncActionVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("AstNodeVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("AstNodeActionVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("AstNodeAsyncVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("AstNodeAsyncActionVisitorBuilder.g.cs", names);
 
         // And the updated compilation actually compiles
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Sync Result Visitor Dispatches Correctly")]
     [Fact]
     public void Sync_Result_Visitor_Dispatches_Correctly()
     {
@@ -119,12 +122,12 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -132,9 +135,10 @@ public class VisitorGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("Num:42|Add|Expr|Stmt", run);
+        ScenarioExpect.Equal("Num:42|Add|Expr|Stmt", run);
     }
 
+    [Scenario("Sync Action Visitor Executes Side Effects")]
     [Fact]
     public void Sync_Action_Visitor_Executes_Side_Effects()
     {
@@ -171,12 +175,12 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -184,9 +188,10 @@ public class VisitorGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as string;
 
-        Assert.Equal("N:7|A", run);
+        ScenarioExpect.Equal("N:7|A", run);
     }
 
+    [Scenario("Async Result Visitor Supports ValueTask")]
     [Fact]
     public void Async_Result_Visitor_Supports_ValueTask()
     {
@@ -228,12 +233,12 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -241,11 +246,12 @@ public class VisitorGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as System.Threading.Tasks.Task<string>;
 
-        Assert.NotNull(run);
+        ScenarioExpect.NotNull(run);
         var result = run.GetAwaiter().GetResult();
-        Assert.Equal("Async:99|AsyncExpr", result);
+        ScenarioExpect.Equal("Async:99|AsyncExpr", result);
     }
 
+    [Scenario("Async Action Visitor Supports ValueTask")]
     [Fact]
     public void Async_Action_Visitor_Supports_ValueTask()
     {
@@ -289,12 +295,12 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -302,11 +308,12 @@ public class VisitorGeneratorTests
             .GetMethod("Run")!
             .Invoke(null, null) as System.Threading.Tasks.Task<string>;
 
-        Assert.NotNull(run);
+        ScenarioExpect.NotNull(run);
         var result = run.GetAwaiter().GetResult();
-        Assert.Equal("AN:123|AS", result);
+        ScenarioExpect.Equal("AN:123|AS", result);
     }
 
+    [Scenario("Throws When No Handler Matches And No Default")]
     [Fact]
     public void Throws_When_No_Handler_Matches_And_No_Default()
     {
@@ -340,20 +347,21 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out _, out var updated);
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
 
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success);
+        ScenarioExpect.True(res.Success);
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
         var runMethod = asm.GetType("PatternKit.Examples.Ast.NoDefaultDemo")!.GetMethod("Run")!;
 
-        Assert.Throws<System.Reflection.TargetInvocationException>(() => runMethod.Invoke(null, null));
+        ScenarioExpect.Throws<System.Reflection.TargetInvocationException>(() => runMethod.Invoke(null, null));
     }
 
+    [Scenario("Custom Visitor Interface Name Works")]
     [Fact]
     public void Custom_Visitor_Interface_Name_Works()
     {
@@ -380,16 +388,17 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
-        Assert.Contains("INodeProcessor.Interfaces.g.cs", names);
-        Assert.Contains("NodeVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("INodeProcessor.Interfaces.g.cs", names);
+        ScenarioExpect.Contains("NodeVisitorBuilder.g.cs", names);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Disable Async Generation Works")]
     [Fact]
     public void Disable_Async_Generation_Works()
     {
@@ -416,22 +425,23 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
 
         // Should have sync builders
-        Assert.Contains("SyncNodeVisitorBuilder.g.cs", names);
-        Assert.Contains("SyncNodeActionVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("SyncNodeVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("SyncNodeActionVisitorBuilder.g.cs", names);
 
         // Should NOT have async builders
-        Assert.DoesNotContain("SyncNodeAsyncVisitorBuilder.g.cs", names);
-        Assert.DoesNotContain("SyncNodeAsyncActionVisitorBuilder.g.cs", names);
+        ScenarioExpect.DoesNotContain("SyncNodeAsyncVisitorBuilder.g.cs", names);
+        ScenarioExpect.DoesNotContain("SyncNodeAsyncActionVisitorBuilder.g.cs", names);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Disable Actions Generation Works")]
     [Fact]
     public void Disable_Actions_Generation_Works()
     {
@@ -458,22 +468,23 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
 
         // Should have result builders
-        Assert.Contains("ResultNodeVisitorBuilder.g.cs", names);
-        Assert.Contains("ResultNodeAsyncVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("ResultNodeVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("ResultNodeAsyncVisitorBuilder.g.cs", names);
 
         // Should NOT have action builders
-        Assert.DoesNotContain("ResultNodeActionVisitorBuilder.g.cs", names);
-        Assert.DoesNotContain("ResultNodeAsyncActionVisitorBuilder.g.cs", names);
+        ScenarioExpect.DoesNotContain("ResultNodeActionVisitorBuilder.g.cs", names);
+        ScenarioExpect.DoesNotContain("ResultNodeAsyncActionVisitorBuilder.g.cs", names);
 
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Generates Visitor For Interface Hierarchy")]
     [Fact]
     public void Generates_Visitor_For_Interface_Hierarchy()
     {
@@ -511,28 +522,29 @@ public class VisitorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated expected files
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
 
         // Interfaces
-        Assert.Contains("IShapeVisitor.Interfaces.g.cs", names);
+        ScenarioExpect.Contains("IShapeVisitor.Interfaces.g.cs", names);
 
         // Accept methods for each type (interface + concrete classes)
-        Assert.Contains("IShape.Accept.g.cs", names);
-        Assert.Contains("Circle.Accept.g.cs", names);
-        Assert.Contains("Rectangle.Accept.g.cs", names);
-        Assert.Contains("Triangle.Accept.g.cs", names);
+        ScenarioExpect.Contains("IShape.Accept.g.cs", names);
+        ScenarioExpect.Contains("Circle.Accept.g.cs", names);
+        ScenarioExpect.Contains("Rectangle.Accept.g.cs", names);
+        ScenarioExpect.Contains("Triangle.Accept.g.cs", names);
 
         // Builders
-        Assert.Contains("IShapeVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("IShapeVisitorBuilder.g.cs", names);
 
         // Verify compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Interface Hierarchy Visitor Dispatches Correctly")]
     [Fact]
     public void Interface_Hierarchy_Visitor_Dispatches_Correctly()
     {
@@ -583,13 +595,13 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Emit and execute
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success, string.Join("\n", res.Diagnostics));
+        ScenarioExpect.True(res.Success, string.Join("\n", res.Diagnostics));
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -600,9 +612,10 @@ public class VisitorGeneratorTests
         // Circle area: π * 5^2 ≈ 78.54
         // Rectangle area: 4 * 6 = 24
         // Total ≈ 102.54
-        Assert.True(result > 100 && result < 105, $"Expected ~102.54, got {result}");
+        ScenarioExpect.True(result > 100 && result < 105, $"Expected ~102.54, got {result}");
     }
 
+    [Scenario("Generates Visitor For Struct Hierarchy")]
     [Fact]
     public void Generates_Visitor_For_Struct_Hierarchy()
     {
@@ -638,25 +651,26 @@ public class VisitorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated expected files
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
 
         // Interfaces
-        Assert.Contains("IValueVisitor.Interfaces.g.cs", names);
+        ScenarioExpect.Contains("IValueVisitor.Interfaces.g.cs", names);
 
         // Accept methods for interface and structs
-        Assert.Contains("IValue.Accept.g.cs", names);
-        Assert.Contains("IntValue.Accept.g.cs", names);
-        Assert.Contains("DoubleValue.Accept.g.cs", names);
-        Assert.Contains("StringValue.Accept.g.cs", names);
+        ScenarioExpect.Contains("IValue.Accept.g.cs", names);
+        ScenarioExpect.Contains("IntValue.Accept.g.cs", names);
+        ScenarioExpect.Contains("DoubleValue.Accept.g.cs", names);
+        ScenarioExpect.Contains("StringValue.Accept.g.cs", names);
 
         // Verify compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Struct Visitor Dispatches Without Boxing")]
     [Fact]
     public void Struct_Visitor_Dispatches_Without_Boxing()
     {
@@ -706,13 +720,13 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Emit and execute
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success, string.Join("\n", res.Diagnostics));
+        ScenarioExpect.True(res.Success, string.Join("\n", res.Diagnostics));
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -720,9 +734,10 @@ public class VisitorGeneratorTests
         var runMethod = demo.GetMethod("Run")!;
         var result = (string)runMethod.Invoke(null, null)!;
 
-        Assert.Equal("Int:42,Double:3.14", result);
+        ScenarioExpect.Equal("Int:42,Double:3.14", result);
     }
 
+    [Scenario("Diagnostic PKVIS001 EmittedWhenNoConcretTypesFound")]
     [Fact]
     public void Diagnostic_PKVIS001_EmittedWhenNoConcretTypesFound()
     {
@@ -744,12 +759,13 @@ public class VisitorGeneratorTests
 
         // Should have PKVIS001 warning
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKVIS001");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKVIS001");
 
         var pkvis001 = diagnostics.First(d => d.Id == "PKVIS001");
-        Assert.Contains("IEmptyHierarchy", pkvis001.GetMessage());
+        ScenarioExpect.Contains("IEmptyHierarchy", pkvis001.GetMessage());
     }
 
+    [Scenario("Diagnostic PKVIS002 EmittedWhenBaseTypeNotPartial")]
     [Fact]
     public void Diagnostic_PKVIS002_EmittedWhenBaseTypeNotPartial()
     {
@@ -773,12 +789,13 @@ public class VisitorGeneratorTests
 
         // Should have PKVIS002 error
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKVIS002");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKVIS002");
 
         var pkvis002 = diagnostics.First(d => d.Id == "PKVIS002");
-        Assert.Contains("NonPartialBase", pkvis002.GetMessage());
+        ScenarioExpect.Contains("NonPartialBase", pkvis002.GetMessage());
     }
 
+    [Scenario("Diagnostic PKVIS004 EmittedWhenDerivedTypeNotPartial")]
     [Fact]
     public void Diagnostic_PKVIS004_EmittedWhenDerivedTypeNotPartial()
     {
@@ -802,12 +819,13 @@ public class VisitorGeneratorTests
 
         // Should have PKVIS004 error
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKVIS004");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKVIS004");
 
         var pkvis004 = diagnostics.First(d => d.Id == "PKVIS004");
-        Assert.Contains("NonPartialDerived", pkvis004.GetMessage());
+        ScenarioExpect.Contains("NonPartialDerived", pkvis004.GetMessage());
     }
 
+    [Scenario("No Diagnostics For Valid Hierarchy")]
     [Fact]
     public void No_Diagnostics_For_Valid_Hierarchy()
     {
@@ -833,9 +851,10 @@ public class VisitorGeneratorTests
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics)
             .Where(d => d.Id.StartsWith("PKVIS"))
             .ToArray();
-        Assert.Empty(diagnostics);
+        ScenarioExpect.Empty(diagnostics);
     }
 
+    [Scenario("Generates Visitor For Record Hierarchy")]
     [Fact]
     public void Generates_Visitor_For_Record_Hierarchy()
     {
@@ -862,28 +881,29 @@ public class VisitorGeneratorTests
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
         // No generator diagnostics
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Confirm we generated expected files
         var names = run.Results.SelectMany(r => r.GeneratedSources).Select(gs => gs.HintName).ToArray();
 
         // Interfaces
-        Assert.Contains("IMessageVisitor.Interfaces.g.cs", names);
+        ScenarioExpect.Contains("IMessageVisitor.Interfaces.g.cs", names);
 
         // Accept methods for each record type
-        Assert.Contains("Message.Accept.g.cs", names);
-        Assert.Contains("TextMessage.Accept.g.cs", names);
-        Assert.Contains("ImageMessage.Accept.g.cs", names);
-        Assert.Contains("AudioMessage.Accept.g.cs", names);
+        ScenarioExpect.Contains("Message.Accept.g.cs", names);
+        ScenarioExpect.Contains("TextMessage.Accept.g.cs", names);
+        ScenarioExpect.Contains("ImageMessage.Accept.g.cs", names);
+        ScenarioExpect.Contains("AudioMessage.Accept.g.cs", names);
 
         // Builders
-        Assert.Contains("MessageVisitorBuilder.g.cs", names);
+        ScenarioExpect.Contains("MessageVisitorBuilder.g.cs", names);
 
         // Verify compilation succeeds
         var emit = updated.Emit(Stream.Null);
-        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("Record Visitor Dispatches Correctly")]
     [Fact]
     public void Record_Visitor_Dispatches_Correctly()
     {
@@ -927,13 +947,13 @@ public class VisitorGeneratorTests
         var gen = new VisitorGenerator();
         _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
 
-        Assert.All(run.Results, r => Assert.Empty(r.Diagnostics));
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
 
         // Emit and execute
         using var pe = new MemoryStream();
         using var pdb = new MemoryStream();
         var res = updated.Emit(pe, pdb);
-        Assert.True(res.Success, string.Join("\n", res.Diagnostics));
+        ScenarioExpect.True(res.Success, string.Join("\n", res.Diagnostics));
         pe.Position = 0;
 
         var asm = AssemblyLoadContext.Default.LoadFromStream(pe, pdb);
@@ -941,9 +961,10 @@ public class VisitorGeneratorTests
         var runMethod = demo.GetMethod("Run")!;
         var result = (string)runMethod.Invoke(null, null)!;
 
-        Assert.Equal("Text: Hello World|Image: PNG", result);
+        ScenarioExpect.Equal("Text: Hello World|Image: PNG", result);
     }
 
+    [Scenario("Diagnostic PKVIS002 EmittedWhenInterfaceBaseTypeNotPartial")]
     [Fact]
     public void Diagnostic_PKVIS002_EmittedWhenInterfaceBaseTypeNotPartial()
     {
@@ -967,9 +988,9 @@ public class VisitorGeneratorTests
 
         // Should have PKVIS002 error
         var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
-        Assert.Contains(diagnostics, d => d.Id == "PKVIS002");
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKVIS002");
 
         var pkvis002 = diagnostics.First(d => d.Id == "PKVIS002");
-        Assert.Contains("INotPartial", pkvis002.GetMessage());
+        ScenarioExpect.Contains("INotPartial", pkvis002.GetMessage());
     }
 }

--- a/test/PatternKit.Tests/Behavioral/AsyncTemplateMethodTests.cs
+++ b/test/PatternKit.Tests/Behavioral/AsyncTemplateMethodTests.cs
@@ -94,8 +94,8 @@ public sealed class AsyncTemplateMethodTests(ITestOutputHelper output) : TinyBdd
         using var cts = new CancellationTokenSource();
         cts.Cancel(); // pre-cancel so cancellation is immediate and deterministic
 
-        // Assert.ThrowsAnyAsync verifies that OperationCanceledException or derived types are thrown
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+        // ScenarioExpect.ThrowsAnyAsync verifies that OperationCanceledException or derived types are thrown
+        await ScenarioExpect.ThrowsAnyAsync<OperationCanceledException>(
             async () => await template.ExecuteAsync(1, cts.Token));
     }
 }
@@ -154,50 +154,55 @@ public sealed class AsyncTemplateMethodEdgeCaseTests
         }
     }
 
+    [Scenario("MinimalTemplate NoHooks Works")]
     [Fact]
     public async Task MinimalTemplate_NoHooks_Works()
     {
         var template = new MinimalAsyncTemplate();
         var result = await template.ExecuteAsync(42);
-        Assert.Equal("Result-42", result);
+        ScenarioExpect.Equal("Result-42", result);
     }
 
+    [Scenario("HooksTemplate ExecutesInOrder")]
     [Fact]
     public async Task HooksTemplate_ExecutesInOrder()
     {
         var template = new HooksAsyncTemplate();
         var result = await template.ExecuteAsync(5);
 
-        Assert.Equal("step:5", result);
-        Assert.Equal(2, template.Log.Count);
-        Assert.Equal("before:5", template.Log[0]);
-        Assert.Equal("after:step:5", template.Log[1]);
+        ScenarioExpect.Equal("step:5", result);
+        ScenarioExpect.Equal(2, template.Log.Count);
+        ScenarioExpect.Equal("before:5", template.Log[0]);
+        ScenarioExpect.Equal("after:step:5", template.Log[1]);
     }
 
+    [Scenario("ThrowingStep NotSynchronized DoesNotCallAfter")]
     [Fact]
     public async Task ThrowingStep_NotSynchronized_DoesNotCallAfter()
     {
         var template = new ThrowingStepTemplate { Sync = false };
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => template.ExecuteAsync(1));
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() => template.ExecuteAsync(1));
 
-        Assert.Equal(1, template.BeforeCount);
-        Assert.Equal(0, template.AfterCount);
+        ScenarioExpect.Equal(1, template.BeforeCount);
+        ScenarioExpect.Equal(0, template.AfterCount);
     }
 
+    [Scenario("ThrowingStep Synchronized MutexIsReleased")]
     [Fact]
     public async Task ThrowingStep_Synchronized_MutexIsReleased()
     {
         var template = new ThrowingStepTemplate { Sync = true };
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => template.ExecuteAsync(1));
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() => template.ExecuteAsync(1));
 
         // The mutex should be released, so a second call should not deadlock
-        await Assert.ThrowsAsync<InvalidOperationException>(() => template.ExecuteAsync(2));
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() => template.ExecuteAsync(2));
 
-        Assert.Equal(2, template.BeforeCount);
+        ScenarioExpect.Equal(2, template.BeforeCount);
     }
 
+    [Scenario("Synchronized Cancellation DuringMutexWait")]
     [Fact]
     public async Task Synchronized_Cancellation_DuringMutexWait()
     {
@@ -211,13 +216,13 @@ public sealed class AsyncTemplateMethodEdgeCaseTests
         cts.Cancel();
 
         // TaskCanceledException is a subclass of OperationCanceledException
-        var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+        var ex = await ScenarioExpect.ThrowsAnyAsync<OperationCanceledException>(
             () => template.ExecuteAsync(2, cts.Token));
-        Assert.True(ex is OperationCanceledException or TaskCanceledException);
+        ScenarioExpect.True(ex is OperationCanceledException or TaskCanceledException);
 
         // First should still complete
         var result = await first;
-        Assert.Equal("slow:1", result);
+        ScenarioExpect.Equal("slow:1", result);
     }
 
     private sealed class SynchronizedSlowTemplate : AsyncTemplateMethod<int, string>

--- a/test/PatternKit.Tests/Behavioral/AsyncTypeDispatcherTests.cs
+++ b/test/PatternKit.Tests/Behavioral/AsyncTypeDispatcherTests.cs
@@ -30,10 +30,10 @@ public sealed class AsyncTypeDispatcherTests(ITestOutputHelper output) : TinyBdd
         var b = await d.DispatchAsync(new Number(7));
         var c = await d.DispatchAsync(new Neg(new Number(1))); // no match, hits default
 
-        // Assert
-        Assert.Equal("+", a);
-        Assert.Equal("#7", b);
-        Assert.Equal("?", c);
+        // Then
+        ScenarioExpect.Equal("+", a);
+        ScenarioExpect.Equal("#7", b);
+        ScenarioExpect.Equal("?", c);
     }
 
     [Scenario("TryDispatchAsync returns false when no handler and no default")]
@@ -48,9 +48,9 @@ public sealed class AsyncTypeDispatcherTests(ITestOutputHelper output) : TinyBdd
         // Act
         var (ok, result) = await d.TryDispatchAsync(new Neg(new Number(3)));
 
-        // Assert
-        Assert.False(ok);
-        Assert.Null(result);
+        // Then
+        ScenarioExpect.False(ok);
+        ScenarioExpect.Null(result);
     }
 
     [Scenario("Async action dispatcher executes side effects by runtime type")]
@@ -71,10 +71,10 @@ public sealed class AsyncTypeDispatcherTests(ITestOutputHelper output) : TinyBdd
         await d.DispatchAsync(new Number(5));
         await d.DispatchAsync(new Neg(new Number(9))); // default
 
-        // Assert
-        Assert.Equal(1, counters[0]);
-        Assert.Equal(1, counters[1]);
-        Assert.Equal(1, counters[2]);
+        // Then
+        ScenarioExpect.Equal(1, counters[0]);
+        ScenarioExpect.Equal(1, counters[1]);
+        ScenarioExpect.Equal(1, counters[2]);
     }
 
     [Scenario("Async handlers with cancellation token")]
@@ -95,8 +95,8 @@ public sealed class AsyncTypeDispatcherTests(ITestOutputHelper output) : TinyBdd
         using var cts = new CancellationTokenSource();
         var result = await d.DispatchAsync(new Number(42), cts.Token);
 
-        // Assert
-        Assert.Equal("#42", result);
+        // Then
+        ScenarioExpect.Equal("#42", result);
     }
 
     [Scenario("TryDispatchAsync action returns false when no handler and no default")]
@@ -113,9 +113,9 @@ public sealed class AsyncTypeDispatcherTests(ITestOutputHelper output) : TinyBdd
         // Act
         var ok = await d.TryDispatchAsync(new Neg(new Number(3)));
 
-        // Assert
-        Assert.False(ok);
-        Assert.Equal(0, counter);
+        // Then
+        ScenarioExpect.False(ok);
+        ScenarioExpect.Equal(0, counter);
     }
 
     [Scenario("DispatchAsync throws when no handler and no default")]
@@ -127,8 +127,8 @@ public sealed class AsyncTypeDispatcherTests(ITestOutputHelper output) : TinyBdd
             .On<Number>(n => n.Value.ToString())
             .Build();
 
-        // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        // Act and verify
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             async () => await d.DispatchAsync(new Neg(new Number(3))));
     }
 }

--- a/test/PatternKit.Tests/Behavioral/Chain/ActionChainTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Chain/ActionChainTests.cs
@@ -237,6 +237,7 @@ public sealed class ActionChainBuilderTests
 {
     private readonly record struct Ctx(List<string> Log, bool Flag = false);
 
+    [Scenario("When Do Handler Executes When True")]
     [Fact]
     public void When_Do_Handler_Executes_When_True()
     {
@@ -252,10 +253,11 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Single(log);
-        Assert.Equal("DO", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("DO", log[0]);
     }
 
+    [Scenario("When Do Handler Skipped When False")]
     [Fact]
     public void When_Do_Handler_Skipped_When_False()
     {
@@ -276,10 +278,11 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Single(log);
-        Assert.Equal("TAIL", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("TAIL", log[0]);
     }
 
+    [Scenario("When Do Handler Can ShortCircuit")]
     [Fact]
     public void When_Do_Handler_Can_ShortCircuit()
     {
@@ -300,10 +303,11 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Single(log);
-        Assert.Equal("STOP", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("STOP", log[0]);
     }
 
+    [Scenario("ThenContinue Always Calls Next")]
     [Fact]
     public void ThenContinue_Always_Calls_Next()
     {
@@ -317,11 +321,12 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("A", log[0]);
-        Assert.Equal("B", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("A", log[0]);
+        ScenarioExpect.Equal("B", log[1]);
     }
 
+    [Scenario("ThenContinue When False Still Continues")]
     [Fact]
     public void ThenContinue_When_False_Still_Continues()
     {
@@ -335,10 +340,11 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Single(log);
-        Assert.Equal("ALWAYS", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("ALWAYS", log[0]);
     }
 
+    [Scenario("Empty Chain Runs Tail")]
     [Fact]
     public void Empty_Chain_Runs_Tail()
     {
@@ -353,10 +359,11 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Single(log);
-        Assert.Equal("TAIL", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("TAIL", log[0]);
     }
 
+    [Scenario("Empty Chain No Tail Works")]
     [Fact]
     public void Empty_Chain_No_Tail_Works()
     {
@@ -366,9 +373,10 @@ public sealed class ActionChainBuilderTests
         // Should not throw
         chain.Execute(new Ctx(log));
 
-        Assert.Empty(log);
+        ScenarioExpect.Empty(log);
     }
 
+    [Scenario("Multiple Use In Order")]
     [Fact]
     public void Multiple_Use_In_Order()
     {
@@ -381,12 +389,13 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("1", log[0]);
-        Assert.Equal("2", log[1]);
-        Assert.Equal("3", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("1", log[0]);
+        ScenarioExpect.Equal("2", log[1]);
+        ScenarioExpect.Equal("3", log[2]);
     }
 
+    [Scenario("Tail Can Call Next Safely")]
     [Fact]
     public void Tail_Can_Call_Next_Safely()
     {
@@ -402,11 +411,12 @@ public sealed class ActionChainBuilderTests
 
         chain.Execute(new Ctx(log));
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("TAIL", log[0]);
-        Assert.Equal("AFTER_NEXT", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("TAIL", log[0]);
+        ScenarioExpect.Equal("AFTER_NEXT", log[1]);
     }
 
+    [Scenario("Concurrent Execution Safe")]
     [Fact]
     public void Concurrent_Execution_Safe()
     {
@@ -425,7 +435,7 @@ public sealed class ActionChainBuilderTests
 
         Task.WaitAll(tasks);
 
-        Assert.Equal(100, counter);
+        ScenarioExpect.Equal(100, counter);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Chain/AsyncChainTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Chain/AsyncChainTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Behavioral.Chain;
+using TinyBDD;
 
 namespace PatternKit.Tests.Behavioral.Chain;
 
@@ -6,6 +7,7 @@ public sealed class AsyncChainTests
 {
     #region AsyncActionChain<TContext> Tests
 
+    [Scenario("AsyncActionChain Executes All Handlers")]
     [Fact]
     public async Task AsyncActionChain_Executes_All_Handlers()
     {
@@ -25,11 +27,12 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("h1-5", log[0]);
-        Assert.Equal("h2-5", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("h1-5", log[0]);
+        ScenarioExpect.Equal("h2-5", log[1]);
     }
 
+    [Scenario("AsyncActionChain When ThenContinue Conditional True")]
     [Fact]
     public async Task AsyncActionChain_When_ThenContinue_Conditional_True()
     {
@@ -42,11 +45,12 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("positive", log[0]);
-        Assert.Equal("always", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("positive", log[0]);
+        ScenarioExpect.Equal("always", log[1]);
     }
 
+    [Scenario("AsyncActionChain When ThenContinue Conditional False")]
     [Fact]
     public async Task AsyncActionChain_When_ThenContinue_Conditional_False()
     {
@@ -59,10 +63,11 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(-5);
 
-        Assert.Single(log);
-        Assert.Equal("always", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("always", log[0]);
     }
 
+    [Scenario("AsyncActionChain ThenStop Halts Chain")]
     [Fact]
     public async Task AsyncActionChain_ThenStop_Halts_Chain()
     {
@@ -75,10 +80,11 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(15);
 
-        Assert.Single(log);
-        Assert.Equal("stopped", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("stopped", log[0]);
     }
 
+    [Scenario("AsyncActionChain ThenStop Continues When False")]
     [Fact]
     public async Task AsyncActionChain_ThenStop_Continues_When_False()
     {
@@ -91,10 +97,11 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("finally", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("finally", log[0]);
     }
 
+    [Scenario("AsyncActionChain Handler Can ShortCircuit")]
     [Fact]
     public async Task AsyncActionChain_Handler_Can_ShortCircuit()
     {
@@ -114,10 +121,11 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("handler-1", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("handler-1", log[0]);
     }
 
+    [Scenario("AsyncActionChain Finally Executes At End")]
     [Fact]
     public async Task AsyncActionChain_Finally_Executes_At_End()
     {
@@ -133,11 +141,12 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("handler", log[0]);
-        Assert.Equal("finally", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("handler", log[0]);
+        ScenarioExpect.Equal("finally", log[1]);
     }
 
+    [Scenario("AsyncActionChain Async Predicate")]
     [Fact]
     public async Task AsyncActionChain_Async_Predicate()
     {
@@ -153,10 +162,11 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("positive", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("positive", log[0]);
     }
 
+    [Scenario("AsyncActionChain Async Action")]
     [Fact]
     public async Task AsyncActionChain_Async_Action()
     {
@@ -172,10 +182,11 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("async-positive", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async-positive", log[0]);
     }
 
+    [Scenario("AsyncActionChain Empty Chain Executes")]
     [Fact]
     public async Task AsyncActionChain_Empty_Chain_Executes()
     {
@@ -183,9 +194,10 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5); // Should not throw
 
-        Assert.True(true);
+        ScenarioExpect.True(true);
     }
 
+    [Scenario("AsyncActionChain Context Passed Through")]
     [Fact]
     public async Task AsyncActionChain_Context_Passed_Through()
     {
@@ -205,10 +217,11 @@ public sealed class AsyncChainTests
 
         await chain.ExecuteAsync(5);
 
-        Assert.Equal(5, capturedValues[0]);
-        Assert.Equal(15, capturedValues[1]);
+        ScenarioExpect.Equal(5, capturedValues[0]);
+        ScenarioExpect.Equal(15, capturedValues[1]);
     }
 
+    [Scenario("AsyncActionChain Multiple When Clauses")]
     [Fact]
     public async Task AsyncActionChain_Multiple_When_Clauses()
     {
@@ -226,16 +239,17 @@ public sealed class AsyncChainTests
         await chain.ExecuteAsync(50);
 
         // All conditions that pass add their entries
-        Assert.Contains("medium", log);
-        Assert.Contains("small", log);
-        Assert.Contains("finally", log);
-        Assert.DoesNotContain("large", log);
+        ScenarioExpect.Contains("medium", log);
+        ScenarioExpect.Contains("small", log);
+        ScenarioExpect.Contains("finally", log);
+        ScenarioExpect.DoesNotContain("large", log);
     }
 
     #endregion
 
     #region AsyncResultChain<TContext, TResult> Tests
 
+    [Scenario("AsyncResultChain Returns First Match")]
     [Fact]
     public async Task AsyncResultChain_Returns_First_Match()
     {
@@ -247,10 +261,11 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.Equal("positive", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("positive", result);
     }
 
+    [Scenario("AsyncResultChain Returns False When No Match")]
     [Fact]
     public async Task AsyncResultChain_Returns_False_When_No_Match()
     {
@@ -260,10 +275,11 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Null(result);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("AsyncResultChain Finally Fallback")]
     [Fact]
     public async Task AsyncResultChain_Finally_Fallback()
     {
@@ -274,10 +290,11 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.Equal("default", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("default", result);
     }
 
+    [Scenario("AsyncResultChain Async Predicate")]
     [Fact]
     public async Task AsyncResultChain_Async_Predicate()
     {
@@ -292,10 +309,11 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.Equal("positive", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("positive", result);
     }
 
+    [Scenario("AsyncResultChain Async Producer")]
     [Fact]
     public async Task AsyncResultChain_Async_Producer()
     {
@@ -310,10 +328,11 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.Equal("async-5", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("async-5", result);
     }
 
+    [Scenario("AsyncResultChain Multiple Conditions")]
     [Fact]
     public async Task AsyncResultChain_Multiple_Conditions()
     {
@@ -329,12 +348,13 @@ public sealed class AsyncChainTests
         var (_, r3) = await chain.ExecuteAsync(75);
         var (_, r4) = await chain.ExecuteAsync(50);
 
-        Assert.Equal("A", r1);
-        Assert.Equal("B", r2);
-        Assert.Equal("C", r3);
-        Assert.Equal("F", r4);
+        ScenarioExpect.Equal("A", r1);
+        ScenarioExpect.Equal("B", r2);
+        ScenarioExpect.Equal("C", r3);
+        ScenarioExpect.Equal("F", r4);
     }
 
+    [Scenario("AsyncResultChain Use Raw Handler")]
     [Fact]
     public async Task AsyncResultChain_Use_Raw_Handler()
     {
@@ -349,10 +369,11 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.Equal("positive-5", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("positive-5", result);
     }
 
+    [Scenario("AsyncResultChain Finally Async Producer")]
     [Fact]
     public async Task AsyncResultChain_Finally_Async_Producer()
     {
@@ -367,10 +388,11 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.Equal("fallback-5", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("fallback-5", result);
     }
 
+    [Scenario("AsyncResultChain Empty Chain Returns False")]
     [Fact]
     public async Task AsyncResultChain_Empty_Chain_Returns_False()
     {
@@ -378,8 +400,8 @@ public sealed class AsyncChainTests
 
         var (success, result) = await chain.ExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Null(result);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(result);
     }
 
     #endregion

--- a/test/PatternKit.Tests/Behavioral/Command/CommandTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Command/CommandTests.cs
@@ -103,13 +103,15 @@ public sealed class CommandBuilderTests
 {
     private readonly record struct Ctx(List<string> Log);
 
+    [Scenario("Command Build Without Do Throws")]
     [Fact]
     public void Command_Build_Without_Do_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             Command<Ctx>.Create().Build());
     }
 
+    [Scenario("Command HasUndo True When Configured")]
     [Fact]
     public async Task Command_HasUndo_True_When_Configured()
     {
@@ -118,9 +120,10 @@ public sealed class CommandBuilderTests
             .Undo(c => { })
             .Build();
 
-        Assert.True(cmd.HasUndo);
+        ScenarioExpect.True(cmd.HasUndo);
     }
 
+    [Scenario("Command HasUndo False When Not Configured")]
     [Fact]
     public async Task Command_HasUndo_False_When_Not_Configured()
     {
@@ -128,9 +131,10 @@ public sealed class CommandBuilderTests
             .Do(c => { })
             .Build();
 
-        Assert.False(cmd.HasUndo);
+        ScenarioExpect.False(cmd.HasUndo);
     }
 
+    [Scenario("Command TryUndo Returns False When No Undo")]
     [Fact]
     public async Task Command_TryUndo_Returns_False_When_No_Undo()
     {
@@ -141,9 +145,10 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(new List<string>());
         var result = cmd.TryUndo(in ctx, out _);
 
-        Assert.False(result);
+        ScenarioExpect.False(result);
     }
 
+    [Scenario("Command Execute With CancellationToken")]
     [Fact]
     public async Task Command_Execute_With_CancellationToken()
     {
@@ -159,10 +164,11 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await cmd.Execute(in ctx, CancellationToken.None);
 
-        Assert.Single(log);
-        Assert.Equal("executed", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("executed", log[0]);
     }
 
+    [Scenario("Command TryUndo With CancellationToken")]
     [Fact]
     public async Task Command_TryUndo_With_CancellationToken()
     {
@@ -182,10 +188,11 @@ public sealed class CommandBuilderTests
         if (cmd.TryUndo(in ctx, CancellationToken.None, out var vt))
             await vt;
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("undo", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("undo", log[1]);
     }
 
+    [Scenario("Command Sync Do Handler")]
     [Fact]
     public async Task Command_Sync_Do_Handler()
     {
@@ -197,9 +204,10 @@ public sealed class CommandBuilderTests
         var ctx = 5;
         await cmd.Execute(in ctx);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("Command Sync Undo Handler")]
     [Fact]
     public async Task Command_Sync_Undo_Handler()
     {
@@ -214,9 +222,10 @@ public sealed class CommandBuilderTests
         if (cmd.TryUndo(in ctx, out var vt))
             await vt;
 
-        Assert.True(undone);
+        ScenarioExpect.True(undone);
     }
 
+    [Scenario("Command Async Do Handler")]
     [Fact]
     public async Task Command_Async_Do_Handler()
     {
@@ -237,10 +246,11 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await cmd.Execute(in ctx);
 
-        Assert.Single(log);
-        Assert.Equal("async-do", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async-do", log[0]);
     }
 
+    [Scenario("Command Async Undo Handler")]
     [Fact]
     public async Task Command_Async_Undo_Handler()
     {
@@ -264,10 +274,11 @@ public sealed class CommandBuilderTests
         if (cmd.TryUndo(in ctx, out var vt))
             await vt;
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("async-undo", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("async-undo", log[1]);
     }
 
+    [Scenario("Macro AddIf True Includes Command")]
     [Fact]
     public async Task Macro_AddIf_True_Includes_Command()
     {
@@ -281,10 +292,11 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Single(log);
-        Assert.Equal("conditional", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("conditional", log[0]);
     }
 
+    [Scenario("Macro AddIf False Excludes Command")]
     [Fact]
     public async Task Macro_AddIf_False_Excludes_Command()
     {
@@ -298,9 +310,10 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Empty(log);
+        ScenarioExpect.Empty(log);
     }
 
+    [Scenario("Macro Empty Does Nothing")]
     [Fact]
     public async Task Macro_Empty_Does_Nothing()
     {
@@ -310,9 +323,10 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Empty(log);
+        ScenarioExpect.Empty(log);
     }
 
+    [Scenario("Macro HasUndo True")]
     [Fact]
     public async Task Macro_HasUndo_True()
     {
@@ -325,9 +339,10 @@ public sealed class CommandBuilderTests
             .Add(cmd)
             .Build();
 
-        Assert.True(macro.HasUndo);
+        ScenarioExpect.True(macro.HasUndo);
     }
 
+    [Scenario("Macro Async Commands")]
     [Fact]
     public async Task Macro_Async_Commands()
     {
@@ -366,11 +381,12 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("async-1", log[0]);
-        Assert.Equal("async-2", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("async-1", log[0]);
+        ScenarioExpect.Equal("async-2", log[1]);
     }
 
+    [Scenario("Macro Mixed Sync And Async")]
     [Fact]
     public async Task Macro_Mixed_Sync_And_Async()
     {
@@ -401,12 +417,13 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("sync", log[0]);
-        Assert.Equal("async", log[1]);
-        Assert.Equal("sync", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("sync", log[0]);
+        ScenarioExpect.Equal("async", log[1]);
+        ScenarioExpect.Equal("sync", log[2]);
     }
 
+    [Scenario("Macro Undo With Async")]
     [Fact]
     public async Task Macro_Undo_With_Async()
     {
@@ -434,10 +451,11 @@ public sealed class CommandBuilderTests
         if (macro.TryUndo(in ctx, out var vt))
             await vt;
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("undo", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("undo", log[1]);
     }
 
+    [Scenario("Macro All Commands Without Undo")]
     [Fact]
     public async Task Macro_All_Commands_Without_Undo()
     {
@@ -457,9 +475,10 @@ public sealed class CommandBuilderTests
         if (macro.TryUndo(in ctx, out var vt))
             await vt;
 
-        Assert.Equal(2, log.Count); // No undo entries added
+        ScenarioExpect.Equal(2, log.Count); // No undo entries added
     }
 
+    [Scenario("Command Execute Overload Without CancellationToken")]
     [Fact]
     public async Task Command_Execute_Overload_Without_CancellationToken()
     {
@@ -471,9 +490,10 @@ public sealed class CommandBuilderTests
         var ctx = 5;
         await cmd.Execute(in ctx); // No CancellationToken
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("Macro Do SlowPath MiddleAsync")]
     [Fact]
     public async Task Macro_Do_SlowPath_MiddleAsync()
     {
@@ -507,12 +527,13 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("sync", log[0]);
-        Assert.Equal("async", log[1]);
-        Assert.Equal("sync", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("sync", log[0]);
+        ScenarioExpect.Equal("async", log[1]);
+        ScenarioExpect.Equal("sync", log[2]);
     }
 
+    [Scenario("Macro Undo SlowPath MiddleAsync")]
     [Fact]
     public async Task Macro_Undo_SlowPath_MiddleAsync()
     {
@@ -553,12 +574,13 @@ public sealed class CommandBuilderTests
             await vt;
 
         // Undo runs in reverse order
-        Assert.Equal(3, log.Count);
-        Assert.Equal("undo:sync", log[0]);
-        Assert.Equal("undo:async", log[1]);
-        Assert.Equal("undo:sync", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("undo:sync", log[0]);
+        ScenarioExpect.Equal("undo:async", log[1]);
+        ScenarioExpect.Equal("undo:sync", log[2]);
     }
 
+    [Scenario("Macro First Command Async")]
     [Fact]
     public async Task Macro_First_Command_Async()
     {
@@ -585,10 +607,11 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Single(log);
-        Assert.Equal("async", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async", log[0]);
     }
 
+    [Scenario("Macro Undo First Command Async")]
     [Fact]
     public async Task Macro_Undo_First_Command_Async()
     {
@@ -620,10 +643,11 @@ public sealed class CommandBuilderTests
         if (macro.TryUndo(in ctx, out var vt))
             await vt;
 
-        Assert.Single(log);
-        Assert.Equal("undo", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("undo", log[0]);
     }
 
+    [Scenario("Macro Multiple Async InSequence")]
     [Fact]
     public async Task Macro_Multiple_Async_InSequence()
     {
@@ -664,22 +688,23 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx(log);
         await macro.Execute(in ctx);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("A", log[0]);
-        Assert.Equal("B", log[1]);
-        Assert.Equal("C", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("A", log[0]);
+        ScenarioExpect.Equal("B", log[1]);
+        ScenarioExpect.Equal("C", log[2]);
 
         log.Clear();
 
         if (macro.TryUndo(in ctx, out var vt))
             await vt;
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("undo:C", log[0]);
-        Assert.Equal("undo:B", log[1]);
-        Assert.Equal("undo:A", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("undo:C", log[0]);
+        ScenarioExpect.Equal("undo:B", log[1]);
+        ScenarioExpect.Equal("undo:A", log[2]);
     }
 
+    [Scenario("Macro Undo SkipsCommands WithoutUndo InSlowPath")]
     [Fact]
     public async Task Macro_Undo_SkipsCommands_WithoutUndo_InSlowPath()
     {
@@ -717,11 +742,12 @@ public sealed class CommandBuilderTests
             await vt;
 
         // Should have 2 undos, skipping the middle command
-        Assert.Equal(2, log.Count);
-        Assert.Equal("undo:1", log[0]);
-        Assert.Equal("undo:1", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("undo:1", log[0]);
+        ScenarioExpect.Equal("undo:1", log[1]);
     }
 
+    [Scenario("Macro CancellationToken Propagates")]
     [Fact]
     public async Task Macro_CancellationToken_Propagates()
     {
@@ -742,7 +768,7 @@ public sealed class CommandBuilderTests
         var ctx = new Ctx([]);
         await macro.Execute(in ctx, cts.Token);
 
-        Assert.Equal(cts.Token, tokenReceived);
+        ScenarioExpect.Equal(cts.Token, tokenReceived);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/FluentVisitorTests.cs
+++ b/test/PatternKit.Tests/Behavioral/FluentVisitorTests.cs
@@ -203,6 +203,7 @@ public sealed class FluentActionVisitorTests
         }
     }
 
+    [Scenario("FluentActionVisitor Dispatches To Handlers")]
     [Fact]
     public void FluentActionVisitor_Dispatches_To_Handlers()
     {
@@ -215,11 +216,12 @@ public sealed class FluentActionVisitorTests
         visitor.Visit(new LogEntry("Test message"));
         visitor.Visit(new ErrorEntry("Something went wrong"));
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("LOG: Test message", log[0]);
-        Assert.Equal("ERROR: Something went wrong", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("LOG: Test message", log[0]);
+        ScenarioExpect.Equal("ERROR: Something went wrong", log[1]);
     }
 
+    [Scenario("FluentActionVisitor Uses Default Handler")]
     [Fact]
     public void FluentActionVisitor_Uses_Default_Handler()
     {
@@ -232,11 +234,12 @@ public sealed class FluentActionVisitorTests
         visitor.Visit(new LogEntry("Hello"));
         visitor.Visit(new ErrorEntry("Oops"));
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("LOG: Hello", log[0]);
-        Assert.Equal("DEFAULT: ErrorEntry", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("LOG: Hello", log[0]);
+        ScenarioExpect.Equal("DEFAULT: ErrorEntry", log[1]);
     }
 
+    [Scenario("FluentActionVisitor Throws When No Handler")]
     [Fact]
     public void FluentActionVisitor_Throws_When_No_Handler()
     {
@@ -244,10 +247,11 @@ public sealed class FluentActionVisitorTests
             .When<LogEntry>(e => { })
             .Build();
 
-        Assert.Throws<NotSupportedException>(() =>
+        ScenarioExpect.Throws<NotSupportedException>(() =>
             visitor.Visit(new ErrorEntry("No handler")));
     }
 
+    [Scenario("FluentActionVisitor VisitDefault With Default Handler")]
     [Fact]
     public void FluentActionVisitor_VisitDefault_With_Default_Handler()
     {
@@ -259,10 +263,11 @@ public sealed class FluentActionVisitorTests
         // Call VisitDefault directly through interface
         ((IActionVisitor)visitor).VisitDefault(new LogEntry("test"));
 
-        Assert.Single(log);
-        Assert.Equal("default:LogEntry", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default:LogEntry", log[0]);
     }
 
+    [Scenario("FluentActionVisitor VisitDefault Without Default Throws")]
     [Fact]
     public void FluentActionVisitor_VisitDefault_Without_Default_Throws()
     {
@@ -270,10 +275,11 @@ public sealed class FluentActionVisitorTests
             .When<LogEntry>(_ => { })
             .Build();
 
-        Assert.Throws<NotSupportedException>(() =>
+        ScenarioExpect.Throws<NotSupportedException>(() =>
             ((IActionVisitor)visitor).VisitDefault(new ErrorEntry("test")));
     }
 
+    [Scenario("FluentActionVisitor AllTypes Handled")]
     [Fact]
     public void FluentActionVisitor_AllTypes_Handled()
     {
@@ -288,10 +294,10 @@ public sealed class FluentActionVisitorTests
         visitor.Visit(new ErrorEntry("oops"));
         visitor.Visit(new MetricEntry("cpu", 0.5));
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("LOG:hello", log[0]);
-        Assert.Equal("ERR:oops", log[1]);
-        Assert.Equal("METRIC:cpu=0.5", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("LOG:hello", log[0]);
+        ScenarioExpect.Equal("ERR:oops", log[1]);
+        ScenarioExpect.Equal("METRIC:cpu=0.5", log[2]);
     }
 }
 
@@ -319,6 +325,7 @@ public sealed class AsyncFluentVisitorTests
                 : visitor.VisitDefaultAsync(this, ct);
     }
 
+    [Scenario("AsyncFluentVisitor Evaluates Expression")]
     [Fact]
     public async Task AsyncFluentVisitor_Evaluates_Expression()
     {
@@ -333,9 +340,10 @@ public sealed class AsyncFluentVisitorTests
         var expr = new AsyncAdd(new AsyncNumber(10), new AsyncNumber(20));
         var result = await evaluator.VisitAsync(expr);
 
-        Assert.Equal(30, result);
+        ScenarioExpect.Equal(30, result);
     }
 
+    [Scenario("AsyncFluentVisitor Async Handler")]
     [Fact]
     public async Task AsyncFluentVisitor_Async_Handler()
     {
@@ -350,9 +358,10 @@ public sealed class AsyncFluentVisitorTests
 
         var result = await visitor.VisitAsync(new AsyncNumber(42));
 
-        Assert.Equal("Number: 42", result);
+        ScenarioExpect.Equal("Number: 42", result);
     }
 
+    [Scenario("AsyncFluentVisitor Uses Default")]
     [Fact]
     public async Task AsyncFluentVisitor_Uses_Default()
     {
@@ -363,9 +372,10 @@ public sealed class AsyncFluentVisitorTests
 
         var result = await visitor.VisitAsync(new AsyncAdd(new AsyncNumber(1), new AsyncNumber(2)));
 
-        Assert.Equal("default", result);
+        ScenarioExpect.Equal("default", result);
     }
 
+    [Scenario("AsyncFluentVisitor Constant Handler")]
     [Fact]
     public async Task AsyncFluentVisitor_Constant_Handler()
     {
@@ -376,9 +386,10 @@ public sealed class AsyncFluentVisitorTests
 
         var result = await visitor.VisitAsync(new AsyncNumber(100));
 
-        Assert.Equal(42, result);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("AsyncFluentVisitor Throws When No Handler")]
     [Fact]
     public async Task AsyncFluentVisitor_Throws_When_No_Handler()
     {
@@ -386,10 +397,11 @@ public sealed class AsyncFluentVisitorTests
             .When<AsyncNumber>(n => n.Value)
             .Build();
 
-        await Assert.ThrowsAsync<NotSupportedException>(() =>
+        await ScenarioExpect.ThrowsAsync<NotSupportedException>(() =>
             visitor.VisitAsync(new AsyncAdd(new AsyncNumber(1), new AsyncNumber(2))).AsTask());
     }
 
+    [Scenario("AsyncFluentVisitor Async Default")]
     [Fact]
     public async Task AsyncFluentVisitor_Async_Default()
     {
@@ -403,7 +415,7 @@ public sealed class AsyncFluentVisitorTests
 
         var result = await visitor.VisitAsync(new AsyncNumber(1));
 
-        Assert.Equal("async-default-AsyncNumber", result);
+        ScenarioExpect.Equal("async-default-AsyncNumber", result);
     }
 }
 
@@ -431,6 +443,7 @@ public sealed class AsyncFluentActionVisitorTests
                 : visitor.VisitDefaultAsync(this, ct);
     }
 
+    [Scenario("AsyncFluentActionVisitor Dispatches")]
     [Fact]
     public async Task AsyncFluentActionVisitor_Dispatches()
     {
@@ -443,11 +456,12 @@ public sealed class AsyncFluentActionVisitorTests
         await visitor.VisitAsync(new AsyncLogEntry("Hello"));
         await visitor.VisitAsync(new AsyncErrorEntry("Oops"));
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("LOG: Hello", log[0]);
-        Assert.Equal("ERROR: Oops", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("LOG: Hello", log[0]);
+        ScenarioExpect.Equal("ERROR: Oops", log[1]);
     }
 
+    [Scenario("AsyncFluentActionVisitor Async Handler")]
     [Fact]
     public async Task AsyncFluentActionVisitor_Async_Handler()
     {
@@ -462,10 +476,11 @@ public sealed class AsyncFluentActionVisitorTests
 
         await visitor.VisitAsync(new AsyncLogEntry("Test"));
 
-        Assert.Single(log);
-        Assert.Equal("ASYNC-LOG: Test", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("ASYNC-LOG: Test", log[0]);
     }
 
+    [Scenario("AsyncFluentActionVisitor Uses Default")]
     [Fact]
     public async Task AsyncFluentActionVisitor_Uses_Default()
     {
@@ -478,11 +493,12 @@ public sealed class AsyncFluentActionVisitorTests
         await visitor.VisitAsync(new AsyncLogEntry("Hi"));
         await visitor.VisitAsync(new AsyncErrorEntry("Err"));
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("log", log[0]);
-        Assert.Equal("default-AsyncErrorEntry", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("log", log[0]);
+        ScenarioExpect.Equal("default-AsyncErrorEntry", log[1]);
     }
 
+    [Scenario("AsyncFluentActionVisitor Async Default")]
     [Fact]
     public async Task AsyncFluentActionVisitor_Async_Default()
     {
@@ -497,10 +513,11 @@ public sealed class AsyncFluentActionVisitorTests
 
         await visitor.VisitAsync(new AsyncLogEntry("Test"));
 
-        Assert.Single(log);
-        Assert.Equal("async-default-AsyncLogEntry", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async-default-AsyncLogEntry", log[0]);
     }
 
+    [Scenario("AsyncFluentActionVisitor Throws When No Handler")]
     [Fact]
     public async Task AsyncFluentActionVisitor_Throws_When_No_Handler()
     {
@@ -508,7 +525,7 @@ public sealed class AsyncFluentActionVisitorTests
             .When<AsyncLogEntry>(e => { })
             .Build();
 
-        await Assert.ThrowsAsync<NotSupportedException>(() =>
+        await ScenarioExpect.ThrowsAsync<NotSupportedException>(() =>
             visitor.VisitAsync(new AsyncErrorEntry("No handler")).AsTask());
     }
 }
@@ -536,6 +553,7 @@ public sealed class FluentVisitorCoverageTests
                 : visitor.VisitDefault(this);
     }
 
+    [Scenario("FluentVisitor When Constant Handler")]
     [Fact]
     public void FluentVisitor_When_Constant_Handler()
     {
@@ -545,9 +563,10 @@ public sealed class FluentVisitorCoverageTests
 
         var result = visitor.Visit(new ElemA("test"));
 
-        Assert.Equal("constant-result", result);
+        ScenarioExpect.Equal("constant-result", result);
     }
 
+    [Scenario("FluentVisitor Default Constant")]
     [Fact]
     public void FluentVisitor_Default_Constant()
     {
@@ -557,9 +576,10 @@ public sealed class FluentVisitorCoverageTests
 
         var result = visitor.Visit(new ElemA("test"));
 
-        Assert.Equal("default-constant", result);
+        ScenarioExpect.Equal("default-constant", result);
     }
 
+    [Scenario("FluentVisitor VisitDefault With Default Returns Result")]
     [Fact]
     public void FluentVisitor_VisitDefault_With_Default_Returns_Result()
     {
@@ -569,9 +589,10 @@ public sealed class FluentVisitorCoverageTests
 
         var result = ((IVisitor<string>)visitor).VisitDefault(new ElemA("test"));
 
-        Assert.Equal("from-default", result);
+        ScenarioExpect.Equal("from-default", result);
     }
 
+    [Scenario("FluentVisitor VisitDefault Without Default Throws")]
     [Fact]
     public void FluentVisitor_VisitDefault_Without_Default_Throws()
     {
@@ -579,10 +600,11 @@ public sealed class FluentVisitorCoverageTests
             .When<ElemA>(e => e.Value)
             .Build();
 
-        Assert.Throws<NotSupportedException>(() =>
+        ScenarioExpect.Throws<NotSupportedException>(() =>
             ((IVisitor<string>)visitor).VisitDefault(new ElemB(42)));
     }
 
+    [Scenario("FluentVisitor Multiple Handlers Work")]
     [Fact]
     public void FluentVisitor_Multiple_Handlers_Work()
     {
@@ -591,10 +613,11 @@ public sealed class FluentVisitorCoverageTests
             .When<ElemB>(e => $"B:{e.Value}")
             .Build();
 
-        Assert.Equal("A:hello", visitor.Visit(new ElemA("hello")));
-        Assert.Equal("B:42", visitor.Visit(new ElemB(42)));
+        ScenarioExpect.Equal("A:hello", visitor.Visit(new ElemA("hello")));
+        ScenarioExpect.Equal("B:42", visitor.Visit(new ElemB(42)));
     }
 
+    [Scenario("FluentVisitor Handler Override Works")]
     [Fact]
     public void FluentVisitor_Handler_Override_Works()
     {
@@ -603,7 +626,7 @@ public sealed class FluentVisitorCoverageTests
             .When<ElemA>(_ => "second")
             .Build();
 
-        Assert.Equal("second", visitor.Visit(new ElemA("test")));
+        ScenarioExpect.Equal("second", visitor.Visit(new ElemA("test")));
     }
 }
 
@@ -630,6 +653,7 @@ public sealed class AsyncFluentVisitorCoverageTests
                 : visitor.VisitDefaultAsync(this, ct);
     }
 
+    [Scenario("AsyncFluentVisitor VisitDefaultAsync With Default")]
     [Fact]
     public async Task AsyncFluentVisitor_VisitDefaultAsync_With_Default()
     {
@@ -639,9 +663,10 @@ public sealed class AsyncFluentVisitorCoverageTests
 
         var result = await ((IAsyncVisitor<string>)visitor).VisitDefaultAsync(new AsyncNumberElement(42), CancellationToken.None);
 
-        Assert.Equal("default-handler", result);
+        ScenarioExpect.Equal("default-handler", result);
     }
 
+    [Scenario("AsyncFluentVisitor VisitDefaultAsync Without Default Throws")]
     [Fact]
     public async Task AsyncFluentVisitor_VisitDefaultAsync_Without_Default_Throws()
     {
@@ -649,10 +674,11 @@ public sealed class AsyncFluentVisitorCoverageTests
             .When<AsyncNumberElement>(e => e.Value.ToString())
             .Build();
 
-        await Assert.ThrowsAsync<NotSupportedException>(() =>
+        await ScenarioExpect.ThrowsAsync<NotSupportedException>(() =>
             ((IAsyncVisitor<string>)visitor).VisitDefaultAsync(new AsyncTextElement("test"), CancellationToken.None).AsTask());
     }
 
+    [Scenario("AsyncFluentVisitor Async Handler With Cancellation")]
     [Fact]
     public async Task AsyncFluentVisitor_Async_Handler_With_Cancellation()
     {
@@ -667,9 +693,10 @@ public sealed class AsyncFluentVisitorCoverageTests
 
         var result = await visitor.VisitAsync(new AsyncNumberElement(42), cts.Token);
 
-        Assert.Equal("42", result);
+        ScenarioExpect.Equal("42", result);
     }
 
+    [Scenario("AsyncFluentVisitor Sync Handler Ignores CancellationToken")]
     [Fact]
     public async Task AsyncFluentVisitor_Sync_Handler_Ignores_CancellationToken()
     {
@@ -680,7 +707,7 @@ public sealed class AsyncFluentVisitorCoverageTests
 
         var result = await visitor.VisitAsync(new AsyncNumberElement(99), cts.Token);
 
-        Assert.Equal("99", result);
+        ScenarioExpect.Equal("99", result);
     }
 }
 
@@ -707,6 +734,7 @@ public sealed class AsyncFluentActionVisitorCoverageTests
                 : visitor.VisitDefaultAsync(this, ct);
     }
 
+    [Scenario("AsyncFluentActionVisitor VisitDefaultAsync With Default")]
     [Fact]
     public async Task AsyncFluentActionVisitor_VisitDefaultAsync_With_Default()
     {
@@ -717,10 +745,11 @@ public sealed class AsyncFluentActionVisitorCoverageTests
 
         await ((IAsyncActionVisitor)visitor).VisitDefaultAsync(new AsyncLogElement("test"), CancellationToken.None);
 
-        Assert.Single(log);
-        Assert.Equal("default", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default", log[0]);
     }
 
+    [Scenario("AsyncFluentActionVisitor VisitDefaultAsync Without Default Throws")]
     [Fact]
     public async Task AsyncFluentActionVisitor_VisitDefaultAsync_Without_Default_Throws()
     {
@@ -728,10 +757,11 @@ public sealed class AsyncFluentActionVisitorCoverageTests
             .When<AsyncLogElement>(e => { })
             .Build();
 
-        await Assert.ThrowsAsync<NotSupportedException>(() =>
+        await ScenarioExpect.ThrowsAsync<NotSupportedException>(() =>
             ((IAsyncActionVisitor)visitor).VisitDefaultAsync(new AsyncErrorElement("err"), CancellationToken.None).AsTask());
     }
 
+    [Scenario("AsyncFluentActionVisitor Async Handler With Cancellation")]
     [Fact]
     public async Task AsyncFluentActionVisitor_Async_Handler_With_Cancellation()
     {
@@ -747,7 +777,7 @@ public sealed class AsyncFluentActionVisitorCoverageTests
 
         await visitor.VisitAsync(new AsyncLogElement("hello"), cts.Token);
 
-        Assert.Single(log);
+        ScenarioExpect.Single(log);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/InterpreterTests.cs
+++ b/test/PatternKit.Tests/Behavioral/InterpreterTests.cs
@@ -339,6 +339,7 @@ public sealed class InterpreterTests(ITestOutputHelper output) : TinyBddXunitBas
 
 public sealed class ActionInterpreterTests
 {
+    [Scenario("ActionInterpreter Terminal Executes")]
     [Fact]
     public void ActionInterpreter_Terminal_Executes()
     {
@@ -349,10 +350,11 @@ public sealed class ActionInterpreterTests
 
         interpreter.Interpret(Terminal("log", "hello"));
 
-        Assert.Single(log);
-        Assert.Equal("hello", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("hello", log[0]);
     }
 
+    [Scenario("ActionInterpreter Terminal WithContext")]
     [Fact]
     public void ActionInterpreter_Terminal_WithContext()
     {
@@ -363,10 +365,11 @@ public sealed class ActionInterpreterTests
 
         interpreter.Interpret(Terminal("log", "hello"), "PREFIX");
 
-        Assert.Single(log);
-        Assert.Equal("PREFIX: hello", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("PREFIX: hello", log[0]);
     }
 
+    [Scenario("ActionInterpreter Sequence ExecutesInOrder")]
     [Fact]
     public void ActionInterpreter_Sequence_ExecutesInOrder()
     {
@@ -382,12 +385,13 @@ public sealed class ActionInterpreterTests
             Terminal("log", "third"));
         interpreter.Interpret(expr);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("first", log[0]);
-        Assert.Equal("second", log[1]);
-        Assert.Equal("third", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("first", log[0]);
+        ScenarioExpect.Equal("second", log[1]);
+        ScenarioExpect.Equal("third", log[2]);
     }
 
+    [Scenario("ActionInterpreter Parallel ExecutesAll")]
     [Fact]
     public void ActionInterpreter_Parallel_ExecutesAll()
     {
@@ -402,11 +406,12 @@ public sealed class ActionInterpreterTests
             Terminal("log", "b"));
         interpreter.Interpret(expr);
 
-        Assert.Equal(2, log.Count);
-        Assert.Contains("a", log);
-        Assert.Contains("b", log);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Contains("a", log);
+        ScenarioExpect.Contains("b", log);
     }
 
+    [Scenario("ActionInterpreter Conditional ThenBranch")]
     [Fact]
     public void ActionInterpreter_Conditional_ThenBranch()
     {
@@ -422,10 +427,11 @@ public sealed class ActionInterpreterTests
             Terminal("log", "else"));
         interpreter.Interpret(expr, true);
 
-        Assert.Single(log);
-        Assert.Equal("then", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("then", log[0]);
     }
 
+    [Scenario("ActionInterpreter Conditional ElseBranch")]
     [Fact]
     public void ActionInterpreter_Conditional_ElseBranch()
     {
@@ -441,10 +447,11 @@ public sealed class ActionInterpreterTests
             Terminal("log", "else"));
         interpreter.Interpret(expr, false);
 
-        Assert.Single(log);
-        Assert.Equal("else", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("else", log[0]);
     }
 
+    [Scenario("ActionInterpreter Conditional NoElseBranch")]
     [Fact]
     public void ActionInterpreter_Conditional_NoElseBranch()
     {
@@ -459,9 +466,10 @@ public sealed class ActionInterpreterTests
             Terminal("log", "then"));
         interpreter.Interpret(expr, false);
 
-        Assert.Empty(log);
+        ScenarioExpect.Empty(log);
     }
 
+    [Scenario("ActionInterpreter Conditional ThrowsWithTooFewChildren")]
     [Fact]
     public void ActionInterpreter_Conditional_ThrowsWithTooFewChildren()
     {
@@ -472,10 +480,11 @@ public sealed class ActionInterpreterTests
 
         var expr = NonTerminal("if", Terminal("log", "only-one"));
 
-        var ex = Assert.Throws<InvalidOperationException>(() => interpreter.Interpret(expr, true));
-        Assert.Contains("at least 2 children", ex.Message);
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() => interpreter.Interpret(expr, true));
+        ScenarioExpect.Contains("at least 2 children", ex.Message);
     }
 
+    [Scenario("ActionInterpreter NonTerminal WithContext")]
     [Fact]
     public void ActionInterpreter_NonTerminal_WithContext()
     {
@@ -494,12 +503,13 @@ public sealed class ActionInterpreterTests
             Terminal("log", "inner"));
         interpreter.Interpret(expr, "CTX");
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("start-CTX", log[0]);
-        Assert.Equal("inner", log[1]);
-        Assert.Equal("end-CTX", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("start-CTX", log[0]);
+        ScenarioExpect.Equal("inner", log[1]);
+        ScenarioExpect.Equal("end-CTX", log[2]);
     }
 
+    [Scenario("ActionInterpreter NonTerminal WithoutContext")]
     [Fact]
     public void ActionInterpreter_NonTerminal_WithoutContext()
     {
@@ -517,9 +527,10 @@ public sealed class ActionInterpreterTests
         var expr = NonTerminal("wrap", Terminal("log", "inner"));
         interpreter.Interpret(expr);
 
-        Assert.Equal(3, log.Count);
+        ScenarioExpect.Equal(3, log.Count);
     }
 
+    [Scenario("ActionInterpreter ThrowsForUnknownTerminal")]
     [Fact]
     public void ActionInterpreter_ThrowsForUnknownTerminal()
     {
@@ -527,11 +538,12 @@ public sealed class ActionInterpreterTests
             .Terminal("log", msg => { })
             .Build();
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() =>
             interpreter.Interpret(Terminal("unknown", "value")));
-        Assert.Contains("No terminal handler", ex.Message);
+        ScenarioExpect.Contains("No terminal handler", ex.Message);
     }
 
+    [Scenario("ActionInterpreter ThrowsForUnknownNonTerminal")]
     [Fact]
     public void ActionInterpreter_ThrowsForUnknownNonTerminal()
     {
@@ -539,11 +551,12 @@ public sealed class ActionInterpreterTests
             .Terminal("log", msg => { })
             .Build();
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() =>
             interpreter.Interpret(NonTerminal("unknown", Terminal("log", "value"))));
-        Assert.Contains("No non-terminal handler", ex.Message);
+        ScenarioExpect.Contains("No non-terminal handler", ex.Message);
     }
 
+    [Scenario("ActionInterpreter TryInterpret Success")]
     [Fact]
     public void ActionInterpreter_TryInterpret_Success()
     {
@@ -554,11 +567,12 @@ public sealed class ActionInterpreterTests
 
         var ok = interpreter.TryInterpret(Terminal("log", "test"), null!, out var error);
 
-        Assert.True(ok);
-        Assert.Null(error);
-        Assert.Single(log);
+        ScenarioExpect.True(ok);
+        ScenarioExpect.Null(error);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("ActionInterpreter TryInterpret Failure")]
     [Fact]
     public void ActionInterpreter_TryInterpret_Failure()
     {
@@ -568,11 +582,12 @@ public sealed class ActionInterpreterTests
 
         var ok = interpreter.TryInterpret(Terminal("unknown", "value"), null!, out var error);
 
-        Assert.False(ok);
-        Assert.NotNull(error);
-        Assert.Contains("No terminal handler", error);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.NotNull(error);
+        ScenarioExpect.Contains("No terminal handler", error);
     }
 
+    [Scenario("ActionInterpreter HasTerminal")]
     [Fact]
     public void ActionInterpreter_HasTerminal()
     {
@@ -580,10 +595,11 @@ public sealed class ActionInterpreterTests
             .Terminal("log", msg => { })
             .Build();
 
-        Assert.True(interpreter.HasTerminal("log"));
-        Assert.False(interpreter.HasTerminal("unknown"));
+        ScenarioExpect.True(interpreter.HasTerminal("log"));
+        ScenarioExpect.False(interpreter.HasTerminal("unknown"));
     }
 
+    [Scenario("ActionInterpreter HasNonTerminal")]
     [Fact]
     public void ActionInterpreter_HasNonTerminal()
     {
@@ -591,10 +607,11 @@ public sealed class ActionInterpreterTests
             .Sequence("seq")
             .Build();
 
-        Assert.True(interpreter.HasNonTerminal("seq"));
-        Assert.False(interpreter.HasNonTerminal("unknown"));
+        ScenarioExpect.True(interpreter.HasNonTerminal("seq"));
+        ScenarioExpect.False(interpreter.HasNonTerminal("unknown"));
     }
 
+    [Scenario("ActionInterpreter InterpretWithDefaultContext")]
     [Fact]
     public void ActionInterpreter_InterpretWithDefaultContext()
     {
@@ -605,9 +622,10 @@ public sealed class ActionInterpreterTests
 
         interpreter.Interpret(Terminal("log", "test"));
 
-        Assert.Single(log);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("ActionInterpreter NestedNonTerminals")]
     [Fact]
     public void ActionInterpreter_NestedNonTerminals()
     {
@@ -624,10 +642,10 @@ public sealed class ActionInterpreterTests
             Terminal("log", "c"));
         interpreter.Interpret(expr);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("a", log[0]);
-        Assert.Equal("b", log[1]);
-        Assert.Equal("c", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("a", log[0]);
+        ScenarioExpect.Equal("b", log[1]);
+        ScenarioExpect.Equal("c", log[2]);
     }
 }
 
@@ -637,6 +655,7 @@ public sealed class ActionInterpreterTests
 
 public sealed class AsyncInterpreterTests
 {
+    [Scenario("AsyncInterpreter Terminal Evaluates")]
     [Fact]
     public async Task AsyncInterpreter_Terminal_Evaluates()
     {
@@ -646,9 +665,10 @@ public sealed class AsyncInterpreterTests
 
         var result = await interpreter.InterpretAsync(Terminal("number", "42"));
 
-        Assert.Equal(42, result);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("AsyncInterpreter Terminal WithContext")]
     [Fact]
     public async Task AsyncInterpreter_Terminal_WithContext()
     {
@@ -659,9 +679,10 @@ public sealed class AsyncInterpreterTests
         var ctx = new Dictionary<string, int> { ["x"] = 100 };
         var result = await interpreter.InterpretAsync(Terminal("var", "x"), ctx);
 
-        Assert.Equal(100, result);
+        ScenarioExpect.Equal(100, result);
     }
 
+    [Scenario("AsyncInterpreter Terminal Async")]
     [Fact]
     public async Task AsyncInterpreter_Terminal_Async()
     {
@@ -675,9 +696,10 @@ public sealed class AsyncInterpreterTests
 
         var result = await interpreter.InterpretAsync(Terminal("number", "42"));
 
-        Assert.Equal(42, result);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("AsyncInterpreter Terminal AsyncWithContext")]
     [Fact]
     public async Task AsyncInterpreter_Terminal_AsyncWithContext()
     {
@@ -691,9 +713,10 @@ public sealed class AsyncInterpreterTests
 
         var result = await interpreter.InterpretAsync(Terminal("number", "10"), 5);
 
-        Assert.Equal(50, result);
+        ScenarioExpect.Equal(50, result);
     }
 
+    [Scenario("AsyncInterpreter Binary Evaluates")]
     [Fact]
     public async Task AsyncInterpreter_Binary_Evaluates()
     {
@@ -707,9 +730,10 @@ public sealed class AsyncInterpreterTests
             Terminal("number", "20"));
         var result = await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(30, result);
+        ScenarioExpect.Equal(30, result);
     }
 
+    [Scenario("AsyncInterpreter Binary ThrowsWithWrongOperandCount")]
     [Fact]
     public async Task AsyncInterpreter_Binary_ThrowsWithWrongOperandCount()
     {
@@ -720,11 +744,12 @@ public sealed class AsyncInterpreterTests
 
         var expr = NonTerminal("add", Terminal("number", "10"));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(expr).AsTask());
-        Assert.Contains("exactly 2 operands", ex.Message);
+        ScenarioExpect.Contains("exactly 2 operands", ex.Message);
     }
 
+    [Scenario("AsyncInterpreter Unary Evaluates")]
     [Fact]
     public async Task AsyncInterpreter_Unary_Evaluates()
     {
@@ -736,9 +761,10 @@ public sealed class AsyncInterpreterTests
         var expr = NonTerminal("neg", Terminal("number", "10"));
         var result = await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(-10, result);
+        ScenarioExpect.Equal(-10, result);
     }
 
+    [Scenario("AsyncInterpreter Unary ThrowsWithWrongOperandCount")]
     [Fact]
     public async Task AsyncInterpreter_Unary_ThrowsWithWrongOperandCount()
     {
@@ -751,11 +777,12 @@ public sealed class AsyncInterpreterTests
             Terminal("number", "10"),
             Terminal("number", "20"));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(expr).AsTask());
-        Assert.Contains("exactly 1 operand", ex.Message);
+        ScenarioExpect.Contains("exactly 1 operand", ex.Message);
     }
 
+    [Scenario("AsyncInterpreter NonTerminal WithContext")]
     [Fact]
     public async Task AsyncInterpreter_NonTerminal_WithContext()
     {
@@ -770,9 +797,10 @@ public sealed class AsyncInterpreterTests
             Terminal("number", "3"));
         var result = await interpreter.InterpretAsync(expr, 10);
 
-        Assert.Equal(60, result); // (1+2+3) * 10
+        ScenarioExpect.Equal(60, result); // (1+2+3) * 10
     }
 
+    [Scenario("AsyncInterpreter NonTerminal WithoutContext")]
     [Fact]
     public async Task AsyncInterpreter_NonTerminal_WithoutContext()
     {
@@ -787,9 +815,10 @@ public sealed class AsyncInterpreterTests
             Terminal("number", "3"));
         var result = await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(6, result);
+        ScenarioExpect.Equal(6, result);
     }
 
+    [Scenario("AsyncInterpreter NonTerminal Async")]
     [Fact]
     public async Task AsyncInterpreter_NonTerminal_Async()
     {
@@ -805,9 +834,10 @@ public sealed class AsyncInterpreterTests
         var expr = NonTerminal("sum", Terminal("number", "10"), Terminal("number", "20"));
         var result = await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(30, result);
+        ScenarioExpect.Equal(30, result);
     }
 
+    [Scenario("AsyncInterpreter TryInterpret Success")]
     [Fact]
     public async Task AsyncInterpreter_TryInterpret_Success()
     {
@@ -817,10 +847,11 @@ public sealed class AsyncInterpreterTests
 
         var (success, result) = await interpreter.TryInterpretAsync(Terminal("number", "42"), null!);
 
-        Assert.True(success);
-        Assert.Equal(42, result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("AsyncInterpreter TryInterpret Failure")]
     [Fact]
     public async Task AsyncInterpreter_TryInterpret_Failure()
     {
@@ -830,10 +861,11 @@ public sealed class AsyncInterpreterTests
 
         var (success, result) = await interpreter.TryInterpretAsync(Terminal("unknown", "value"), null!);
 
-        Assert.False(success);
-        Assert.Equal(default, result);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal(default, result);
     }
 
+    [Scenario("AsyncInterpreter HasTerminal")]
     [Fact]
     public async Task AsyncInterpreter_HasTerminal()
     {
@@ -841,10 +873,11 @@ public sealed class AsyncInterpreterTests
             .Terminal("number", token => int.Parse(token))
             .Build();
 
-        Assert.True(interpreter.HasTerminal("number"));
-        Assert.False(interpreter.HasTerminal("unknown"));
+        ScenarioExpect.True(interpreter.HasTerminal("number"));
+        ScenarioExpect.False(interpreter.HasTerminal("unknown"));
     }
 
+    [Scenario("AsyncInterpreter HasNonTerminal")]
     [Fact]
     public async Task AsyncInterpreter_HasNonTerminal()
     {
@@ -852,10 +885,11 @@ public sealed class AsyncInterpreterTests
             .Binary("add", (l, r) => l + r)
             .Build();
 
-        Assert.True(interpreter.HasNonTerminal("add"));
-        Assert.False(interpreter.HasNonTerminal("unknown"));
+        ScenarioExpect.True(interpreter.HasNonTerminal("add"));
+        ScenarioExpect.False(interpreter.HasNonTerminal("unknown"));
     }
 
+    [Scenario("AsyncInterpreter ThrowsForUnknownTerminal")]
     [Fact]
     public async Task AsyncInterpreter_ThrowsForUnknownTerminal()
     {
@@ -863,11 +897,12 @@ public sealed class AsyncInterpreterTests
             .Terminal("number", token => int.Parse(token))
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(Terminal("unknown", "value")).AsTask());
-        Assert.Contains("No terminal handler", ex.Message);
+        ScenarioExpect.Contains("No terminal handler", ex.Message);
     }
 
+    [Scenario("AsyncInterpreter ThrowsForUnknownNonTerminal")]
     [Fact]
     public async Task AsyncInterpreter_ThrowsForUnknownNonTerminal()
     {
@@ -875,11 +910,12 @@ public sealed class AsyncInterpreterTests
             .Terminal("number", token => int.Parse(token))
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(NonTerminal("unknown", Terminal("number", "1"))).AsTask());
-        Assert.Contains("No non-terminal handler", ex.Message);
+        ScenarioExpect.Contains("No non-terminal handler", ex.Message);
     }
 
+    [Scenario("AsyncInterpreter NestedExpressions")]
     [Fact]
     public async Task AsyncInterpreter_NestedExpressions()
     {
@@ -895,7 +931,7 @@ public sealed class AsyncInterpreterTests
             NonTerminal("add", Terminal("number", "3"), Terminal("number", "4")));
         var result = await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(21, result);
+        ScenarioExpect.Equal(21, result);
     }
 }
 
@@ -905,6 +941,7 @@ public sealed class AsyncInterpreterTests
 
 public sealed class AsyncActionInterpreterTests
 {
+    [Scenario("AsyncActionInterpreter Terminal Executes")]
     [Fact]
     public async Task AsyncActionInterpreter_Terminal_Executes()
     {
@@ -915,10 +952,11 @@ public sealed class AsyncActionInterpreterTests
 
         await interpreter.InterpretAsync(Terminal("log", "hello"));
 
-        Assert.Single(log);
-        Assert.Equal("hello", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("hello", log[0]);
     }
 
+    [Scenario("AsyncActionInterpreter Terminal WithContext")]
     [Fact]
     public async Task AsyncActionInterpreter_Terminal_WithContext()
     {
@@ -929,10 +967,11 @@ public sealed class AsyncActionInterpreterTests
 
         await interpreter.InterpretAsync(Terminal("log", "hello"), "PREFIX");
 
-        Assert.Single(log);
-        Assert.Equal("PREFIX: hello", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("PREFIX: hello", log[0]);
     }
 
+    [Scenario("AsyncActionInterpreter Terminal Async")]
     [Fact]
     public async Task AsyncActionInterpreter_Terminal_Async()
     {
@@ -947,9 +986,10 @@ public sealed class AsyncActionInterpreterTests
 
         await interpreter.InterpretAsync(Terminal("log", "hello"));
 
-        Assert.Single(log);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("AsyncActionInterpreter Terminal AsyncWithContext")]
     [Fact]
     public async Task AsyncActionInterpreter_Terminal_AsyncWithContext()
     {
@@ -964,10 +1004,11 @@ public sealed class AsyncActionInterpreterTests
 
         await interpreter.InterpretAsync(Terminal("log", "hello"), "PREFIX");
 
-        Assert.Single(log);
-        Assert.Equal("PREFIX: hello", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("PREFIX: hello", log[0]);
     }
 
+    [Scenario("AsyncActionInterpreter Sequence ExecutesInOrder")]
     [Fact]
     public async Task AsyncActionInterpreter_Sequence_ExecutesInOrder()
     {
@@ -983,12 +1024,13 @@ public sealed class AsyncActionInterpreterTests
             Terminal("log", "third"));
         await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("first", log[0]);
-        Assert.Equal("second", log[1]);
-        Assert.Equal("third", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("first", log[0]);
+        ScenarioExpect.Equal("second", log[1]);
+        ScenarioExpect.Equal("third", log[2]);
     }
 
+    [Scenario("AsyncActionInterpreter Parallel ExecutesAll")]
     [Fact]
     public async Task AsyncActionInterpreter_Parallel_ExecutesAll()
     {
@@ -1003,11 +1045,12 @@ public sealed class AsyncActionInterpreterTests
             Terminal("log", "b"));
         await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(2, log.Count);
-        Assert.Contains("a", log);
-        Assert.Contains("b", log);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Contains("a", log);
+        ScenarioExpect.Contains("b", log);
     }
 
+    [Scenario("AsyncActionInterpreter Conditional ThenBranch")]
     [Fact]
     public async Task AsyncActionInterpreter_Conditional_ThenBranch()
     {
@@ -1023,10 +1066,11 @@ public sealed class AsyncActionInterpreterTests
             Terminal("log", "else"));
         await interpreter.InterpretAsync(expr, true);
 
-        Assert.Single(log);
-        Assert.Equal("then", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("then", log[0]);
     }
 
+    [Scenario("AsyncActionInterpreter Conditional ElseBranch")]
     [Fact]
     public async Task AsyncActionInterpreter_Conditional_ElseBranch()
     {
@@ -1042,10 +1086,11 @@ public sealed class AsyncActionInterpreterTests
             Terminal("log", "else"));
         await interpreter.InterpretAsync(expr, false);
 
-        Assert.Single(log);
-        Assert.Equal("else", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("else", log[0]);
     }
 
+    [Scenario("AsyncActionInterpreter Conditional Async")]
     [Fact]
     public async Task AsyncActionInterpreter_Conditional_Async()
     {
@@ -1065,10 +1110,11 @@ public sealed class AsyncActionInterpreterTests
             Terminal("log", "else"));
         await interpreter.InterpretAsync(expr, true);
 
-        Assert.Single(log);
-        Assert.Equal("then", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("then", log[0]);
     }
 
+    [Scenario("AsyncActionInterpreter Conditional ThrowsWithTooFewChildren")]
     [Fact]
     public async Task AsyncActionInterpreter_Conditional_ThrowsWithTooFewChildren()
     {
@@ -1079,11 +1125,12 @@ public sealed class AsyncActionInterpreterTests
 
         var expr = NonTerminal("if", Terminal("log", "only-one"));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(expr, true).AsTask());
-        Assert.Contains("at least 2 children", ex.Message);
+        ScenarioExpect.Contains("at least 2 children", ex.Message);
     }
 
+    [Scenario("AsyncActionInterpreter NonTerminal WithContext")]
     [Fact]
     public async Task AsyncActionInterpreter_NonTerminal_WithContext()
     {
@@ -1101,12 +1148,13 @@ public sealed class AsyncActionInterpreterTests
         var expr = NonTerminal("wrap", Terminal("log", "inner"));
         await interpreter.InterpretAsync(expr, "CTX");
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("start-CTX", log[0]);
-        Assert.Equal("inner", log[1]);
-        Assert.Equal("end-CTX", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("start-CTX", log[0]);
+        ScenarioExpect.Equal("inner", log[1]);
+        ScenarioExpect.Equal("end-CTX", log[2]);
     }
 
+    [Scenario("AsyncActionInterpreter NonTerminal WithoutContext")]
     [Fact]
     public async Task AsyncActionInterpreter_NonTerminal_WithoutContext()
     {
@@ -1124,9 +1172,10 @@ public sealed class AsyncActionInterpreterTests
         var expr = NonTerminal("wrap", Terminal("log", "inner"));
         await interpreter.InterpretAsync(expr);
 
-        Assert.Equal(3, log.Count);
+        ScenarioExpect.Equal(3, log.Count);
     }
 
+    [Scenario("AsyncActionInterpreter TryInterpret Success")]
     [Fact]
     public async Task AsyncActionInterpreter_TryInterpret_Success()
     {
@@ -1137,11 +1186,12 @@ public sealed class AsyncActionInterpreterTests
 
         var (success, error) = await interpreter.TryInterpretAsync(Terminal("log", "test"), null!);
 
-        Assert.True(success);
-        Assert.Null(error);
-        Assert.Single(log);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Null(error);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("AsyncActionInterpreter TryInterpret Failure")]
     [Fact]
     public async Task AsyncActionInterpreter_TryInterpret_Failure()
     {
@@ -1151,11 +1201,12 @@ public sealed class AsyncActionInterpreterTests
 
         var (success, error) = await interpreter.TryInterpretAsync(Terminal("unknown", "value"), null!);
 
-        Assert.False(success);
-        Assert.NotNull(error);
-        Assert.Contains("No terminal handler", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.NotNull(error);
+        ScenarioExpect.Contains("No terminal handler", error);
     }
 
+    [Scenario("AsyncActionInterpreter HasTerminal")]
     [Fact]
     public async Task AsyncActionInterpreter_HasTerminal()
     {
@@ -1163,10 +1214,11 @@ public sealed class AsyncActionInterpreterTests
             .Terminal("log", msg => { })
             .Build();
 
-        Assert.True(interpreter.HasTerminal("log"));
-        Assert.False(interpreter.HasTerminal("unknown"));
+        ScenarioExpect.True(interpreter.HasTerminal("log"));
+        ScenarioExpect.False(interpreter.HasTerminal("unknown"));
     }
 
+    [Scenario("AsyncActionInterpreter HasNonTerminal")]
     [Fact]
     public async Task AsyncActionInterpreter_HasNonTerminal()
     {
@@ -1174,10 +1226,11 @@ public sealed class AsyncActionInterpreterTests
             .Sequence("seq")
             .Build();
 
-        Assert.True(interpreter.HasNonTerminal("seq"));
-        Assert.False(interpreter.HasNonTerminal("unknown"));
+        ScenarioExpect.True(interpreter.HasNonTerminal("seq"));
+        ScenarioExpect.False(interpreter.HasNonTerminal("unknown"));
     }
 
+    [Scenario("AsyncActionInterpreter ThrowsForUnknownTerminal")]
     [Fact]
     public async Task AsyncActionInterpreter_ThrowsForUnknownTerminal()
     {
@@ -1185,11 +1238,12 @@ public sealed class AsyncActionInterpreterTests
             .Terminal("log", msg => { })
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(Terminal("unknown", "value")).AsTask());
-        Assert.Contains("No terminal handler", ex.Message);
+        ScenarioExpect.Contains("No terminal handler", ex.Message);
     }
 
+    [Scenario("AsyncActionInterpreter ThrowsForUnknownNonTerminal")]
     [Fact]
     public async Task AsyncActionInterpreter_ThrowsForUnknownNonTerminal()
     {
@@ -1197,11 +1251,12 @@ public sealed class AsyncActionInterpreterTests
             .Terminal("log", msg => { })
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(NonTerminal("unknown", Terminal("log", "value"))).AsTask());
-        Assert.Contains("No non-terminal handler", ex.Message);
+        ScenarioExpect.Contains("No non-terminal handler", ex.Message);
     }
 
+    [Scenario("AsyncActionInterpreter InterpretWithoutContext")]
     [Fact]
     public async Task AsyncActionInterpreter_InterpretWithoutContext()
     {
@@ -1212,9 +1267,10 @@ public sealed class AsyncActionInterpreterTests
 
         await interpreter.InterpretAsync(Terminal("log", "test"));
 
-        Assert.Single(log);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("AsyncActionInterpreter ThrowsForUnknownExpressionType")]
     [Fact]
     public async Task AsyncActionInterpreter_ThrowsForUnknownExpressionType()
     {
@@ -1225,9 +1281,9 @@ public sealed class AsyncActionInterpreterTests
         // Create a custom expression type
         var customExpr = new CustomExpression();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             interpreter.InterpretAsync(customExpr).AsTask());
-        Assert.Contains("Unknown expression type", ex.Message);
+        ScenarioExpect.Contains("Unknown expression type", ex.Message);
     }
 
     private class CustomExpression : IExpression
@@ -1242,17 +1298,19 @@ public sealed class AsyncActionInterpreterTests
 
 public sealed class ExpressionExtensionsTests
 {
+    [Scenario("Terminal CreatesTerminalExpression")]
     [Fact]
     public void Terminal_CreatesTerminalExpression()
     {
         var expr = Terminal("number", "42");
 
-        Assert.IsType<TerminalExpression>(expr);
+        ScenarioExpect.IsType<TerminalExpression>(expr);
         var terminal = (TerminalExpression)expr;
-        Assert.Equal("number", terminal.Type);
-        Assert.Equal("42", terminal.Value);
+        ScenarioExpect.Equal("number", terminal.Type);
+        ScenarioExpect.Equal("42", terminal.Value);
     }
 
+    [Scenario("NonTerminal CreatesNonTerminalExpression")]
     [Fact]
     public void NonTerminal_CreatesNonTerminalExpression()
     {
@@ -1260,72 +1318,78 @@ public sealed class ExpressionExtensionsTests
             Terminal("number", "1"),
             Terminal("number", "2"));
 
-        Assert.IsType<NonTerminalExpression>(expr);
+        ScenarioExpect.IsType<NonTerminalExpression>(expr);
         var nonTerminal = (NonTerminalExpression)expr;
-        Assert.Equal("add", nonTerminal.Type);
-        Assert.Equal(2, nonTerminal.Children.Length);
+        ScenarioExpect.Equal("add", nonTerminal.Type);
+        ScenarioExpect.Equal(2, nonTerminal.Children.Length);
     }
 
+    [Scenario("Number CreatesNumberTerminal")]
     [Fact]
     public void Number_CreatesNumberTerminal()
     {
         var expr = Number(42.5);
 
-        Assert.IsType<TerminalExpression>(expr);
+        ScenarioExpect.IsType<TerminalExpression>(expr);
         var terminal = (TerminalExpression)expr;
-        Assert.Equal("number", terminal.Type);
-        Assert.Equal("42.5", terminal.Value);
+        ScenarioExpect.Equal("number", terminal.Type);
+        ScenarioExpect.Equal("42.5", terminal.Value);
     }
 
+    [Scenario("String CreatesStringTerminal")]
     [Fact]
     public void String_CreatesStringTerminal()
     {
         var expr = ExpressionExtensions.String("hello");
 
-        Assert.IsType<TerminalExpression>(expr);
+        ScenarioExpect.IsType<TerminalExpression>(expr);
         var terminal = (TerminalExpression)expr;
-        Assert.Equal("string", terminal.Type);
-        Assert.Equal("hello", terminal.Value);
+        ScenarioExpect.Equal("string", terminal.Type);
+        ScenarioExpect.Equal("hello", terminal.Value);
     }
 
+    [Scenario("Identifier CreatesIdentifierTerminal")]
     [Fact]
     public void Identifier_CreatesIdentifierTerminal()
     {
         var expr = Identifier("x");
 
-        Assert.IsType<TerminalExpression>(expr);
+        ScenarioExpect.IsType<TerminalExpression>(expr);
         var terminal = (TerminalExpression)expr;
-        Assert.Equal("identifier", terminal.Type);
-        Assert.Equal("x", terminal.Value);
+        ScenarioExpect.Equal("identifier", terminal.Type);
+        ScenarioExpect.Equal("x", terminal.Value);
     }
 
+    [Scenario("Boolean CreatesBooleanTerminal")]
     [Fact]
     public void Boolean_CreatesBooleanTerminal()
     {
         var trueExpr = Boolean(true);
         var falseExpr = Boolean(false);
 
-        Assert.IsType<TerminalExpression>(trueExpr);
-        Assert.IsType<TerminalExpression>(falseExpr);
+        ScenarioExpect.IsType<TerminalExpression>(trueExpr);
+        ScenarioExpect.IsType<TerminalExpression>(falseExpr);
 
         var trueTerminal = (TerminalExpression)trueExpr;
         var falseTerminal = (TerminalExpression)falseExpr;
 
-        Assert.Equal("boolean", trueTerminal.Type);
-        Assert.Equal("true", trueTerminal.Value);
-        Assert.Equal("boolean", falseTerminal.Type);
-        Assert.Equal("false", falseTerminal.Value);
+        ScenarioExpect.Equal("boolean", trueTerminal.Type);
+        ScenarioExpect.Equal("true", trueTerminal.Value);
+        ScenarioExpect.Equal("boolean", falseTerminal.Type);
+        ScenarioExpect.Equal("false", falseTerminal.Value);
     }
 
+    [Scenario("TerminalExpression Properties")]
     [Fact]
     public void TerminalExpression_Properties()
     {
         var expr = new TerminalExpression("type", "value");
 
-        Assert.Equal("type", expr.Type);
-        Assert.Equal("value", expr.Value);
+        ScenarioExpect.Equal("type", expr.Type);
+        ScenarioExpect.Equal("value", expr.Value);
     }
 
+    [Scenario("NonTerminalExpression Properties")]
     [Fact]
     public void NonTerminalExpression_Properties()
     {
@@ -1333,21 +1397,23 @@ public sealed class ExpressionExtensionsTests
         var child2 = Terminal("b", "2");
         var expr = new NonTerminalExpression("type", child1, child2);
 
-        Assert.Equal("type", expr.Type);
-        Assert.Equal(2, expr.Children.Length);
-        Assert.Same(child1, expr.Children[0]);
-        Assert.Same(child2, expr.Children[1]);
+        ScenarioExpect.Equal("type", expr.Type);
+        ScenarioExpect.Equal(2, expr.Children.Length);
+        ScenarioExpect.Same(child1, expr.Children[0]);
+        ScenarioExpect.Same(child2, expr.Children[1]);
     }
 
+    [Scenario("NonTerminalExpression EmptyChildren")]
     [Fact]
     public void NonTerminalExpression_EmptyChildren()
     {
         var expr = new NonTerminalExpression("empty");
 
-        Assert.Equal("empty", expr.Type);
-        Assert.Empty(expr.Children);
+        ScenarioExpect.Equal("empty", expr.Type);
+        ScenarioExpect.Empty(expr.Children);
     }
 
+    [Scenario("InterpretWithExtensions ArithmeticExample")]
     [Fact]
     public void InterpretWithExtensions_ArithmeticExample()
     {
@@ -1366,9 +1432,10 @@ public sealed class ExpressionExtensionsTests
 
         var result = interpreter.Interpret(expr);
 
-        Assert.Equal(16, result); // 10 + (2 * 3)
+        ScenarioExpect.Equal(16, result); // 10 + (2 * 3)
     }
 
+    [Scenario("InterpretWithExtensions BooleanExample")]
     [Fact]
     public void InterpretWithExtensions_BooleanExample()
     {
@@ -1384,7 +1451,7 @@ public sealed class ExpressionExtensionsTests
 
         var result = interpreter.Interpret(expr);
 
-        Assert.True(result);
+        ScenarioExpect.True(result);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Iterator/AsyncFlowTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Iterator/AsyncFlowTests.cs
@@ -111,80 +111,91 @@ public sealed class AsyncFlowBuilderTests
             yield return i;
     }
 
+    [Scenario("AsyncFlow From Null Throws")]
     [Fact]
     public void AsyncFlow_From_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => AsyncFlow<int>.From(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => AsyncFlow<int>.From(null!));
     }
 
+    [Scenario("AsyncFlow Map Null Throws")]
     [Fact]
     public void AsyncFlow_Map_Null_Throws()
     {
         var flow = AsyncFlow<int>.From(RangeAsync(3));
-        Assert.Throws<ArgumentNullException>(() => flow.Map<int>(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.Map<int>(null!));
     }
 
+    [Scenario("AsyncFlow Filter Null Throws")]
     [Fact]
     public void AsyncFlow_Filter_Null_Throws()
     {
         var flow = AsyncFlow<int>.From(RangeAsync(3));
-        Assert.Throws<ArgumentNullException>(() => flow.Filter(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.Filter(null!));
     }
 
+    [Scenario("AsyncFlow FlatMap Null Throws")]
     [Fact]
     public void AsyncFlow_FlatMap_Null_Throws()
     {
         var flow = AsyncFlow<int>.From(RangeAsync(3));
-        Assert.Throws<ArgumentNullException>(() => flow.FlatMap<int>(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.FlatMap<int>(null!));
     }
 
+    [Scenario("AsyncFlow Tee Null Throws")]
     [Fact]
     public void AsyncFlow_Tee_Null_Throws()
     {
         var flow = AsyncFlow<int>.From(RangeAsync(3));
-        Assert.Throws<ArgumentNullException>(() => flow.Tee(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.Tee(null!));
     }
 
+    [Scenario("SharedAsyncFlow Branch Null Throws")]
     [Fact]
     public void SharedAsyncFlow_Branch_Null_Throws()
     {
         var shared = AsyncFlow<int>.From(RangeAsync(3)).Share();
-        Assert.Throws<ArgumentNullException>(() => shared.Branch(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => shared.Branch(null!));
     }
 
+    [Scenario("AsyncFlow FoldAsync")]
     [Fact]
     public async Task AsyncFlow_FoldAsync()
     {
         var flow = AsyncFlow<int>.From(RangeAsync(5));
         var sum = await flow.FoldAsync(0, (acc, x) => acc + x);
 
-        Assert.Equal(15, sum);
+        ScenarioExpect.Equal(15, sum);
     }
 
+    [Scenario("AsyncFlow FoldAsync Null Flow Throws")]
     [Fact]
     public async Task AsyncFlow_FoldAsync_Null_Flow_Throws()
     {
         AsyncFlow<int>? flow = null;
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(() =>
             flow!.FoldAsync(0, (acc, x) => acc + x).AsTask());
     }
 
+    [Scenario("AsyncFlow FoldAsync Null Folder Throws")]
     [Fact]
     public async Task AsyncFlow_FoldAsync_Null_Folder_Throws()
     {
         var flow = AsyncFlow<int>.From(RangeAsync(3));
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(() =>
             flow.FoldAsync<int, int>(0, null!).AsTask());
     }
 
+    [Scenario("AsyncFlow FirstOptionAsync Null Throws")]
     [Fact]
     public async Task AsyncFlow_FirstOptionAsync_Null_Throws()
     {
         AsyncFlow<int>? flow = null;
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(() =>
             flow!.FirstOptionAsync().AsTask());
     }
 
+    [Scenario("SharedAsyncFlow Fork Works")]
     [Fact]
     public async Task SharedAsyncFlow_Fork_Works()
     {
@@ -195,9 +206,10 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in fork)
             result.Add(v);
 
-        Assert.Equal(new[] { 1, 2, 3 }, result);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, result);
     }
 
+    [Scenario("AsyncFlow Empty Source")]
     [Fact]
     public async Task AsyncFlow_Empty_Source()
     {
@@ -206,9 +218,10 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in flow)
             result.Add(v);
 
-        Assert.Empty(result);
+        ScenarioExpect.Empty(result);
     }
 
+    [Scenario("AsyncFlow Chained Operations")]
     [Fact]
     public async Task AsyncFlow_Chained_Operations()
     {
@@ -220,9 +233,10 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in flow)
             result.Add(v);
 
-        Assert.Equal(new[] { 20, 40, 60, 80, 100 }, result);
+        ScenarioExpect.Equal(new[] { 20, 40, 60, 80, 100 }, result);
     }
 
+    [Scenario("AsyncFlow WithCancellation Works")]
     [Fact]
     public async Task AsyncFlow_WithCancellation_Works()
     {
@@ -233,9 +247,10 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in flow.WithCancellation(cts.Token))
             result.Add(v);
 
-        Assert.Equal(new[] { 1, 2, 3 }, result);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, result);
     }
 
+    [Scenario("SharedAsyncFlow MultipleForks SameData")]
     [Fact]
     public async Task SharedAsyncFlow_MultipleForks_SameData()
     {
@@ -253,11 +268,12 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in fork2) list2.Add(v);
         await foreach (var v in fork3) list3.Add(v);
 
-        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, list1);
-        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, list2);
-        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, list3);
+        ScenarioExpect.Equal(new[] { 1, 2, 3, 4, 5 }, list1);
+        ScenarioExpect.Equal(new[] { 1, 2, 3, 4, 5 }, list2);
+        ScenarioExpect.Equal(new[] { 1, 2, 3, 4, 5 }, list3);
     }
 
+    [Scenario("SharedAsyncFlow ConcurrentForks")]
     [Fact]
     public async Task SharedAsyncFlow_ConcurrentForks()
     {
@@ -275,11 +291,12 @@ public sealed class AsyncFlowBuilderTests
 
         foreach (var result in results)
         {
-            Assert.Equal(10, result.Count);
-            Assert.Equal(Enumerable.Range(1, 10), result);
+            ScenarioExpect.Equal(10, result.Count);
+            ScenarioExpect.Equal(Enumerable.Range(1, 10), result);
         }
     }
 
+    [Scenario("SharedAsyncFlow Branch TrueFalse")]
     [Fact]
     public async Task SharedAsyncFlow_Branch_TrueFalse()
     {
@@ -292,10 +309,11 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in trueFlow) evenList.Add(v);
         await foreach (var v in falseFlow) oddList.Add(v);
 
-        Assert.Equal(new[] { 2, 4, 6, 8, 10 }, evenList);
-        Assert.Equal(new[] { 1, 3, 5, 7, 9 }, oddList);
+        ScenarioExpect.Equal(new[] { 2, 4, 6, 8, 10 }, evenList);
+        ScenarioExpect.Equal(new[] { 1, 3, 5, 7, 9 }, oddList);
     }
 
+    [Scenario("AsyncFlow Map Transform")]
     [Fact]
     public async Task AsyncFlow_Map_Transform()
     {
@@ -305,9 +323,10 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in flow.Map(x => $"item{x}"))
             result.Add(v);
 
-        Assert.Equal(new[] { "item1", "item2", "item3" }, result);
+        ScenarioExpect.Equal(new[] { "item1", "item2", "item3" }, result);
     }
 
+    [Scenario("AsyncFlow Filter Predicate")]
     [Fact]
     public async Task AsyncFlow_Filter_Predicate()
     {
@@ -317,9 +336,10 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in flow.Filter(x => x > 5))
             result.Add(v);
 
-        Assert.Equal(new[] { 6, 7, 8, 9, 10 }, result);
+        ScenarioExpect.Equal(new[] { 6, 7, 8, 9, 10 }, result);
     }
 
+    [Scenario("AsyncFlow Tee SideEffect")]
     [Fact]
     public async Task AsyncFlow_Tee_SideEffect()
     {
@@ -330,8 +350,8 @@ public sealed class AsyncFlowBuilderTests
         await foreach (var v in flow.Tee(x => sideEffects.Add(x * 10)))
             result.Add(v);
 
-        Assert.Equal(new[] { 1, 2, 3 }, result);
-        Assert.Equal(new[] { 10, 20, 30 }, sideEffects);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, result);
+        ScenarioExpect.Equal(new[] { 10, 20, 30 }, sideEffects);
     }
 }
 
@@ -363,6 +383,7 @@ public sealed class AsyncReplayBufferTests
         }
     }
 
+    [Scenario("SharedAsyncFlow SourceThrows PropagatesException")]
     [Fact]
     public async Task SharedAsyncFlow_SourceThrows_PropagatesException()
     {
@@ -370,16 +391,17 @@ public sealed class AsyncReplayBufferTests
         var fork = shared.Fork();
 
         var items = new List<int>();
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await foreach (var v in fork)
                 items.Add(v);
         });
 
-        Assert.Equal("Source error", ex.Message);
-        Assert.Equal(new[] { 1, 2 }, items);
+        ScenarioExpect.Equal("Source error", ex.Message);
+        ScenarioExpect.Equal(new[] { 1, 2 }, items);
     }
 
+    [Scenario("SharedAsyncFlow ErrorPropagates ToMultipleForks")]
     [Fact]
     public async Task SharedAsyncFlow_ErrorPropagates_ToMultipleForks()
     {
@@ -390,7 +412,7 @@ public sealed class AsyncReplayBufferTests
 
         // First fork consumes and hits error
         var items1 = new List<int>();
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await foreach (var v in fork1)
                 items1.Add(v);
@@ -402,10 +424,11 @@ public sealed class AsyncReplayBufferTests
         await foreach (var v in fork2)
             items2.Add(v);
 
-        Assert.Equal(new[] { 1, 2 }, items1);
-        Assert.Equal(new[] { 1, 2 }, items2); // Gets buffered items without error
+        ScenarioExpect.Equal(new[] { 1, 2 }, items1);
+        ScenarioExpect.Equal(new[] { 1, 2 }, items2); // Gets buffered items without error
     }
 
+    [Scenario("SharedAsyncFlow Cancellation StopsEnumeration")]
     [Fact]
     public async Task SharedAsyncFlow_Cancellation_StopsEnumeration()
     {
@@ -426,7 +449,7 @@ public sealed class AsyncReplayBufferTests
             cts.Cancel();
 
             // Next attempt should throw
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await ScenarioExpect.ThrowsAnyAsync<OperationCanceledException>(async () =>
             {
                 while (await enumerator.MoveNextAsync())
                     items.Add(enumerator.Current);
@@ -437,9 +460,10 @@ public sealed class AsyncReplayBufferTests
             await enumerator.DisposeAsync();
         }
 
-        Assert.Single(items);
+        ScenarioExpect.Single(items);
     }
 
+    [Scenario("SharedAsyncFlow TryGetAsync NegativeIndex ReturnsFalse")]
     [Fact]
     public async Task SharedAsyncFlow_TryGetAsync_NegativeIndex_ReturnsFalse()
     {
@@ -452,9 +476,10 @@ public sealed class AsyncReplayBufferTests
         await foreach (var v in fork)
             items.Add(v);
 
-        Assert.Equal(new[] { 1, 2, 3 }, items);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, items);
     }
 
+    [Scenario("SharedAsyncFlow MultipleConcurrentWaiters")]
     [Fact]
     public async Task SharedAsyncFlow_MultipleConcurrentWaiters()
     {
@@ -473,10 +498,11 @@ public sealed class AsyncReplayBufferTests
 
         foreach (var result in results)
         {
-            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, result);
+            ScenarioExpect.Equal(new[] { 1, 2, 3, 4, 5 }, result);
         }
     }
 
+    [Scenario("SharedAsyncFlow EmptySource AllForksEmpty")]
     [Fact]
     public async Task SharedAsyncFlow_EmptySource_AllForksEmpty()
     {
@@ -491,10 +517,11 @@ public sealed class AsyncReplayBufferTests
         await foreach (var v in fork1) items1.Add(v);
         await foreach (var v in fork2) items2.Add(v);
 
-        Assert.Empty(items1);
-        Assert.Empty(items2);
+        ScenarioExpect.Empty(items1);
+        ScenarioExpect.Empty(items2);
     }
 
+    [Scenario("SharedAsyncFlow SingleItem AllForksGetIt")]
     [Fact]
     public async Task SharedAsyncFlow_SingleItem_AllForksGetIt()
     {
@@ -512,11 +539,12 @@ public sealed class AsyncReplayBufferTests
         await foreach (var v in fork2) items2.Add(v);
         await foreach (var v in fork3) items3.Add(v);
 
-        Assert.Equal(new[] { 1 }, items1);
-        Assert.Equal(new[] { 1 }, items2);
-        Assert.Equal(new[] { 1 }, items3);
+        ScenarioExpect.Equal(new[] { 1 }, items1);
+        ScenarioExpect.Equal(new[] { 1 }, items2);
+        ScenarioExpect.Equal(new[] { 1 }, items3);
     }
 
+    [Scenario("SharedAsyncFlow SequentialForkConsumption")]
     [Fact]
     public async Task SharedAsyncFlow_SequentialForkConsumption()
     {
@@ -540,11 +568,12 @@ public sealed class AsyncReplayBufferTests
         var items2 = new List<int>();
         await foreach (var v in fork2) items2.Add(v);
 
-        Assert.Equal(1, enumerationCount); // Source should only be enumerated once
-        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, items1);
-        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, items2);
+        ScenarioExpect.Equal(1, enumerationCount); // Source should only be enumerated once
+        ScenarioExpect.Equal(new[] { 1, 2, 3, 4, 5 }, items1);
+        ScenarioExpect.Equal(new[] { 1, 2, 3, 4, 5 }, items2);
     }
 
+    [Scenario("SharedAsyncFlow InterleavedForkConsumption")]
     [Fact]
     public async Task SharedAsyncFlow_InterleavedForkConsumption()
     {
@@ -556,26 +585,26 @@ public sealed class AsyncReplayBufferTests
         try
         {
             // Interleave consumption
-            Assert.True(await fork1.MoveNextAsync());
-            Assert.Equal(1, fork1.Current);
+            ScenarioExpect.True(await fork1.MoveNextAsync());
+            ScenarioExpect.Equal(1, fork1.Current);
 
-            Assert.True(await fork2.MoveNextAsync());
-            Assert.Equal(1, fork2.Current);
+            ScenarioExpect.True(await fork2.MoveNextAsync());
+            ScenarioExpect.Equal(1, fork2.Current);
 
-            Assert.True(await fork2.MoveNextAsync());
-            Assert.Equal(2, fork2.Current);
+            ScenarioExpect.True(await fork2.MoveNextAsync());
+            ScenarioExpect.Equal(2, fork2.Current);
 
-            Assert.True(await fork1.MoveNextAsync());
-            Assert.Equal(2, fork1.Current);
+            ScenarioExpect.True(await fork1.MoveNextAsync());
+            ScenarioExpect.Equal(2, fork1.Current);
 
-            Assert.True(await fork1.MoveNextAsync());
-            Assert.Equal(3, fork1.Current);
+            ScenarioExpect.True(await fork1.MoveNextAsync());
+            ScenarioExpect.Equal(3, fork1.Current);
 
-            Assert.True(await fork2.MoveNextAsync());
-            Assert.Equal(3, fork2.Current);
+            ScenarioExpect.True(await fork2.MoveNextAsync());
+            ScenarioExpect.Equal(3, fork2.Current);
 
-            Assert.False(await fork1.MoveNextAsync());
-            Assert.False(await fork2.MoveNextAsync());
+            ScenarioExpect.False(await fork1.MoveNextAsync());
+            ScenarioExpect.False(await fork2.MoveNextAsync());
         }
         finally
         {

--- a/test/PatternKit.Tests/Behavioral/Iterator/FlowTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Iterator/FlowTests.cs
@@ -82,94 +82,106 @@ public sealed class FlowTests(ITestOutputHelper output) : TinyBddXunitBase(outpu
 
 public sealed class FlowBuilderTests
 {
+    [Scenario("Flow From Null Throws")]
     [Fact]
     public void Flow_From_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => Flow<int>.From(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => Flow<int>.From(null!));
     }
 
+    [Scenario("Flow Map Null Throws")]
     [Fact]
     public void Flow_Map_Null_Throws()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3 });
-        Assert.Throws<ArgumentNullException>(() => flow.Map<int>(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.Map<int>(null!));
     }
 
+    [Scenario("Flow Filter Null Throws")]
     [Fact]
     public void Flow_Filter_Null_Throws()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3 });
-        Assert.Throws<ArgumentNullException>(() => flow.Filter(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.Filter(null!));
     }
 
+    [Scenario("Flow FlatMap Null Throws")]
     [Fact]
     public void Flow_FlatMap_Null_Throws()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3 });
-        Assert.Throws<ArgumentNullException>(() => flow.FlatMap<int>(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.FlatMap<int>(null!));
     }
 
+    [Scenario("Flow Tee Null Throws")]
     [Fact]
     public void Flow_Tee_Null_Throws()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3 });
-        Assert.Throws<ArgumentNullException>(() => flow.Tee(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.Tee(null!));
     }
 
+    [Scenario("SharedFlow Branch Null Throws")]
     [Fact]
     public void SharedFlow_Branch_Null_Throws()
     {
         var shared = Flow<int>.From(new[] { 1, 2, 3 }).Share();
-        Assert.Throws<ArgumentNullException>(() => shared.Branch(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => shared.Branch(null!));
     }
 
+    [Scenario("SharedFlow Fork Multiple")]
     [Fact]
     public void SharedFlow_Fork_Multiple()
     {
         var shared = Flow<int>.From(new[] { 1, 2, 3 }).Share();
         var forks = shared.Fork(3);
 
-        Assert.Equal(3, forks.Length);
+        ScenarioExpect.Equal(3, forks.Length);
 
         var results = forks.Select(f => f.ToList()).ToArray();
         foreach (var result in results)
         {
-            Assert.Equal(new[] { 1, 2, 3 }, result);
+            ScenarioExpect.Equal(new[] { 1, 2, 3 }, result);
         }
     }
 
+    [Scenario("SharedFlow Fork Zero Throws")]
     [Fact]
     public void SharedFlow_Fork_Zero_Throws()
     {
         var shared = Flow<int>.From(new[] { 1, 2, 3 }).Share();
-        Assert.Throws<ArgumentOutOfRangeException>(() => shared.Fork(0));
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => shared.Fork(0));
     }
 
+    [Scenario("SharedFlow Fork Negative Throws")]
     [Fact]
     public void SharedFlow_Fork_Negative_Throws()
     {
         var shared = Flow<int>.From(new[] { 1, 2, 3 }).Share();
-        Assert.Throws<ArgumentOutOfRangeException>(() => shared.Fork(-1));
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => shared.Fork(-1));
     }
 
+    [Scenario("SharedFlow Map")]
     [Fact]
     public void SharedFlow_Map()
     {
         var shared = Flow<int>.From(new[] { 1, 2, 3 }).Share();
         var result = shared.Map(x => x * 10).ToList();
 
-        Assert.Equal(new[] { 10, 20, 30 }, result);
+        ScenarioExpect.Equal(new[] { 10, 20, 30 }, result);
     }
 
+    [Scenario("SharedFlow Filter")]
     [Fact]
     public void SharedFlow_Filter()
     {
         var shared = Flow<int>.From(new[] { 1, 2, 3, 4, 5 }).Share();
         var result = shared.Filter(x => x % 2 == 0).ToList();
 
-        Assert.Equal(new[] { 2, 4 }, result);
+        ScenarioExpect.Equal(new[] { 2, 4 }, result);
     }
 
+    [Scenario("SharedFlow AsFlow")]
     [Fact]
     public void SharedFlow_AsFlow()
     {
@@ -177,82 +189,92 @@ public sealed class FlowBuilderTests
         var flow = shared.AsFlow();
         var result = flow.ToList();
 
-        Assert.Equal(new[] { 1, 2, 3 }, result);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, result);
     }
 
+    [Scenario("FlowExtensions Fold")]
     [Fact]
     public void FlowExtensions_Fold()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3, 4, 5 });
         var sum = flow.Fold(0, (acc, x) => acc + x);
 
-        Assert.Equal(15, sum);
+        ScenarioExpect.Equal(15, sum);
     }
 
+    [Scenario("FlowExtensions Fold Null Flow Throws")]
     [Fact]
     public void FlowExtensions_Fold_Null_Flow_Throws()
     {
         Flow<int>? flow = null;
-        Assert.Throws<ArgumentNullException>(() => flow!.Fold(0, (acc, x) => acc + x));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow!.Fold(0, (acc, x) => acc + x));
     }
 
+    [Scenario("FlowExtensions Fold Null Folder Throws")]
     [Fact]
     public void FlowExtensions_Fold_Null_Folder_Throws()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3 });
-        Assert.Throws<ArgumentNullException>(() => flow.Fold<int, int>(0, null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow.Fold<int, int>(0, null!));
     }
 
+    [Scenario("SharedFlow Fold")]
     [Fact]
     public void SharedFlow_Fold()
     {
         var shared = Flow<int>.From(new[] { 1, 2, 3, 4, 5 }).Share();
         var sum = shared.Fold(0, (acc, x) => acc + x);
 
-        Assert.Equal(15, sum);
+        ScenarioExpect.Equal(15, sum);
     }
 
+    [Scenario("FlowExtensions FirstOrDefault Found")]
     [Fact]
     public void FlowExtensions_FirstOrDefault_Found()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3, 4, 5 });
         var result = flow.FirstOrDefault(x => x > 3);
 
-        Assert.Equal(4, result);
+        ScenarioExpect.Equal(4, result);
     }
 
+    [Scenario("FlowExtensions FirstOrDefault NotFound")]
     [Fact]
     public void FlowExtensions_FirstOrDefault_NotFound()
     {
         var flow = Flow<int>.From(new[] { 1, 2, 3 });
         var result = flow.FirstOrDefault(x => x > 10);
 
-        Assert.Equal(default, result);
+        ScenarioExpect.Equal(default, result);
     }
 
+    [Scenario("FlowExtensions FirstOrDefault NoPredicate")]
     [Fact]
     public void FlowExtensions_FirstOrDefault_NoPredicate()
     {
         var flow = Flow<int>.From(new[] { 5, 6, 7 });
         var result = flow.FirstOrDefault();
 
-        Assert.Equal(5, result);
+        ScenarioExpect.Equal(5, result);
     }
 
+    [Scenario("FlowExtensions FirstOrDefault Null Throws")]
     [Fact]
     public void FlowExtensions_FirstOrDefault_Null_Throws()
     {
         Flow<int>? flow = null;
-        Assert.Throws<ArgumentNullException>(() => flow!.FirstOrDefault());
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow!.FirstOrDefault());
     }
 
+    [Scenario("FlowExtensions FirstOption Null Throws")]
     [Fact]
     public void FlowExtensions_FirstOption_Null_Throws()
     {
         Flow<int>? flow = null;
-        Assert.Throws<ArgumentNullException>(() => flow!.FirstOption());
+        ScenarioExpect.Throws<ArgumentNullException>(() => flow!.FirstOption());
     }
 
+    [Scenario("Flow Deferred Execution")]
     [Fact]
     public void Flow_Deferred_Execution()
     {
@@ -264,22 +286,24 @@ public sealed class FlowBuilderTests
         }
 
         var flow = Flow<int>.From(Source());
-        Assert.False(evaluated); // Should be deferred
+        ScenarioExpect.False(evaluated); // Should be deferred
 
         var list = flow.ToList();
-        Assert.True(evaluated); // Now evaluated
-        Assert.Equal(new[] { 1 }, list);
+        ScenarioExpect.True(evaluated); // Now evaluated
+        ScenarioExpect.Equal(new[] { 1 }, list);
     }
 
+    [Scenario("Flow Empty Source")]
     [Fact]
     public void Flow_Empty_Source()
     {
         var flow = Flow<int>.From(Array.Empty<int>());
         var result = flow.Map(x => x * 2).Filter(x => x > 0).ToList();
 
-        Assert.Empty(result);
+        ScenarioExpect.Empty(result);
     }
 
+    [Scenario("SharedFlow Multiple Enumerations Share Data")]
     [Fact]
     public void SharedFlow_Multiple_Enumerations_Share_Data()
     {
@@ -299,12 +323,13 @@ public sealed class FlowBuilderTests
         var list3 = shared.Fork().ToList();
 
         // Source should only be enumerated once
-        Assert.Equal(1, callCount);
-        Assert.Equal(new[] { 1, 2, 3 }, list1);
-        Assert.Equal(new[] { 1, 2, 3 }, list2);
-        Assert.Equal(new[] { 1, 2, 3 }, list3);
+        ScenarioExpect.Equal(1, callCount);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, list1);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, list2);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, list3);
     }
 
+    [Scenario("Flow Chained Operations")]
     [Fact]
     public void Flow_Chained_Operations()
     {
@@ -315,7 +340,7 @@ public sealed class FlowBuilderTests
             .Filter(x => x < 50)        // 4, 16, 36
             .ToList();
 
-        Assert.Equal(new[] { 4, 16, 36 }, result);
+        ScenarioExpect.Equal(new[] { 4, 16, 36 }, result);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Iterator/ReplayableSequenceTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Iterator/ReplayableSequenceTests.cs
@@ -191,15 +191,17 @@ public sealed class ReplayableSequenceTests(ITestOutputHelper output) : TinyBddX
 
 public sealed class ReplayableSequenceBuilderTests
 {
+    [Scenario("Lookahead NegativeOffset Throws")]
     [Fact]
     public void Lookahead_NegativeOffset_Throws()
     {
         var seq = ReplayableSequence<int>.From(Enumerable.Range(1, 5));
         var cursor = seq.GetCursor();
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => cursor.Lookahead(-1));
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => cursor.Lookahead(-1));
     }
 
+    [Scenario("Lookahead BeyondSequence ReturnsNone")]
     [Fact]
     public void Lookahead_BeyondSequence_ReturnsNone()
     {
@@ -208,9 +210,10 @@ public sealed class ReplayableSequenceBuilderTests
 
         var option = cursor.Lookahead(10); // way beyond end
 
-        Assert.False(option.HasValue);
+        ScenarioExpect.False(option.HasValue);
     }
 
+    [Scenario("Peek EmptySequence ReturnsFalse")]
     [Fact]
     public void Peek_EmptySequence_ReturnsFalse()
     {
@@ -219,10 +222,11 @@ public sealed class ReplayableSequenceBuilderTests
 
         var found = cursor.Peek(out var value);
 
-        Assert.False(found);
-        Assert.Equal(default, value);
+        ScenarioExpect.False(found);
+        ScenarioExpect.Equal(default, value);
     }
 
+    [Scenario("TryNext EmptySequence ReturnsFalse")]
     [Fact]
     public void TryNext_EmptySequence_ReturnsFalse()
     {
@@ -231,11 +235,12 @@ public sealed class ReplayableSequenceBuilderTests
 
         var found = cursor.TryNext(out var value, out var next);
 
-        Assert.False(found);
-        Assert.Equal(default, value);
-        Assert.Equal(0, next.Position);
+        ScenarioExpect.False(found);
+        ScenarioExpect.Equal(default, value);
+        ScenarioExpect.Equal(0, next.Position);
     }
 
+    [Scenario("AsEnumerable FromNonZeroPosition")]
     [Fact]
     public void AsEnumerable_FromNonZeroPosition()
     {
@@ -246,9 +251,10 @@ public sealed class ReplayableSequenceBuilderTests
 
         var remaining = cursor.AsEnumerable().ToList();
 
-        Assert.Equal(new[] { 3, 4, 5 }, remaining);
+        ScenarioExpect.Equal(new[] { 3, 4, 5 }, remaining);
     }
 
+    [Scenario("Fork PreservesPosition")]
     [Fact]
     public void Fork_PreservesPosition()
     {
@@ -259,28 +265,31 @@ public sealed class ReplayableSequenceBuilderTests
 
         var fork = cursor.Fork();
 
-        Assert.Equal(cursor.Position, fork.Position);
-        Assert.Equal(2, fork.Position);
+        ScenarioExpect.Equal(cursor.Position, fork.Position);
+        ScenarioExpect.Equal(2, fork.Position);
     }
 
+    [Scenario("Batch ZeroSize Throws")]
     [Fact]
     public void Batch_ZeroSize_Throws()
     {
         var seq = ReplayableSequence<int>.From(Enumerable.Range(1, 5));
         var cursor = seq.GetCursor();
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => cursor.Batch(0).ToList());
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => cursor.Batch(0).ToList());
     }
 
+    [Scenario("Batch NegativeSize Throws")]
     [Fact]
     public void Batch_NegativeSize_Throws()
     {
         var seq = ReplayableSequence<int>.From(Enumerable.Range(1, 5));
         var cursor = seq.GetCursor();
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => cursor.Batch(-1).ToList());
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => cursor.Batch(-1).ToList());
     }
 
+    [Scenario("Batch EmptySequence YieldsNothing")]
     [Fact]
     public void Batch_EmptySequence_YieldsNothing()
     {
@@ -289,9 +298,10 @@ public sealed class ReplayableSequenceBuilderTests
 
         var batches = cursor.Batch(3).ToList();
 
-        Assert.Empty(batches);
+        ScenarioExpect.Empty(batches);
     }
 
+    [Scenario("Batch ExactMultiple NoPartial")]
     [Fact]
     public void Batch_ExactMultiple_NoPartial()
     {
@@ -300,11 +310,12 @@ public sealed class ReplayableSequenceBuilderTests
 
         var batches = cursor.Batch(3).ToList();
 
-        Assert.Equal(2, batches.Count);
-        Assert.Equal(new[] { 1, 2, 3 }, batches[0]);
-        Assert.Equal(new[] { 4, 5, 6 }, batches[1]);
+        ScenarioExpect.Equal(2, batches.Count);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, batches[0]);
+        ScenarioExpect.Equal(new[] { 4, 5, 6 }, batches[1]);
     }
 
+    [Scenario("ConcurrentCursors ShareBuffer")]
     [Fact]
     public void ConcurrentCursors_ShareBuffer()
     {
@@ -324,11 +335,12 @@ public sealed class ReplayableSequenceBuilderTests
 
         foreach (var result in results)
         {
-            Assert.Equal(100, result.Count);
-            Assert.Equal(Enumerable.Range(1, 100), result);
+            ScenarioExpect.Equal(100, result.Count);
+            ScenarioExpect.Equal(Enumerable.Range(1, 100), result);
         }
     }
 
+    [Scenario("MultipleForks IndependentPositions")]
     [Fact]
     public void MultipleForks_IndependentPositions()
     {
@@ -347,12 +359,13 @@ public sealed class ReplayableSequenceBuilderTests
         c2.TryNext(out _, out c2);
         c2.TryNext(out _, out c2);
 
-        Assert.Equal(2, c1.Position);
-        Assert.Equal(5, c2.Position);
-        Assert.Equal(2, c3.Position);
+        ScenarioExpect.Equal(2, c1.Position);
+        ScenarioExpect.Equal(5, c2.Position);
+        ScenarioExpect.Equal(2, c3.Position);
     }
 
 #if !NETSTANDARD2_0
+    [Scenario("AsAsyncEnumerable YieldsAllElements")]
     [Fact]
     public async Task AsAsyncEnumerable_YieldsAllElements()
     {
@@ -362,9 +375,10 @@ public sealed class ReplayableSequenceBuilderTests
         await foreach (var v in seq.AsAsyncEnumerable())
             list.Add(v);
 
-        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, list);
+        ScenarioExpect.Equal(new[] { 1, 2, 3, 4, 5 }, list);
     }
 
+    [Scenario("AsAsyncEnumerable RespectsToken")]
     [Fact]
     public async Task AsAsyncEnumerable_RespectsToken()
     {
@@ -372,7 +386,7 @@ public sealed class ReplayableSequenceBuilderTests
         using var cts = new CancellationTokenSource();
         var list = new List<int>();
 
-        var ex = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        var ex = await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
         {
             await foreach (var v in seq.AsAsyncEnumerable(cts.Token))
             {
@@ -381,7 +395,7 @@ public sealed class ReplayableSequenceBuilderTests
             }
         });
 
-        Assert.Equal(5, list.Count);
+        ScenarioExpect.Equal(5, list.Count);
     }
 #endif
 }

--- a/test/PatternKit.Tests/Behavioral/Iterator/WindowSequenceTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Iterator/WindowSequenceTests.cs
@@ -75,38 +75,43 @@ public sealed class WindowSequenceTests(ITestOutputHelper output) : TinyBddXunit
 
 public sealed class WindowSequenceBuilderTests
 {
+    [Scenario("Windows NullSource Throws")]
     [Fact]
     public void Windows_NullSource_Throws()
     {
         IEnumerable<int>? source = null;
 
-        Assert.Throws<ArgumentNullException>(() => source!.Windows(3).ToList());
+        ScenarioExpect.Throws<ArgumentNullException>(() => source!.Windows(3).ToList());
     }
 
+    [Scenario("Windows NegativeSize Throws")]
     [Fact]
     public void Windows_NegativeSize_Throws()
     {
         var source = Enumerable.Range(1, 10);
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => source.Windows(-1).ToList());
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => source.Windows(-1).ToList());
     }
 
+    [Scenario("Windows ZeroStride Throws")]
     [Fact]
     public void Windows_ZeroStride_Throws()
     {
         var source = Enumerable.Range(1, 10);
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => source.Windows(3, stride: 0).ToList());
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => source.Windows(3, stride: 0).ToList());
     }
 
+    [Scenario("Windows NegativeStride Throws")]
     [Fact]
     public void Windows_NegativeStride_Throws()
     {
         var source = Enumerable.Range(1, 10);
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => source.Windows(3, stride: -1).ToList());
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => source.Windows(3, stride: -1).ToList());
     }
 
+    [Scenario("Windows EmptySource YieldsNothing")]
     [Fact]
     public void Windows_EmptySource_YieldsNothing()
     {
@@ -114,9 +119,10 @@ public sealed class WindowSequenceBuilderTests
 
         var windows = source.Windows(3).ToList();
 
-        Assert.Empty(windows);
+        ScenarioExpect.Empty(windows);
     }
 
+    [Scenario("Windows SourceSmallerThanSize NoWindows")]
     [Fact]
     public void Windows_SourceSmallerThanSize_NoWindows()
     {
@@ -124,9 +130,10 @@ public sealed class WindowSequenceBuilderTests
 
         var windows = source.Windows(5).ToList();
 
-        Assert.Empty(windows);
+        ScenarioExpect.Empty(windows);
     }
 
+    [Scenario("Windows SourceSmallerThanSize WithPartial YieldsPartial")]
     [Fact]
     public void Windows_SourceSmallerThanSize_WithPartial_YieldsPartial()
     {
@@ -134,11 +141,12 @@ public sealed class WindowSequenceBuilderTests
 
         var windows = source.Windows(5, includePartial: true).ToList();
 
-        Assert.Single(windows);
-        Assert.True(windows[0].IsPartial);
-        Assert.Equal(2, windows[0].Count);
+        ScenarioExpect.Single(windows);
+        ScenarioExpect.True(windows[0].IsPartial);
+        ScenarioExpect.Equal(2, windows[0].Count);
     }
 
+    [Scenario("Windows ExactSize SingleWindow")]
     [Fact]
     public void Windows_ExactSize_SingleWindow()
     {
@@ -146,30 +154,33 @@ public sealed class WindowSequenceBuilderTests
 
         var windows = source.Windows(3).ToList();
 
-        Assert.Single(windows);
-        Assert.Equal(new[] { 1, 2, 3 }, windows[0].ToArray());
-        Assert.False(windows[0].IsPartial);
+        ScenarioExpect.Single(windows);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, windows[0].ToArray());
+        ScenarioExpect.False(windows[0].IsPartial);
     }
 
+    [Scenario("Window Indexer ValidIndex")]
     [Fact]
     public void Window_Indexer_ValidIndex()
     {
         var window = Enumerable.Range(1, 5).Windows(3).First();
 
-        Assert.Equal(1, window[0]);
-        Assert.Equal(2, window[1]);
-        Assert.Equal(3, window[2]);
+        ScenarioExpect.Equal(1, window[0]);
+        ScenarioExpect.Equal(2, window[1]);
+        ScenarioExpect.Equal(3, window[2]);
     }
 
+    [Scenario("Window Indexer InvalidIndex Throws")]
     [Fact]
     public void Window_Indexer_InvalidIndex_Throws()
     {
         var window = Enumerable.Range(1, 5).Windows(3).First();
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => window[3]);
-        Assert.Throws<ArgumentOutOfRangeException>(() => window[-1]);
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => _ = window[3]);
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => _ = window[-1]);
     }
 
+    [Scenario("Window GetEnumerator Works")]
     [Fact]
     public void Window_GetEnumerator_Works()
     {
@@ -179,9 +190,10 @@ public sealed class WindowSequenceBuilderTests
         foreach (var item in window)
             list.Add(item);
 
-        Assert.Equal(new[] { 1, 2, 3 }, list);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, list);
     }
 
+    [Scenario("Windows LargeStride SkipsElements")]
     [Fact]
     public void Windows_LargeStride_SkipsElements()
     {
@@ -193,10 +205,11 @@ public sealed class WindowSequenceBuilderTests
         // [1,2] at pos 0, [5,6] at pos 4, [9,10] at pos 8 - only 3 windows fit
         var windows = source.Windows(2, stride: 4).ToList();
 
-        Assert.True(windows.Count >= 2); // At least 2 windows
-        Assert.Equal(new[] { 1, 2 }, windows[0].ToArray());
+        ScenarioExpect.True(windows.Count >= 2); // At least 2 windows
+        ScenarioExpect.Equal(new[] { 1, 2 }, windows[0].ToArray());
     }
 
+    [Scenario("Windows StrideGreaterThanSize NoOverlap")]
     [Fact]
     public void Windows_StrideGreaterThanSize_NoOverlap()
     {
@@ -211,12 +224,13 @@ public sealed class WindowSequenceBuilderTests
         // Window 4: [7,8]
         var windows = source.Windows(2, stride: 3).ToList();
 
-        Assert.True(windows.Count >= 2);
-        Assert.Equal(new[] { 1, 2 }, windows[0].ToArray());
+        ScenarioExpect.True(windows.Count >= 2);
+        ScenarioExpect.Equal(new[] { 1, 2 }, windows[0].ToArray());
         // Second window depends on stride implementation
-        Assert.Equal(2, windows[1].Count);
+        ScenarioExpect.Equal(2, windows[1].Count);
     }
 
+    [Scenario("Windows ReuseBuffer SameArrayReused")]
     [Fact]
     public void Windows_ReuseBuffer_SameArrayReused()
     {
@@ -224,18 +238,20 @@ public sealed class WindowSequenceBuilderTests
         var windows = source.Windows(3, stride: 1, reuseBuffer: true).ToList();
 
         // All windows should have IsBufferReused = true
-        Assert.All(windows, w => Assert.True(w.IsBufferReused));
+        ScenarioExpect.All(windows, w => ScenarioExpect.True(w.IsBufferReused));
     }
 
+    [Scenario("Windows NoReuseBuffer FreshArrays")]
     [Fact]
     public void Windows_NoReuseBuffer_FreshArrays()
     {
         var source = Enumerable.Range(1, 6);
         var windows = source.Windows(3, stride: 1, reuseBuffer: false).ToList();
 
-        Assert.All(windows, w => Assert.False(w.IsBufferReused));
+        ScenarioExpect.All(windows, w => ScenarioExpect.False(w.IsBufferReused));
     }
 
+    [Scenario("Window ToArray CreatesCopy")]
     [Fact]
     public void Window_ToArray_CreatesCopy()
     {
@@ -250,30 +266,33 @@ public sealed class WindowSequenceBuilderTests
         var copy2 = allWindows[1].ToArray();
 
         // ToArray should create distinct arrays
-        Assert.NotSame(copy1, copy2);
-        Assert.Equal(new[] { 1, 2, 3 }, copy1);
-        Assert.Equal(new[] { 2, 3, 4 }, copy2);
+        ScenarioExpect.NotSame(copy1, copy2);
+        ScenarioExpect.Equal(new[] { 1, 2, 3 }, copy1);
+        ScenarioExpect.Equal(new[] { 2, 3, 4 }, copy2);
     }
 
+    [Scenario("Windows PartialWindow IsNotBufferReused")]
     [Fact]
     public void Windows_PartialWindow_IsNotBufferReused()
     {
         var source = Enumerable.Range(1, 4);
         var windows = source.Windows(3, stride: 2, includePartial: true, reuseBuffer: true).ToList();
 
-        Assert.Equal(2, windows.Count);
-        Assert.True(windows[0].IsBufferReused);    // full window
-        Assert.False(windows[1].IsBufferReused);   // partial window always gets fresh array
+        ScenarioExpect.Equal(2, windows.Count);
+        ScenarioExpect.True(windows[0].IsBufferReused);    // full window
+        ScenarioExpect.False(windows[1].IsBufferReused);   // partial window always gets fresh array
     }
 
+    [Scenario("Windows Count Property")]
     [Fact]
     public void Windows_Count_Property()
     {
         var window = Enumerable.Range(1, 10).Windows(4).First();
 
-        Assert.Equal(4, window.Count);
+        ScenarioExpect.Equal(4, window.Count);
     }
 
+    [Scenario("Windows IsPartial Property")]
     [Fact]
     public void Windows_IsPartial_Property()
     {
@@ -283,13 +302,13 @@ public sealed class WindowSequenceBuilderTests
         // Window 3: [5] at pos 4 (partial - only 1 element left)
         var windows = Enumerable.Range(1, 5).Windows(3, stride: 2, includePartial: true).ToList();
 
-        Assert.True(windows.Count >= 2);
-        Assert.False(windows[0].IsPartial);  // 1,2,3 - full
+        ScenarioExpect.True(windows.Count >= 2);
+        ScenarioExpect.False(windows[0].IsPartial);  // 1,2,3 - full
 
         // The last window should be partial if there are any remaining elements
         var lastWindow = windows[^1];
         if (windows.Count > 2)
-            Assert.True(lastWindow.IsPartial);
+            ScenarioExpect.True(lastWindow.IsPartial);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Mediator/MediatorTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Mediator/MediatorTests.cs
@@ -115,15 +115,17 @@ public sealed class MediatorBuilderTests
     private sealed record Pong(string Value);
     private sealed record Alert(string Message);
 
+    [Scenario("Send NoHandler Throws")]
     [Fact]
     public async Task Send_NoHandler_Throws()
     {
         var m = PatternKit.Behavioral.Mediator.Mediator.Create().Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => m.Send<Ping, Pong>(new Ping(1)).AsTask());
     }
 
+    [Scenario("Send NullResult ReturnsDefault")]
     [Fact]
     public async Task Send_NullResult_ReturnsDefault()
     {
@@ -132,9 +134,10 @@ public sealed class MediatorBuilderTests
             .Build();
 
         var result = await m.Send<Ping, Pong>(new Ping(1));
-        Assert.Null(result);
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("Publish NoHandlers NoOp")]
     [Fact]
     public async Task Publish_NoHandlers_NoOp()
     {
@@ -144,6 +147,7 @@ public sealed class MediatorBuilderTests
         await m.Publish(new Alert("test"));
     }
 
+    [Scenario("Publish SingleHandler Executes")]
     [Fact]
     public async Task Publish_SingleHandler_Executes()
     {
@@ -154,10 +158,11 @@ public sealed class MediatorBuilderTests
 
         await m.Publish(new Alert("hello"));
 
-        Assert.Single(received);
-        Assert.Equal("hello", received[0]);
+        ScenarioExpect.Single(received);
+        ScenarioExpect.Equal("hello", received[0]);
     }
 
+    [Scenario("Publish MultipleHandlers AllExecute")]
     [Fact]
     public async Task Publish_MultipleHandlers_AllExecute()
     {
@@ -170,12 +175,13 @@ public sealed class MediatorBuilderTests
 
         await m.Publish(new Alert("test"));
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("h1:test", log[0]);
-        Assert.Equal("h2:test", log[1]);
-        Assert.Equal("h3:test", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("h1:test", log[0]);
+        ScenarioExpect.Equal("h2:test", log[1]);
+        ScenarioExpect.Equal("h3:test", log[2]);
     }
 
+    [Scenario("Pre Behavior Runs Before Handler")]
     [Fact]
     public async Task Pre_Behavior_Runs_Before_Handler()
     {
@@ -187,9 +193,10 @@ public sealed class MediatorBuilderTests
 
         await m.Send<Ping, Pong>(new Ping(1));
 
-        Assert.Equal(new[] { "pre", "handler" }, log);
+        ScenarioExpect.Equal(new[] { "pre", "handler" }, log);
     }
 
+    [Scenario("Post Behavior Runs After Handler")]
     [Fact]
     public async Task Post_Behavior_Runs_After_Handler()
     {
@@ -201,9 +208,10 @@ public sealed class MediatorBuilderTests
 
         await m.Send<Ping, Pong>(new Ping(1));
 
-        Assert.Equal(new[] { "handler", "post" }, log);
+        ScenarioExpect.Equal(new[] { "handler", "post" }, log);
     }
 
+    [Scenario("Multiple Pre And Post Behaviors")]
     [Fact]
     public async Task Multiple_Pre_And_Post_Behaviors()
     {
@@ -218,9 +226,10 @@ public sealed class MediatorBuilderTests
 
         await m.Send<Ping, Pong>(new Ping(1));
 
-        Assert.Equal(new[] { "pre1", "pre2", "handler", "post1", "post2" }, log);
+        ScenarioExpect.Equal(new[] { "pre1", "pre2", "handler", "post1", "post2" }, log);
     }
 
+    [Scenario("Whole Behavior Wraps Handler")]
     [Fact]
     public async Task Whole_Behavior_Wraps_Handler()
     {
@@ -238,9 +247,10 @@ public sealed class MediatorBuilderTests
 
         await m.Send<Ping, Pong>(new Ping(1));
 
-        Assert.Equal(new[] { "whole:before", "handler", "whole:after" }, log);
+        ScenarioExpect.Equal(new[] { "whole:before", "handler", "whole:after" }, log);
     }
 
+    [Scenario("Multiple Whole Behaviors Wrap InOrder")]
     [Fact]
     public async Task Multiple_Whole_Behaviors_Wrap_InOrder()
     {
@@ -266,9 +276,10 @@ public sealed class MediatorBuilderTests
         await m.Send<Ping, Pong>(new Ping(1));
 
         // Last registered is innermost
-        Assert.Equal(new[] { "outer:before", "inner:before", "handler", "inner:after", "outer:after" }, log);
+        ScenarioExpect.Equal(new[] { "outer:before", "inner:before", "handler", "inner:after", "outer:after" }, log);
     }
 
+    [Scenario("Sync Command Handler")]
     [Fact]
     public async Task Sync_Command_Handler()
     {
@@ -278,10 +289,11 @@ public sealed class MediatorBuilderTests
 
         var result = await m.Send<Ping, Pong>(new Ping(42));
 
-        Assert.NotNull(result);
-        Assert.Equal("sync:42", result!.Value);
+        ScenarioExpect.NotNull(result);
+        ScenarioExpect.Equal("sync:42", result!.Value);
     }
 
+    [Scenario("Async Whole Behavior")]
     [Fact]
     public async Task Async_Whole_Behavior()
     {
@@ -314,9 +326,10 @@ public sealed class MediatorBuilderTests
 
         await m.Send<Ping, Pong>(new Ping(1));
 
-        Assert.Equal(new[] { "whole:before", "handler", "whole:after" }, log);
+        ScenarioExpect.Equal(new[] { "whole:before", "handler", "whole:after" }, log);
     }
 
+    [Scenario("Publish With Behaviors")]
     [Fact]
     public async Task Publish_With_Behaviors()
     {
@@ -329,21 +342,23 @@ public sealed class MediatorBuilderTests
 
         await m.Publish(new Alert("test"));
 
-        Assert.Equal(new[] { "pre", "handler:test", "post" }, log);
+        ScenarioExpect.Equal(new[] { "pre", "handler:test", "post" }, log);
     }
 
 #if NET8_0_OR_GREATER
+    [Scenario("Stream NoHandler Throws")]
     [Fact]
     public async Task Stream_NoHandler_Throws()
     {
         var m = PatternKit.Behavioral.Mediator.Mediator.Create().Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await foreach (var _ in m.Stream<Ping, int>(new Ping(1))) { }
         });
     }
 
+    [Scenario("Stream Yields All Items")]
     [Fact]
     public async Task Stream_Yields_All_Items()
     {
@@ -355,7 +370,7 @@ public sealed class MediatorBuilderTests
         await foreach (var x in m.Stream<Ping, int>(new Ping(10)))
             items.Add(x);
 
-        Assert.Equal(new[] { 10, 11, 12, 13, 14 }, items);
+        ScenarioExpect.Equal(new[] { 10, 11, 12, 13, 14 }, items);
     }
 
     private static async IAsyncEnumerable<int> RangeAsync(int start, int count)
@@ -367,6 +382,7 @@ public sealed class MediatorBuilderTests
         }
     }
 
+    [Scenario("Stream PrePost Behaviors")]
     [Fact]
     public async Task Stream_PrePost_Behaviors()
     {
@@ -379,10 +395,11 @@ public sealed class MediatorBuilderTests
 
         await foreach (var _ in m.Stream<Ping, int>(new Ping(1))) { }
 
-        Assert.Contains("pre", log);
-        Assert.Contains("post", log);
+        ScenarioExpect.Contains("pre", log);
+        ScenarioExpect.Contains("post", log);
     }
 
+    [Scenario("Stream With Whole Behavior")]
     [Fact]
     public async Task Stream_With_Whole_Behavior()
     {
@@ -398,7 +415,7 @@ public sealed class MediatorBuilderTests
 
         await foreach (var _ in m.Stream<Ping, int>(new Ping(1))) { }
 
-        Assert.Contains("whole", log);
+        ScenarioExpect.Contains("whole", log);
     }
 #endif
 }
@@ -409,6 +426,7 @@ public sealed class MediatorBuilderTests
 
 public sealed class TaskExtensionsTests
 {
+    [Scenario("AsValueTask CompletedTask ReturnsValueTask")]
     [Fact]
     public async Task AsValueTask_CompletedTask_ReturnsValueTask()
     {
@@ -416,10 +434,11 @@ public sealed class TaskExtensionsTests
 
         var valueTask = PatternKit.Behavioral.Mediator.TaskExtensions.AsValueTask(task);
 
-        Assert.True(valueTask.IsCompletedSuccessfully);
-        Assert.Equal(42, await valueTask);
+        ScenarioExpect.True(valueTask.IsCompletedSuccessfully);
+        ScenarioExpect.Equal(42, await valueTask);
     }
 
+    [Scenario("AsValueTask PendingTask ReturnsValueTask")]
     [Fact]
     public async Task AsValueTask_PendingTask_ReturnsValueTask()
     {
@@ -431,9 +450,10 @@ public sealed class TaskExtensionsTests
 
         var valueTask = PatternKit.Behavioral.Mediator.TaskExtensions.AsValueTask(task);
 
-        Assert.Equal("result", await valueTask);
+        ScenarioExpect.Equal("result", await valueTask);
     }
 
+    [Scenario("AsValueTask FaultedTask PropagatesException")]
     [Fact]
     public async Task AsValueTask_FaultedTask_PropagatesException()
     {
@@ -441,13 +461,14 @@ public sealed class TaskExtensionsTests
 
         var valueTask = PatternKit.Behavioral.Mediator.TaskExtensions.AsValueTask(task);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => valueTask.AsTask());
-        Assert.Equal("test error", ex.Message);
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() => valueTask.AsTask());
+        ScenarioExpect.Equal("test error", ex.Message);
     }
 }
 
 public sealed class MediatorHelpersTests
 {
+    [Scenario("Box CompletedSuccessfully ReturnsBoxedValue")]
     [Fact]
     public async Task Box_CompletedSuccessfully_ReturnsBoxedValue()
     {
@@ -455,11 +476,12 @@ public sealed class MediatorHelpersTests
 
         var boxed = PatternKit.Behavioral.Mediator.MediatorHelpers.Box(valueTask);
 
-        Assert.True(boxed.IsCompletedSuccessfully);
+        ScenarioExpect.True(boxed.IsCompletedSuccessfully);
         var result = await boxed;
-        Assert.Equal(42, result);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("Box PendingTask AwaitsAndReturns")]
     [Fact]
     public async Task Box_PendingTask_AwaitsAndReturns()
     {
@@ -468,13 +490,14 @@ public sealed class MediatorHelpersTests
 
         var boxed = PatternKit.Behavioral.Mediator.MediatorHelpers.Box(valueTask);
 
-        Assert.False(boxed.IsCompleted);
+        ScenarioExpect.False(boxed.IsCompleted);
         source.SetResult("async result");
 
         var result = await boxed;
-        Assert.Equal("async result", result);
+        ScenarioExpect.Equal("async result", result);
     }
 
+    [Scenario("Box NullResult ReturnsNull")]
     [Fact]
     public async Task Box_NullResult_ReturnsNull()
     {
@@ -483,9 +506,10 @@ public sealed class MediatorHelpersTests
         var boxed = PatternKit.Behavioral.Mediator.MediatorHelpers.Box(valueTask);
 
         var result = await boxed;
-        Assert.Null(result);
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("Box ReferenceType BoxesCorrectly")]
     [Fact]
     public async Task Box_ReferenceType_BoxesCorrectly()
     {
@@ -495,9 +519,10 @@ public sealed class MediatorHelpersTests
         var boxed = PatternKit.Behavioral.Mediator.MediatorHelpers.Box(valueTask);
 
         var result = await boxed;
-        Assert.Same(obj, result);
+        ScenarioExpect.Same(obj, result);
     }
 
+    [Scenario("Box AsyncPath BoxesCorrectly")]
     [Fact]
     public async Task Box_AsyncPath_BoxesCorrectly()
     {
@@ -510,7 +535,7 @@ public sealed class MediatorHelpersTests
         var boxed = PatternKit.Behavioral.Mediator.MediatorHelpers.Box(valueTask);
 
         var result = await boxed;
-        Assert.Equal(123, result);
+        ScenarioExpect.Equal(123, result);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Memento/MementoTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Memento/MementoTests.cs
@@ -177,22 +177,25 @@ public sealed class MementoTests(ITestOutputHelper output) : TinyBddXunitBase(ou
 
 public sealed class MementoBuilderTests
 {
+    [Scenario("CanUndo Empty ReturnsFalse")]
     [Fact]
     public void CanUndo_Empty_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
-        Assert.False(h.CanUndo);
+        ScenarioExpect.False(h.CanUndo);
     }
 
+    [Scenario("CanUndo SingleSnapshot ReturnsFalse")]
     [Fact]
     public void CanUndo_SingleSnapshot_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
         var s = 1;
         h.Save(in s);
-        Assert.False(h.CanUndo);
+        ScenarioExpect.False(h.CanUndo);
     }
 
+    [Scenario("CanUndo MultipleSnapshots ReturnsTrue")]
     [Fact]
     public void CanUndo_MultipleSnapshots_ReturnsTrue()
     {
@@ -201,25 +204,28 @@ public sealed class MementoBuilderTests
         h.Save(in s);
         s = 2;
         h.Save(in s);
-        Assert.True(h.CanUndo);
+        ScenarioExpect.True(h.CanUndo);
     }
 
+    [Scenario("CanRedo Empty ReturnsFalse")]
     [Fact]
     public void CanRedo_Empty_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
-        Assert.False(h.CanRedo);
+        ScenarioExpect.False(h.CanRedo);
     }
 
+    [Scenario("CanRedo AtEnd ReturnsFalse")]
     [Fact]
     public void CanRedo_AtEnd_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
         var s = 1;
         h.Save(in s);
-        Assert.False(h.CanRedo);
+        ScenarioExpect.False(h.CanRedo);
     }
 
+    [Scenario("CanRedo AfterUndo ReturnsTrue")]
     [Fact]
     public void CanRedo_AfterUndo_ReturnsTrue()
     {
@@ -229,19 +235,21 @@ public sealed class MementoBuilderTests
         s = 2;
         h.Save(in s);
         h.Undo(ref s);
-        Assert.True(h.CanRedo);
+        ScenarioExpect.True(h.CanRedo);
     }
 
+    [Scenario("Undo Empty ReturnsFalse")]
     [Fact]
     public void Undo_Empty_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
         var s = 42;
         var result = h.Undo(ref s);
-        Assert.False(result);
-        Assert.Equal(42, s);
+        ScenarioExpect.False(result);
+        ScenarioExpect.Equal(42, s);
     }
 
+    [Scenario("Undo SingleSnapshot ReturnsFalse")]
     [Fact]
     public void Undo_SingleSnapshot_ReturnsFalse()
     {
@@ -249,19 +257,21 @@ public sealed class MementoBuilderTests
         var s = 1;
         h.Save(in s);
         var result = h.Undo(ref s);
-        Assert.False(result);
+        ScenarioExpect.False(result);
     }
 
+    [Scenario("Redo Empty ReturnsFalse")]
     [Fact]
     public void Redo_Empty_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
         var s = 42;
         var result = h.Redo(ref s);
-        Assert.False(result);
-        Assert.Equal(42, s);
+        ScenarioExpect.False(result);
+        ScenarioExpect.Equal(42, s);
     }
 
+    [Scenario("Redo AtEnd ReturnsFalse")]
     [Fact]
     public void Redo_AtEnd_ReturnsFalse()
     {
@@ -269,18 +279,20 @@ public sealed class MementoBuilderTests
         var s = 1;
         h.Save(in s);
         var result = h.Redo(ref s);
-        Assert.False(result);
+        ScenarioExpect.False(result);
     }
 
+    [Scenario("TryGetCurrent Empty ReturnsFalse")]
     [Fact]
     public void TryGetCurrent_Empty_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
         var result = h.TryGetCurrent(out var snapshot);
-        Assert.False(result);
-        Assert.Equal(default, snapshot);
+        ScenarioExpect.False(result);
+        ScenarioExpect.Equal(default, snapshot);
     }
 
+    [Scenario("TryGetCurrent WithSnapshot ReturnsTrue")]
     [Fact]
     public void TryGetCurrent_WithSnapshot_ReturnsTrue()
     {
@@ -288,42 +300,47 @@ public sealed class MementoBuilderTests
         var s = 42;
         h.Save(in s, tag: "test");
         var result = h.TryGetCurrent(out var snapshot);
-        Assert.True(result);
-        Assert.Equal(42, snapshot.State);
-        Assert.Equal("test", snapshot.Tag);
+        ScenarioExpect.True(result);
+        ScenarioExpect.Equal(42, snapshot.State);
+        ScenarioExpect.Equal("test", snapshot.Tag);
     }
 
+    [Scenario("CurrentVersion Empty ReturnsZero")]
     [Fact]
     public void CurrentVersion_Empty_ReturnsZero()
     {
         var h = Memento<int>.Create().Build();
-        Assert.Equal(0, h.CurrentVersion);
+        ScenarioExpect.Equal(0, h.CurrentVersion);
     }
 
+    [Scenario("Count Empty ReturnsZero")]
     [Fact]
     public void Count_Empty_ReturnsZero()
     {
         var h = Memento<int>.Create().Build();
-        Assert.Equal(0, h.Count);
+        ScenarioExpect.Equal(0, h.Count);
     }
 
+    [Scenario("Capacity NegativeValue Throws")]
     [Fact]
     public void Capacity_NegativeValue_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() =>
             Memento<int>.Create().Capacity(-1));
     }
 
+    [Scenario("Restore EmptyHistory ReturnsFalse")]
     [Fact]
     public void Restore_EmptyHistory_ReturnsFalse()
     {
         var h = Memento<int>.Create().Build();
         var s = 42;
         var result = h.Restore(1, ref s);
-        Assert.False(result);
-        Assert.Equal(42, s);
+        ScenarioExpect.False(result);
+        ScenarioExpect.Equal(42, s);
     }
 
+    [Scenario("History ReturnsImmutableCopy")]
     [Fact]
     public void History_ReturnsImmutableCopy()
     {
@@ -336,11 +353,12 @@ public sealed class MementoBuilderTests
         var history1 = h.History;
         var history2 = h.History;
 
-        Assert.NotSame(history1, history2);
-        Assert.Equal(2, history1.Count);
-        Assert.Equal(2, history2.Count);
+        ScenarioExpect.NotSame(history1, history2);
+        ScenarioExpect.Equal(2, history1.Count);
+        ScenarioExpect.Equal(2, history2.Count);
     }
 
+    [Scenario("ApplyWith CustomApplier")]
     [Fact]
     public void ApplyWith_CustomApplier()
     {
@@ -359,10 +377,11 @@ public sealed class MementoBuilderTests
         h.Save(in s);
         h.Undo(ref s);
 
-        Assert.Contains("apply:1", log);
-        Assert.Equal(1, s);
+        ScenarioExpect.Contains("apply:1", log);
+        ScenarioExpect.Equal(1, s);
     }
 
+    [Scenario("DefaultCloner ShallowCopies")]
     [Fact]
     public void DefaultCloner_ShallowCopies()
     {
@@ -371,9 +390,10 @@ public sealed class MementoBuilderTests
         var s = 42;
         h.Save(in s);
         h.TryGetCurrent(out var snap);
-        Assert.Equal(42, snap.State);
+        ScenarioExpect.Equal(42, snap.State);
     }
 
+    [Scenario("Snapshot HasTag Property")]
     [Fact]
     public void Snapshot_HasTag_Property()
     {
@@ -384,10 +404,11 @@ public sealed class MementoBuilderTests
         h.Save(in s); // no tag
 
         var history = h.History;
-        Assert.True(history[0].HasTag);
-        Assert.False(history[1].HasTag);
+        ScenarioExpect.True(history[0].HasTag);
+        ScenarioExpect.False(history[1].HasTag);
     }
 
+    [Scenario("Snapshot TimestampUtc IsSet")]
     [Fact]
     public void Snapshot_TimestampUtc_IsSet()
     {
@@ -398,10 +419,11 @@ public sealed class MementoBuilderTests
         var after = DateTime.UtcNow;
 
         h.TryGetCurrent(out var snap);
-        Assert.True(snap.TimestampUtc >= before);
-        Assert.True(snap.TimestampUtc <= after);
+        ScenarioExpect.True(snap.TimestampUtc >= before);
+        ScenarioExpect.True(snap.TimestampUtc <= after);
     }
 
+    [Scenario("MultipleUndo ReturnsToFirstState")]
     [Fact]
     public void MultipleUndo_ReturnsToFirstState()
     {
@@ -415,16 +437,17 @@ public sealed class MementoBuilderTests
         s = 3;
         h.Save(in s); // v4
 
-        Assert.True(h.Undo(ref s));
-        Assert.Equal(2, s);
-        Assert.True(h.Undo(ref s));
-        Assert.Equal(1, s);
-        Assert.True(h.Undo(ref s));
-        Assert.Equal(0, s);
-        Assert.False(h.Undo(ref s));
-        Assert.Equal(0, s);
+        ScenarioExpect.True(h.Undo(ref s));
+        ScenarioExpect.Equal(2, s);
+        ScenarioExpect.True(h.Undo(ref s));
+        ScenarioExpect.Equal(1, s);
+        ScenarioExpect.True(h.Undo(ref s));
+        ScenarioExpect.Equal(0, s);
+        ScenarioExpect.False(h.Undo(ref s));
+        ScenarioExpect.Equal(0, s);
     }
 
+    [Scenario("MultipleRedo ReturnsToLastState")]
     [Fact]
     public void MultipleRedo_ReturnsToLastState()
     {
@@ -439,13 +462,14 @@ public sealed class MementoBuilderTests
         h.Undo(ref s);
         h.Undo(ref s);
 
-        Assert.True(h.Redo(ref s));
-        Assert.Equal(1, s);
-        Assert.True(h.Redo(ref s));
-        Assert.Equal(2, s);
-        Assert.False(h.Redo(ref s));
+        ScenarioExpect.True(h.Redo(ref s));
+        ScenarioExpect.Equal(1, s);
+        ScenarioExpect.True(h.Redo(ref s));
+        ScenarioExpect.Equal(2, s);
+        ScenarioExpect.False(h.Redo(ref s));
     }
 
+    [Scenario("SaveAfterUndo TruncatesForwardHistory")]
     [Fact]
     public void SaveAfterUndo_TruncatesForwardHistory()
     {
@@ -458,13 +482,13 @@ public sealed class MementoBuilderTests
         h.Save(in s); // v3
 
         h.Undo(ref s); // cursor at v2
-        Assert.Equal(1, s);
+        ScenarioExpect.Equal(1, s);
 
         s = 10;
         h.Save(in s); // v4, should truncate v3
 
-        Assert.Equal(3, h.Count);
-        Assert.False(h.CanRedo);
+        ScenarioExpect.Equal(3, h.Count);
+        ScenarioExpect.False(h.CanRedo);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Observer/AsyncObserverTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Observer/AsyncObserverTests.cs
@@ -220,42 +220,45 @@ public sealed class AsyncObserverEdgeCaseTests
 {
     private readonly record struct Evt(int Id);
 
+    [Scenario("SubscriberCount ReflectsSubscriptions")]
     [Fact]
     public void SubscriberCount_ReflectsSubscriptions()
     {
         var observer = AsyncObserver<Evt>.Create().Build();
 
-        Assert.Equal(0, observer.SubscriberCount);
+        ScenarioExpect.Equal(0, observer.SubscriberCount);
 
         var sub1 = observer.Subscribe(_ => default);
-        Assert.Equal(1, observer.SubscriberCount);
+        ScenarioExpect.Equal(1, observer.SubscriberCount);
 
         var sub2 = observer.Subscribe(_ => default);
-        Assert.Equal(2, observer.SubscriberCount);
+        ScenarioExpect.Equal(2, observer.SubscriberCount);
 
         sub1.Dispose();
-        Assert.Equal(1, observer.SubscriberCount);
+        ScenarioExpect.Equal(1, observer.SubscriberCount);
 
         sub2.Dispose();
-        Assert.Equal(0, observer.SubscriberCount);
+        ScenarioExpect.Equal(0, observer.SubscriberCount);
     }
 
+    [Scenario("DoubleDispose IsHarmless")]
     [Fact]
     public void DoubleDispose_IsHarmless()
     {
         var observer = AsyncObserver<Evt>.Create().Build();
         var sub = observer.Subscribe(_ => default);
 
-        Assert.Equal(1, observer.SubscriberCount);
+        ScenarioExpect.Equal(1, observer.SubscriberCount);
 
         sub.Dispose();
-        Assert.Equal(0, observer.SubscriberCount);
+        ScenarioExpect.Equal(0, observer.SubscriberCount);
 
         // Second dispose should not throw or cause issues
         sub.Dispose();
-        Assert.Equal(0, observer.SubscriberCount);
+        ScenarioExpect.Equal(0, observer.SubscriberCount);
     }
 
+    [Scenario("Cancellation StopsPublish")]
     [Fact]
     public async Task Cancellation_StopsPublish()
     {
@@ -271,12 +274,13 @@ public sealed class AsyncObserverEdgeCaseTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(
             () => observer.PublishAsync(new Evt(1), cts.Token).AsTask());
 
-        Assert.Empty(log);
+        ScenarioExpect.Empty(log);
     }
 
+    [Scenario("Cancellation DuringHandlerExecution")]
     [Fact]
     public async Task Cancellation_DuringHandlerExecution()
     {
@@ -299,13 +303,14 @@ public sealed class AsyncObserverEdgeCaseTests
             return default;
         });
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(
             () => observer.PublishAsync(new Evt(1), cts.Token).AsTask());
 
-        Assert.Single(log);
-        Assert.Equal(1, log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal(1, log[0]);
     }
 
+    [Scenario("SyncErrorSink Adapter Works")]
     [Fact]
     public async Task SyncErrorSink_Adapter_Works()
     {
@@ -321,11 +326,12 @@ public sealed class AsyncObserverEdgeCaseTests
 
         await observer.PublishAsync(new Evt(42));
 
-        Assert.Single(errors);
-        Assert.IsType<InvalidOperationException>(errors[0]);
-        Assert.Single(log);
+        ScenarioExpect.Single(errors);
+        ScenarioExpect.IsType<InvalidOperationException>(errors[0]);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("ErrorSink Exception IsSwallowed")]
     [Fact]
     public async Task ErrorSink_Exception_IsSwallowed()
     {
@@ -341,9 +347,10 @@ public sealed class AsyncObserverEdgeCaseTests
         // Should not throw - sink errors are swallowed
         await observer.PublishAsync(new Evt(1));
 
-        Assert.Single(log);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("PredicateFilter FalseSkipsHandler")]
     [Fact]
     public async Task PredicateFilter_FalseSkipsHandler()
     {
@@ -355,13 +362,14 @@ public sealed class AsyncObserverEdgeCaseTests
             e => { log.Add(e.Id); return default; });
 
         await observer.PublishAsync(new Evt(5));
-        Assert.Empty(log);
+        ScenarioExpect.Empty(log);
 
         await observer.PublishAsync(new Evt(15));
-        Assert.Single(log);
-        Assert.Equal(15, log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal(15, log[0]);
     }
 
+    [Scenario("NullPredicate AlwaysRuns")]
     [Fact]
     public async Task NullPredicate_AlwaysRuns()
     {
@@ -373,9 +381,10 @@ public sealed class AsyncObserverEdgeCaseTests
         await observer.PublishAsync(new Evt(1));
         await observer.PublishAsync(new Evt(2));
 
-        Assert.Equal(2, log.Count);
+        ScenarioExpect.Equal(2, log.Count);
     }
 
+    [Scenario("ConcurrentSubscribeUnsubscribe")]
     [Fact]
     public async Task ConcurrentSubscribeUnsubscribe()
     {
@@ -393,7 +402,7 @@ public sealed class AsyncObserverEdgeCaseTests
 
         await Task.WhenAll(subscribeTasks);
 
-        Assert.Equal(50, observer.SubscriberCount);
+        ScenarioExpect.Equal(50, observer.SubscriberCount);
 
         // Unsubscribe concurrently
         var unsubscribeTasks = subscriptions
@@ -402,9 +411,10 @@ public sealed class AsyncObserverEdgeCaseTests
 
         await Task.WhenAll(unsubscribeTasks);
 
-        Assert.Equal(0, observer.SubscriberCount);
+        ScenarioExpect.Equal(0, observer.SubscriberCount);
     }
 
+    [Scenario("ThrowAggregate NoErrors NoException")]
     [Fact]
     public async Task ThrowAggregate_NoErrors_NoException()
     {
@@ -417,9 +427,10 @@ public sealed class AsyncObserverEdgeCaseTests
 
         await observer.PublishAsync(new Evt(1));
 
-        Assert.Single(log);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("EmptyObserver PublishDoesNothing")]
     [Fact]
     public async Task EmptyObserver_PublishDoesNothing()
     {
@@ -429,6 +440,7 @@ public sealed class AsyncObserverEdgeCaseTests
         // No exception, nothing happens
     }
 
+    [Scenario("Subscribe Handler Only Overload")]
     [Fact]
     public async Task Subscribe_Handler_Only_Overload()
     {
@@ -439,8 +451,8 @@ public sealed class AsyncObserverEdgeCaseTests
 
         await observer.PublishAsync(new Evt(42));
 
-        Assert.Single(log);
-        Assert.Equal(42, log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal(42, log[0]);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/State/AsyncStateMachineTests.cs
+++ b/test/PatternKit.Tests/Behavioral/State/AsyncStateMachineTests.cs
@@ -98,6 +98,7 @@ public sealed class AsyncStateMachineBuilderTests
     private enum S { A, B, C, D }
     private readonly record struct E(string Kind);
 
+    [Scenario("CustomComparer Works")]
     [Fact]
     public async Task CustomComparer_Works()
     {
@@ -114,11 +115,12 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync("IDLE", new E("go"));
 
-        Assert.True(handled);
-        Assert.Equal("ACTIVE", state);
-        Assert.Contains("entered", log);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal("ACTIVE", state);
+        ScenarioExpect.Contains("entered", log);
     }
 
+    [Scenario("ThenBuilder End Without Effect")]
     [Fact]
     public async Task ThenBuilder_End_Without_Effect()
     {
@@ -130,10 +132,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("go"));
 
-        Assert.True(handled);
-        Assert.Equal(S.B, state);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.B, state);
     }
 
+    [Scenario("ThenBuilder Stay End")]
     [Fact]
     public async Task ThenBuilder_Stay_End()
     {
@@ -145,10 +148,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("stay"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
     }
 
+    [Scenario("ThenBuilder AsDefault Stay")]
     [Fact]
     public async Task ThenBuilder_AsDefault_Stay()
     {
@@ -161,11 +165,12 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("anything"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
-        Assert.Equal("default", log[0]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
+        ScenarioExpect.Equal("default", log[0]);
     }
 
+    [Scenario("ThenBuilder AsDefault Permit")]
     [Fact]
     public async Task ThenBuilder_AsDefault_Permit()
     {
@@ -182,13 +187,14 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("anything"));
 
-        Assert.True(handled);
-        Assert.Equal(S.C, state);
-        Assert.Equal("exit:A", log[0]);
-        Assert.Equal("default:go-to-C", log[1]);
-        Assert.Equal("enter:C", log[2]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.C, state);
+        ScenarioExpect.Equal("exit:A", log[0]);
+        ScenarioExpect.Equal("default:go-to-C", log[1]);
+        ScenarioExpect.Equal("enter:C", log[2]);
     }
 
+    [Scenario("MultipleOnEnterOnExit Hooks")]
     [Fact]
     public async Task MultipleOnEnterOnExit_Hooks()
     {
@@ -207,13 +213,14 @@ public sealed class AsyncStateMachineBuilderTests
 
         await m.TryTransitionAsync(S.A, new E("go"));
 
-        Assert.Equal(4, log.Count);
-        Assert.Equal("exit:A:1", log[0]);
-        Assert.Equal("exit:A:2", log[1]);
-        Assert.Equal("enter:B:1", log[2]);
-        Assert.Equal("enter:B:2", log[3]);
+        ScenarioExpect.Equal(4, log.Count);
+        ScenarioExpect.Equal("exit:A:1", log[0]);
+        ScenarioExpect.Equal("exit:A:2", log[1]);
+        ScenarioExpect.Equal("enter:B:1", log[2]);
+        ScenarioExpect.Equal("enter:B:2", log[3]);
     }
 
+    [Scenario("StateBuilder Direct Access")]
     [Fact]
     public async Task StateBuilder_Direct_Access()
     {
@@ -233,9 +240,10 @@ public sealed class AsyncStateMachineBuilderTests
 
         await m.TryTransitionAsync(S.A, new E("go"));
 
-        Assert.Contains("enter:B", log);
+        ScenarioExpect.Contains("enter:B", log);
     }
 
+    [Scenario("UnknownState Returns False")]
     [Fact]
     public async Task UnknownState_Returns_False()
     {
@@ -247,10 +255,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.C, new E("go"));
 
-        Assert.False(handled);
-        Assert.Equal(S.C, state);
+        ScenarioExpect.False(handled);
+        ScenarioExpect.Equal(S.C, state);
     }
 
+    [Scenario("Transition To Self State No Exit Enter")]
     [Fact]
     public async Task Transition_To_Self_State_No_Exit_Enter()
     {
@@ -265,10 +274,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         await m.TryTransitionAsync(S.A, new E("self"));
 
-        Assert.Single(log);
-        Assert.Equal("effect", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("effect", log[0]);
     }
 
+    [Scenario("Cancellation Token Propagates")]
     [Fact]
     public async Task Cancellation_Token_Propagates()
     {
@@ -287,9 +297,10 @@ public sealed class AsyncStateMachineBuilderTests
 
         await m.TryTransitionAsync(S.A, new E("go"), cts.Token);
 
-        Assert.True(tokenReceived);
+        ScenarioExpect.True(tokenReceived);
     }
 
+    [Scenario("WhenBuilder Permit Then Stay Override")]
     [Fact]
     public async Task WhenBuilder_Permit_Then_Stay_Override()
     {
@@ -302,10 +313,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (_, state) = await m.TryTransitionAsync(S.A, new E("test"));
 
-        Assert.Equal(S.A, state);
-        Assert.Equal("stayed", log[0]);
+        ScenarioExpect.Equal(S.A, state);
+        ScenarioExpect.Equal("stayed", log[0]);
     }
 
+    [Scenario("Default Effect Only On Stay")]
     [Fact]
     public async Task Default_Effect_Only_On_Stay()
     {
@@ -319,10 +331,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         await m.TryTransitionAsync(S.A, new E("any"));
 
-        Assert.Single(log);
-        Assert.Equal("default-effect", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default-effect", log[0]);
     }
 
+    [Scenario("Null Hook Is Ignored")]
     [Fact]
     public async Task Null_Hook_Is_Ignored()
     {
@@ -340,9 +353,10 @@ public sealed class AsyncStateMachineBuilderTests
 
         await m.TryTransitionAsync(S.A, new E("go"));
 
-        Assert.Single(log);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("NoDefault NoMatch Returns False")]
     [Fact]
     public async Task NoDefault_NoMatch_Returns_False()
     {
@@ -354,9 +368,10 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, _) = await m.TryTransitionAsync(S.A, new E("other"));
 
-        Assert.False(handled);
+        ScenarioExpect.False(handled);
     }
 
+    [Scenario("AsDefault Without Effect")]
     [Fact]
     public async Task AsDefault_Without_Effect()
     {
@@ -368,10 +383,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("any"));
 
-        Assert.True(handled);
-        Assert.Equal(S.B, state);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.B, state);
     }
 
+    [Scenario("Transition To Unconfigured State Works")]
     [Fact]
     public async Task Transition_To_Unconfigured_State_Works()
     {
@@ -386,14 +402,15 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("go"));
 
-        Assert.True(handled);
-        Assert.Equal(S.D, state);
-        Assert.Equal(2, log.Count);
-        Assert.Equal("exit:A", log[0]);
-        Assert.Equal("effect:go", log[1]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.D, state);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("exit:A", log[0]);
+        ScenarioExpect.Equal("effect:go", log[1]);
         // No OnEnter for S.D since it's not configured
     }
 
+    [Scenario("Default Transition To Unconfigured State")]
     [Fact]
     public async Task Default_Transition_To_Unconfigured_State()
     {
@@ -408,13 +425,14 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("anything"));
 
-        Assert.True(handled);
-        Assert.Equal(S.D, state);
-        Assert.Equal(2, log.Count);
-        Assert.Equal("exit:A", log[0]);
-        Assert.Equal("default:go-to-D", log[1]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.D, state);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("exit:A", log[0]);
+        ScenarioExpect.Equal("default:go-to-D", log[1]);
     }
 
+    [Scenario("Default Transition Without Effect")]
     [Fact]
     public async Task Default_Transition_Without_Effect()
     {
@@ -429,10 +447,11 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("any"));
 
-        Assert.True(handled);
-        Assert.Equal(S.B, state);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.B, state);
     }
 
+    [Scenario("Default Stay Without Effect")]
     [Fact]
     public async Task Default_Stay_Without_Effect()
     {
@@ -446,11 +465,12 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("any"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
-        Assert.Empty(log); // No exit because we stayed
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
+        ScenarioExpect.Empty(log); // No exit because we stayed
     }
 
+    [Scenario("Edge Effect Only On Stay")]
     [Fact]
     public async Task Edge_Effect_Only_On_Stay()
     {
@@ -463,10 +483,10 @@ public sealed class AsyncStateMachineBuilderTests
 
         var (handled, state) = await m.TryTransitionAsync(S.A, new E("stay"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
-        Assert.Single(log);
-        Assert.Equal("stayed", log[0]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("stayed", log[0]);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/State/StateMachineTests.cs
+++ b/test/PatternKit.Tests/Behavioral/State/StateMachineTests.cs
@@ -127,6 +127,7 @@ public sealed class StateMachineBuilderTests
     private enum S { A, B, C, D }
     private readonly record struct E(string Kind);
 
+    [Scenario("CustomComparer Works")]
     [Fact]
     public void CustomComparer_Works()
     {
@@ -144,11 +145,12 @@ public sealed class StateMachineBuilderTests
         var state = "IDLE"; // Different case
         var handled = m.TryTransition(ref state, new E("go"));
 
-        Assert.True(handled);
-        Assert.Equal("ACTIVE", state);
-        Assert.Contains("entered", log);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal("ACTIVE", state);
+        ScenarioExpect.Contains("entered", log);
     }
 
+    [Scenario("ThenBuilder End Without Effect")]
     [Fact]
     public void ThenBuilder_End_Without_Effect()
     {
@@ -161,10 +163,11 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("go"));
 
-        Assert.True(handled);
-        Assert.Equal(S.B, state);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.B, state);
     }
 
+    [Scenario("ThenBuilder Stay End")]
     [Fact]
     public void ThenBuilder_Stay_End()
     {
@@ -177,10 +180,11 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("stay"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
     }
 
+    [Scenario("ThenBuilder AsDefault Stay")]
     [Fact]
     public void ThenBuilder_AsDefault_Stay()
     {
@@ -195,11 +199,12 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("anything"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
-        Assert.Equal("default", log[0]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
+        ScenarioExpect.Equal("default", log[0]);
     }
 
+    [Scenario("ThenBuilder AsDefault Permit")]
     [Fact]
     public void ThenBuilder_AsDefault_Permit()
     {
@@ -217,13 +222,14 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("anything"));
 
-        Assert.True(handled);
-        Assert.Equal(S.C, state);
-        Assert.Equal("exit:A", log[0]);
-        Assert.Equal("default:go-to-C", log[1]);
-        Assert.Equal("enter:C", log[2]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.C, state);
+        ScenarioExpect.Equal("exit:A", log[0]);
+        ScenarioExpect.Equal("default:go-to-C", log[1]);
+        ScenarioExpect.Equal("enter:C", log[2]);
     }
 
+    [Scenario("MultipleOnEnterOnExit Hooks")]
     [Fact]
     public void MultipleOnEnterOnExit_Hooks()
     {
@@ -243,13 +249,14 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         m.TryTransition(ref state, new E("go"));
 
-        Assert.Equal(4, log.Count);
-        Assert.Equal("exit:A:1", log[0]);
-        Assert.Equal("exit:A:2", log[1]);
-        Assert.Equal("enter:B:1", log[2]);
-        Assert.Equal("enter:B:2", log[3]);
+        ScenarioExpect.Equal(4, log.Count);
+        ScenarioExpect.Equal("exit:A:1", log[0]);
+        ScenarioExpect.Equal("exit:A:2", log[1]);
+        ScenarioExpect.Equal("enter:B:1", log[2]);
+        ScenarioExpect.Equal("enter:B:2", log[3]);
     }
 
+    [Scenario("StateBuilder Direct Access")]
     [Fact]
     public void StateBuilder_Direct_Access()
     {
@@ -270,10 +277,11 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         m.TryTransition(ref state, new E("go"));
 
-        Assert.Equal(S.B, state);
-        Assert.Contains("enter:B", log);
+        ScenarioExpect.Equal(S.B, state);
+        ScenarioExpect.Contains("enter:B", log);
     }
 
+    [Scenario("UnknownState Returns False")]
     [Fact]
     public void UnknownState_Returns_False()
     {
@@ -286,10 +294,11 @@ public sealed class StateMachineBuilderTests
         var state = S.C; // Not configured
         var handled = m.TryTransition(ref state, new E("go"));
 
-        Assert.False(handled);
-        Assert.Equal(S.C, state);
+        ScenarioExpect.False(handled);
+        ScenarioExpect.Equal(S.C, state);
     }
 
+    [Scenario("Transition To Self State No Exit Enter")]
     [Fact]
     public void Transition_To_Self_State_No_Exit_Enter()
     {
@@ -306,10 +315,11 @@ public sealed class StateMachineBuilderTests
         m.TryTransition(ref state, new E("self"));
 
         // Should only run effect, not exit/enter since state stays the same
-        Assert.Single(log);
-        Assert.Equal("effect", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("effect", log[0]);
     }
 
+    [Scenario("WhenBuilder Permit Then Stay Override")]
     [Fact]
     public void WhenBuilder_Permit_Then_Stay_Override()
     {
@@ -324,10 +334,11 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         m.TryTransition(ref state, new E("test"));
 
-        Assert.Equal(S.A, state); // Should stay
-        Assert.Equal("stayed", log[0]);
+        ScenarioExpect.Equal(S.A, state); // Should stay
+        ScenarioExpect.Equal("stayed", log[0]);
     }
 
+    [Scenario("Default Effect Only On Stay")]
     [Fact]
     public void Default_Effect_Only_On_Stay()
     {
@@ -343,10 +354,11 @@ public sealed class StateMachineBuilderTests
         m.TryTransition(ref state, new E("any"));
 
         // No exit should be called for stay
-        Assert.Single(log);
-        Assert.Equal("default-effect", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default-effect", log[0]);
     }
 
+    [Scenario("Null Hook Is Ignored")]
     [Fact]
     public void Null_Hook_Is_Ignored()
     {
@@ -365,10 +377,11 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         m.TryTransition(ref state, new E("go"));
 
-        Assert.Equal(S.B, state);
-        Assert.Single(log);
+        ScenarioExpect.Equal(S.B, state);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("NoDefault NoMatch Returns False")]
     [Fact]
     public void NoDefault_NoMatch_Returns_False()
     {
@@ -381,9 +394,10 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("other"));
 
-        Assert.False(handled);
+        ScenarioExpect.False(handled);
     }
 
+    [Scenario("Default Permit To Unconfigured State")]
     [Fact]
     public void Default_Permit_To_Unconfigured_State()
     {
@@ -400,14 +414,15 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("anything"));
 
-        Assert.True(handled);
-        Assert.Equal(S.D, state);
-        Assert.Equal(2, log.Count);
-        Assert.Equal("exit:A", log[0]);
-        Assert.Equal("default:go-to-D", log[1]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.D, state);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("exit:A", log[0]);
+        ScenarioExpect.Equal("default:go-to-D", log[1]);
         // No enter:D because D has no config
     }
 
+    [Scenario("Regular Transition To Unconfigured State")]
     [Fact]
     public void Regular_Transition_To_Unconfigured_State()
     {
@@ -422,11 +437,12 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("go"));
 
-        Assert.True(handled);
-        Assert.Equal(S.D, state);
-        Assert.Equal(2, log.Count);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.D, state);
+        ScenarioExpect.Equal(2, log.Count);
     }
 
+    [Scenario("Default Stay With No Effect")]
     [Fact]
     public void Default_Stay_With_No_Effect()
     {
@@ -439,10 +455,11 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("anything"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
     }
 
+    [Scenario("Default Permit Same State Only Effect")]
     [Fact]
     public void Default_Permit_Same_State_Only_Effect()
     {
@@ -459,12 +476,13 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         var handled = m.TryTransition(ref state, new E("x"));
 
-        Assert.True(handled);
-        Assert.Equal(S.A, state);
-        Assert.Single(log);
-        Assert.Equal("default-effect", log[0]);
+        ScenarioExpect.True(handled);
+        ScenarioExpect.Equal(S.A, state);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default-effect", log[0]);
     }
 
+    [Scenario("Otherwise AsDefault Works")]
     [Fact]
     public void Otherwise_AsDefault_Works()
     {
@@ -481,10 +499,11 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         m.TryTransition(ref state, new E("any"));
 
-        Assert.Equal(S.B, state);
-        Assert.Contains("enter:B", log);
+        ScenarioExpect.Equal(S.B, state);
+        ScenarioExpect.Contains("enter:B", log);
     }
 
+    [Scenario("Transition Throws For Unhandled")]
     [Fact]
     public void Transition_Throws_For_Unhandled()
     {
@@ -495,13 +514,14 @@ public sealed class StateMachineBuilderTests
             .Build();
 
         var state = S.A;
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() =>
             m.Transition(ref state, new E("nope")));
 
-        Assert.Contains("nope", ex.Message);
-        Assert.Contains("A", ex.Message);
+        ScenarioExpect.Contains("nope", ex.Message);
+        ScenarioExpect.Contains("A", ex.Message);
     }
 
+    [Scenario("NullComparer Uses Default")]
     [Fact]
     public void NullComparer_Uses_Default()
     {
@@ -515,7 +535,7 @@ public sealed class StateMachineBuilderTests
         var state = S.A;
         m.TryTransition(ref state, new E("go"));
 
-        Assert.Equal(S.B, state);
+        ScenarioExpect.Equal(S.B, state);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Strategy/AsyncActionStrategyTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Strategy/AsyncActionStrategyTests.cs
@@ -152,6 +152,7 @@ public sealed class AsyncActionStrategyTests(ITestOutputHelper output) : TinyBdd
 
 public sealed class AsyncActionStrategyBuilderTests
 {
+    [Scenario("TryExecuteAsync WithDefault ReturnsTrue")]
     [Fact]
     public async Task TryExecuteAsync_WithDefault_ReturnsTrue()
     {
@@ -163,10 +164,11 @@ public sealed class AsyncActionStrategyBuilderTests
 
         var result = await strategy.TryExecuteAsync(0);
 
-        Assert.True(result);
-        Assert.Contains("default", log);
+        ScenarioExpect.True(result);
+        ScenarioExpect.Contains("default", log);
     }
 
+    [Scenario("TryExecuteAsync MatchingPredicate ReturnsTrue")]
     [Fact]
     public async Task TryExecuteAsync_MatchingPredicate_ReturnsTrue()
     {
@@ -177,10 +179,11 @@ public sealed class AsyncActionStrategyBuilderTests
 
         var result = await strategy.TryExecuteAsync(5);
 
-        Assert.True(result);
-        Assert.Contains("positive", log);
+        ScenarioExpect.True(result);
+        ScenarioExpect.Contains("positive", log);
     }
 
+    [Scenario("ExecuteAsync Respects Cancellation")]
     [Fact]
     public async Task ExecuteAsync_Respects_Cancellation()
     {
@@ -198,12 +201,13 @@ public sealed class AsyncActionStrategyBuilderTests
 
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await strategy.ExecuteAsync(5, cts.Token));
 
-        Assert.True(started);
+        ScenarioExpect.True(started);
     }
 
+    [Scenario("SyncPredicate WithCancellationToken Works")]
     [Fact]
     public async Task SyncPredicate_WithCancellationToken_Works()
     {
@@ -221,9 +225,10 @@ public sealed class AsyncActionStrategyBuilderTests
 
         await strategy.ExecuteAsync(5, cts.Token);
 
-        Assert.True(tokenReceived);
+        ScenarioExpect.True(tokenReceived);
     }
 
+    [Scenario("Multiple When Branches FirstMatch Wins")]
     [Fact]
     public async Task Multiple_When_Branches_FirstMatch_Wins()
     {
@@ -236,10 +241,11 @@ public sealed class AsyncActionStrategyBuilderTests
 
         await strategy.ExecuteAsync(6); // even and div3, but even wins
 
-        Assert.Single(log);
-        Assert.Equal("even", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("even", log[0]);
     }
 
+    [Scenario("Async Handler Executes Fully")]
     [Fact]
     public async Task Async_Handler_Executes_Fully()
     {
@@ -255,9 +261,10 @@ public sealed class AsyncActionStrategyBuilderTests
 
         await strategy.ExecuteAsync(1);
 
-        Assert.True(completed);
+        ScenarioExpect.True(completed);
     }
 
+    [Scenario("Empty Strategy WithDefault UsesDefault")]
     [Fact]
     public async Task Empty_Strategy_WithDefault_UsesDefault()
     {
@@ -268,19 +275,21 @@ public sealed class AsyncActionStrategyBuilderTests
 
         await strategy.ExecuteAsync(42);
 
-        Assert.Single(log);
-        Assert.Equal("default", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default", log[0]);
     }
 
+    [Scenario("Empty Strategy NoDefault Throws")]
     [Fact]
     public async Task Empty_Strategy_NoDefault_Throws()
     {
         var strategy = AsyncActionStrategy<int>.Create().Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             strategy.ExecuteAsync(42).AsTask());
     }
 
+    [Scenario("Sync Then Handler Works")]
     [Fact]
     public async Task Sync_Then_Handler_Works()
     {
@@ -291,9 +300,10 @@ public sealed class AsyncActionStrategyBuilderTests
 
         await strategy.ExecuteAsync(42);
 
-        Assert.Contains("value:42", log);
+        ScenarioExpect.Contains("value:42", log);
     }
 
+    [Scenario("Multiple Strategies Independent")]
     [Fact]
     public async Task Multiple_Strategies_Independent()
     {
@@ -311,12 +321,13 @@ public sealed class AsyncActionStrategyBuilderTests
         await s1.ExecuteAsync(1);
         await s2.ExecuteAsync(1);
 
-        Assert.Single(log1);
-        Assert.Single(log2);
-        Assert.Equal("s1", log1[0]);
-        Assert.Equal("s2", log2[0]);
+        ScenarioExpect.Single(log1);
+        ScenarioExpect.Single(log2);
+        ScenarioExpect.Equal("s1", log1[0]);
+        ScenarioExpect.Equal("s2", log2[0]);
     }
 
+    [Scenario("Concurrent Execution Safe")]
     [Fact]
     public async Task Concurrent_Execution_Safe()
     {
@@ -336,7 +347,7 @@ public sealed class AsyncActionStrategyBuilderTests
 
         await Task.WhenAll(tasks);
 
-        Assert.Equal(100, counter);
+        ScenarioExpect.Equal(100, counter);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Strategy/AsyncStrategyTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Strategy/AsyncStrategyTests.cs
@@ -198,6 +198,7 @@ public sealed class AsyncStrategyTests(ITestOutputHelper output) : TinyBddXunitB
 
 public sealed class AsyncStrategyEdgeCaseTests
 {
+    [Scenario("SyncPredicate WithCancellationToken Adapter")]
     [Fact]
     public async Task SyncPredicate_WithCancellationToken_Adapter()
     {
@@ -214,10 +215,11 @@ public sealed class AsyncStrategyEdgeCaseTests
         var cts = new CancellationTokenSource();
         var result = await strategy.ExecuteAsync(5, cts.Token);
 
-        Assert.Equal("positive", result);
-        Assert.Equal(cts.Token, tokenReceived);
+        ScenarioExpect.Equal("positive", result);
+        ScenarioExpect.Equal(cts.Token, tokenReceived);
     }
 
+    [Scenario("SyncPredicate Without CancellationToken Adapter")]
     [Fact]
     public async Task SyncPredicate_Without_CancellationToken_Adapter()
     {
@@ -227,10 +229,11 @@ public sealed class AsyncStrategyEdgeCaseTests
             .Default(_ => "odd")
             .Build();
 
-        Assert.Equal("even", await strategy.ExecuteAsync(4));
-        Assert.Equal("odd", await strategy.ExecuteAsync(5));
+        ScenarioExpect.Equal("even", await strategy.ExecuteAsync(4));
+        ScenarioExpect.Equal("odd", await strategy.ExecuteAsync(5));
     }
 
+    [Scenario("SyncDefault Adapter")]
     [Fact]
     public async Task SyncDefault_Adapter()
     {
@@ -242,18 +245,20 @@ public sealed class AsyncStrategyEdgeCaseTests
 
         var result = await strategy.ExecuteAsync(42);
 
-        Assert.Equal("default:42", result);
+        ScenarioExpect.Equal("default:42", result);
     }
 
+    [Scenario("Empty Strategy Throws")]
     [Fact]
     public async Task Empty_Strategy_Throws()
     {
         var strategy = AsyncStrategy<int, string>.Create().Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => strategy.ExecuteAsync(1).AsTask());
     }
 
+    [Scenario("Multiple Predicates First Match Wins")]
     [Fact]
     public async Task Multiple_Predicates_First_Match_Wins()
     {
@@ -275,11 +280,12 @@ public sealed class AsyncStrategyEdgeCaseTests
 
         var result = await strategy.ExecuteAsync(5);
 
-        Assert.Equal("first", result);
-        Assert.Single(log); // Only first predicate evaluated
-        Assert.Equal("pred1", log[0]);
+        ScenarioExpect.Equal("first", result);
+        ScenarioExpect.Single(log); // Only first predicate evaluated
+        ScenarioExpect.Equal("pred1", log[0]);
     }
 
+    [Scenario("All Predicates Evaluated Until Match")]
     [Fact]
     public async Task All_Predicates_Evaluated_Until_Match()
     {
@@ -307,10 +313,11 @@ public sealed class AsyncStrategyEdgeCaseTests
 
         var result = await strategy.ExecuteAsync(5);
 
-        Assert.Equal("third", result);
-        Assert.Equal(3, log.Count);
+        ScenarioExpect.Equal("third", result);
+        ScenarioExpect.Equal(3, log.Count);
     }
 
+    [Scenario("Handler Receives Input And Token")]
     [Fact]
     public async Task Handler_Receives_Input_And_Token()
     {
@@ -330,10 +337,11 @@ public sealed class AsyncStrategyEdgeCaseTests
         var cts = new CancellationTokenSource();
         await strategy.ExecuteAsync(42, cts.Token);
 
-        Assert.Equal(42, capturedInput);
-        Assert.Equal(cts.Token, capturedToken);
+        ScenarioExpect.Equal(42, capturedInput);
+        ScenarioExpect.Equal(cts.Token, capturedToken);
     }
 
+    [Scenario("Default Only Strategy")]
     [Fact]
     public async Task Default_Only_Strategy()
     {
@@ -343,9 +351,10 @@ public sealed class AsyncStrategyEdgeCaseTests
 
         var result = await strategy.ExecuteAsync(99);
 
-        Assert.Equal("default:99", result);
+        ScenarioExpect.Equal("default:99", result);
     }
 
+    [Scenario("AsyncPredicate And Handler")]
     [Fact]
     public async Task AsyncPredicate_And_Handler()
     {
@@ -364,7 +373,7 @@ public sealed class AsyncStrategyEdgeCaseTests
 
         var result = await strategy.ExecuteAsync(5);
 
-        Assert.Equal("async:5", result);
+        ScenarioExpect.Equal("async:5", result);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Strategy/TryStrategyTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Strategy/TryStrategyTests.cs
@@ -168,6 +168,7 @@ public sealed class TryHandlerExtensionsTests
         return false;
     }
 
+    [Scenario("TryGetResult FirstMatch ReturnsTrue")]
     [Fact]
     public void TryGetResult_FirstMatch_ReturnsTrue()
     {
@@ -176,10 +177,11 @@ public sealed class TryHandlerExtensionsTests
         var input = 6;
         var success = handlers.TryGetResult(in input, out var result);
 
-        Assert.True(success);
-        Assert.Equal("even", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("even", result);
     }
 
+    [Scenario("TryGetResult SecondMatch ReturnsTrue")]
     [Fact]
     public void TryGetResult_SecondMatch_ReturnsTrue()
     {
@@ -188,10 +190,11 @@ public sealed class TryHandlerExtensionsTests
         var input = 9; // odd, divisible by 3
         var success = handlers.TryGetResult(in input, out var result);
 
-        Assert.True(success);
-        Assert.Equal("div3", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("div3", result);
     }
 
+    [Scenario("TryGetResult NoMatch ReturnsFalse")]
     [Fact]
     public void TryGetResult_NoMatch_ReturnsFalse()
     {
@@ -200,10 +203,11 @@ public sealed class TryHandlerExtensionsTests
         var input = 7; // odd, not divisible by 3
         var success = handlers.TryGetResult(in input, out var result);
 
-        Assert.False(success);
-        Assert.Null(result);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("TryGetResult EmptyHandlers ReturnsFalse")]
     [Fact]
     public void TryGetResult_EmptyHandlers_ReturnsFalse()
     {
@@ -211,10 +215,11 @@ public sealed class TryHandlerExtensionsTests
         var input = 5;
         var success = handlers.TryGetResult(in input, out var result);
 
-        Assert.False(success);
-        Assert.Null(result);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("FirstMatch Found ReturnsSome")]
     [Fact]
     public void FirstMatch_Found_ReturnsSome()
     {
@@ -223,10 +228,11 @@ public sealed class TryHandlerExtensionsTests
         var input = 4;
         var option = handlers.FirstMatch(in input);
 
-        Assert.True(option.HasValue);
-        Assert.Equal("even", option.ValueOrDefault);
+        ScenarioExpect.True(option.HasValue);
+        ScenarioExpect.Equal("even", option.ValueOrDefault);
     }
 
+    [Scenario("FirstMatch NotFound ReturnsNone")]
     [Fact]
     public void FirstMatch_NotFound_ReturnsNone()
     {
@@ -235,9 +241,10 @@ public sealed class TryHandlerExtensionsTests
         var input = 42;
         var option = handlers.FirstMatch(in input);
 
-        Assert.False(option.HasValue);
+        ScenarioExpect.False(option.HasValue);
     }
 
+    [Scenario("FirstMatch MultipleMatches ReturnsFirst")]
     [Fact]
     public void FirstMatch_MultipleMatches_ReturnsFirst()
     {
@@ -246,8 +253,8 @@ public sealed class TryHandlerExtensionsTests
         var input = 6; // both even and divisible by 3
         var option = handlers.FirstMatch(in input);
 
-        Assert.True(option.HasValue);
-        Assert.Equal("even", option.ValueOrDefault); // first wins
+        ScenarioExpect.True(option.HasValue);
+        ScenarioExpect.Equal("even", option.ValueOrDefault); // first wins
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Template/AsyncTemplateTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Template/AsyncTemplateTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Behavioral.Template;
+using TinyBDD;
 
 namespace PatternKit.Tests.Behavioral.Template;
 
@@ -6,6 +7,7 @@ public sealed class AsyncTemplateTests
 {
     #region AsyncTemplate<TIn, TOut> Tests
 
+    [Scenario("AsyncTemplate Executes Steps In Order")]
     [Fact]
     public async Task AsyncTemplate_Executes_Steps_In_Order()
     {
@@ -29,12 +31,13 @@ public sealed class AsyncTemplateTests
 
         var result = await template.ExecuteAsync(5);
 
-        Assert.Equal("5", result);
-        Assert.Equal("before-5", log[0]);
-        Assert.Equal("step", log[1]);
-        Assert.Equal("after-5->5", log[2]);
+        ScenarioExpect.Equal("5", result);
+        ScenarioExpect.Equal("before-5", log[0]);
+        ScenarioExpect.Equal("step", log[1]);
+        ScenarioExpect.Equal("after-5->5", log[2]);
     }
 
+    [Scenario("AsyncTemplate Multiple Before Steps")]
     [Fact]
     public async Task AsyncTemplate_Multiple_Before_Steps()
     {
@@ -46,10 +49,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Equal("before-1", log[0]);
-        Assert.Equal("before-2", log[1]);
+        ScenarioExpect.Equal("before-1", log[0]);
+        ScenarioExpect.Equal("before-2", log[1]);
     }
 
+    [Scenario("AsyncTemplate Multiple After Steps")]
     [Fact]
     public async Task AsyncTemplate_Multiple_After_Steps()
     {
@@ -61,10 +65,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Equal("after-1", log[0]);
-        Assert.Equal("after-2", log[1]);
+        ScenarioExpect.Equal("after-1", log[0]);
+        ScenarioExpect.Equal("after-2", log[1]);
     }
 
+    [Scenario("AsyncTemplate TryExecute Returns Success")]
     [Fact]
     public async Task AsyncTemplate_TryExecute_Returns_Success()
     {
@@ -73,11 +78,12 @@ public sealed class AsyncTemplateTests
 
         var (success, result, error) = await template.TryExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.Equal(10, result);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal(10, result);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("AsyncTemplate TryExecute Catches Exception")]
     [Fact]
     public async Task AsyncTemplate_TryExecute_Catches_Exception()
     {
@@ -89,11 +95,12 @@ public sealed class AsyncTemplateTests
 
         var (success, result, error) = await template.TryExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Equal(default, result);
-        Assert.Equal("test", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal(default, result);
+        ScenarioExpect.Equal("test", error);
     }
 
+    [Scenario("AsyncTemplate Async Before")]
     [Fact]
     public async Task AsyncTemplate_Async_Before()
     {
@@ -108,10 +115,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("async-before", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async-before", log[0]);
     }
 
+    [Scenario("AsyncTemplate Async After")]
     [Fact]
     public async Task AsyncTemplate_Async_After()
     {
@@ -126,10 +134,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("async-after", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async-after", log[0]);
     }
 
+    [Scenario("AsyncTemplate OnError Handler")]
     [Fact]
     public async Task AsyncTemplate_OnError_Handler()
     {
@@ -143,11 +152,12 @@ public sealed class AsyncTemplateTests
 
         var (success, _, _) = await template.TryExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Single(log);
-        Assert.Contains("error", log[0]);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Contains("error", log[0]);
     }
 
+    [Scenario("AsyncTemplate Synchronized")]
     [Fact]
     public async Task AsyncTemplate_Synchronized()
     {
@@ -165,13 +175,14 @@ public sealed class AsyncTemplateTests
         var tasks = Enumerable.Range(0, 5).Select(_ => template.ExecuteAsync(0)).ToArray();
         await Task.WhenAll(tasks);
 
-        Assert.Equal(5, count);
+        ScenarioExpect.Equal(5, count);
     }
 
     #endregion
 
     #region AsyncActionTemplate<TIn> Tests
 
+    [Scenario("AsyncActionTemplate Executes")]
     [Fact]
     public async Task AsyncActionTemplate_Executes()
     {
@@ -185,9 +196,10 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionTemplate Steps In Order")]
     [Fact]
     public async Task AsyncActionTemplate_Steps_In_Order()
     {
@@ -203,11 +215,12 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Equal("before", log[0]);
-        Assert.Equal("core", log[1]);
-        Assert.Equal("after", log[2]);
+        ScenarioExpect.Equal("before", log[0]);
+        ScenarioExpect.Equal("core", log[1]);
+        ScenarioExpect.Equal("after", log[2]);
     }
 
+    [Scenario("AsyncActionTemplate TryExecute Returns Success")]
     [Fact]
     public async Task AsyncActionTemplate_TryExecute_Returns_Success()
     {
@@ -221,11 +234,12 @@ public sealed class AsyncTemplateTests
 
         var (success, error) = await template.TryExecuteAsync(5);
 
-        Assert.True(success);
-        Assert.True(executed);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.True(executed);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("AsyncActionTemplate TryExecute Catches Exception")]
     [Fact]
     public async Task AsyncActionTemplate_TryExecute_Catches_Exception()
     {
@@ -237,10 +251,11 @@ public sealed class AsyncTemplateTests
 
         var (success, error) = await template.TryExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Equal("test", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("test", error);
     }
 
+    [Scenario("AsyncActionTemplate Multiple Before")]
     [Fact]
     public async Task AsyncActionTemplate_Multiple_Before()
     {
@@ -252,10 +267,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Equal("before-1", log[0]);
-        Assert.Equal("before-2", log[1]);
+        ScenarioExpect.Equal("before-1", log[0]);
+        ScenarioExpect.Equal("before-2", log[1]);
     }
 
+    [Scenario("AsyncActionTemplate Multiple After")]
     [Fact]
     public async Task AsyncActionTemplate_Multiple_After()
     {
@@ -267,10 +283,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Equal("after-1", log[0]);
-        Assert.Equal("after-2", log[1]);
+        ScenarioExpect.Equal("after-1", log[0]);
+        ScenarioExpect.Equal("after-2", log[1]);
     }
 
+    [Scenario("AsyncActionTemplate Synchronized")]
     [Fact]
     public async Task AsyncActionTemplate_Synchronized()
     {
@@ -287,9 +304,10 @@ public sealed class AsyncTemplateTests
         var tasks = Enumerable.Range(0, 5).Select(_ => template.ExecuteAsync(0)).ToArray();
         await Task.WhenAll(tasks);
 
-        Assert.Equal(5, count);
+        ScenarioExpect.Equal(5, count);
     }
 
+    [Scenario("AsyncActionTemplate Async Before")]
     [Fact]
     public async Task AsyncActionTemplate_Async_Before()
     {
@@ -304,10 +322,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("async-before", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async-before", log[0]);
     }
 
+    [Scenario("AsyncActionTemplate Async After")]
     [Fact]
     public async Task AsyncActionTemplate_Async_After()
     {
@@ -322,10 +341,11 @@ public sealed class AsyncTemplateTests
 
         await template.ExecuteAsync(5);
 
-        Assert.Single(log);
-        Assert.Equal("async-after", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("async-after", log[0]);
     }
 
+    [Scenario("AsyncActionTemplate OnError Sync Handler")]
     [Fact]
     public async Task AsyncActionTemplate_OnError_Sync_Handler()
     {
@@ -339,11 +359,12 @@ public sealed class AsyncTemplateTests
 
         var (success, error) = await template.TryExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Single(log);
-        Assert.Contains("error", log[0]);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Contains("error", log[0]);
     }
 
+    [Scenario("AsyncActionTemplate OnError Async Handler")]
     [Fact]
     public async Task AsyncActionTemplate_OnError_Async_Handler()
     {
@@ -361,11 +382,12 @@ public sealed class AsyncTemplateTests
 
         var (success, error) = await template.TryExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Single(log);
-        Assert.Contains("async-error", log[0]);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Contains("async-error", log[0]);
     }
 
+    [Scenario("AsyncActionTemplate OnError Handler Throws IsSwallowed")]
     [Fact]
     public async Task AsyncActionTemplate_OnError_Handler_Throws_IsSwallowed()
     {
@@ -380,16 +402,17 @@ public sealed class AsyncTemplateTests
 
         var (success, error) = await template.TryExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Equal("original", error);
-        Assert.Single(log);
-        Assert.Equal("second handler", log[0]);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("original", error);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("second handler", log[0]);
     }
 
     #endregion
 
     #region ActionTemplate<TIn> Tests
 
+    [Scenario("ActionTemplate Executes")]
     [Fact]
     public void ActionTemplate_Executes()
     {
@@ -399,9 +422,10 @@ public sealed class AsyncTemplateTests
 
         template.Execute(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionTemplate Steps In Order")]
     [Fact]
     public void ActionTemplate_Steps_In_Order()
     {
@@ -413,11 +437,12 @@ public sealed class AsyncTemplateTests
 
         template.Execute(5);
 
-        Assert.Equal("before", log[0]);
-        Assert.Equal("core", log[1]);
-        Assert.Equal("after", log[2]);
+        ScenarioExpect.Equal("before", log[0]);
+        ScenarioExpect.Equal("core", log[1]);
+        ScenarioExpect.Equal("after", log[2]);
     }
 
+    [Scenario("ActionTemplate TryExecute Returns Success")]
     [Fact]
     public void ActionTemplate_TryExecute_Returns_Success()
     {
@@ -427,11 +452,12 @@ public sealed class AsyncTemplateTests
 
         var success = template.TryExecute(5, out var error);
 
-        Assert.True(success);
-        Assert.True(executed);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.True(executed);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("ActionTemplate TryExecute Catches Exception")]
     [Fact]
     public void ActionTemplate_TryExecute_Catches_Exception()
     {
@@ -443,10 +469,11 @@ public sealed class AsyncTemplateTests
 
         var success = template.TryExecute(5, out var error);
 
-        Assert.False(success);
-        Assert.Equal("test", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("test", error);
     }
 
+    [Scenario("ActionTemplate Multiple Before")]
     [Fact]
     public void ActionTemplate_Multiple_Before()
     {
@@ -458,10 +485,11 @@ public sealed class AsyncTemplateTests
 
         template.Execute(5);
 
-        Assert.Contains("before-1", log);
-        Assert.Contains("before-2", log);
+        ScenarioExpect.Contains("before-1", log);
+        ScenarioExpect.Contains("before-2", log);
     }
 
+    [Scenario("ActionTemplate Multiple After")]
     [Fact]
     public void ActionTemplate_Multiple_After()
     {
@@ -473,10 +501,11 @@ public sealed class AsyncTemplateTests
 
         template.Execute(5);
 
-        Assert.Contains("after-1", log);
-        Assert.Contains("after-2", log);
+        ScenarioExpect.Contains("after-1", log);
+        ScenarioExpect.Contains("after-2", log);
     }
 
+    [Scenario("ActionTemplate Synchronized")]
     [Fact]
     public void ActionTemplate_Synchronized()
     {
@@ -492,7 +521,7 @@ public sealed class AsyncTemplateTests
 
         Parallel.For(0, 5, _ => template.Execute(0));
 
-        Assert.Equal(5, count);
+        ScenarioExpect.Equal(5, count);
     }
 
     #endregion
@@ -504,6 +533,7 @@ public sealed class AsyncTemplateTests
         protected override int Step(int context) => context * 2;
     }
 
+    [Scenario("TemplateMethod Executes")]
     [Fact]
     public void TemplateMethod_Executes()
     {
@@ -511,7 +541,7 @@ public sealed class AsyncTemplateTests
 
         var result = template.Execute(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
     private sealed class TemplateWithHooks : TemplateMethod<int, int>
@@ -527,6 +557,7 @@ public sealed class AsyncTemplateTests
         protected override void OnAfter(int context, int result) => Log.Add("after");
     }
 
+    [Scenario("TemplateMethod Hooks Execute In Order")]
     [Fact]
     public void TemplateMethod_Hooks_Execute_In_Order()
     {
@@ -534,34 +565,37 @@ public sealed class AsyncTemplateTests
 
         var result = template.Execute(5);
 
-        Assert.Equal(10, result);
-        Assert.Equal("before", template.Log[0]);
-        Assert.Equal("step", template.Log[1]);
-        Assert.Equal("after", template.Log[2]);
+        ScenarioExpect.Equal(10, result);
+        ScenarioExpect.Equal("before", template.Log[0]);
+        ScenarioExpect.Equal("step", template.Log[1]);
+        ScenarioExpect.Equal("after", template.Log[2]);
     }
 
     #endregion
 
     #region Null Argument Tests
 
+    [Scenario("AsyncTemplate Core Null Throws")]
     [Fact]
     public void AsyncTemplate_Core_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncTemplate<int, int>.Create(null!));
     }
 
+    [Scenario("AsyncActionTemplate Core Null Throws")]
     [Fact]
     public void AsyncActionTemplate_Core_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionTemplate<int>.Create(null!));
     }
 
+    [Scenario("ActionTemplate Core Null Throws")]
     [Fact]
     public void ActionTemplate_Core_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionTemplate<int>.Create(null!));
     }
 

--- a/test/PatternKit.Tests/Behavioral/TemplateFluentTests.cs
+++ b/test/PatternKit.Tests/Behavioral/TemplateFluentTests.cs
@@ -109,6 +109,7 @@ public sealed class TemplateFluentTests(ITestOutputHelper output) : TinyBddXunit
 
 public sealed class ActionTemplateTests
 {
+    [Scenario("ActionTemplate Execute NoHooks")]
     [Fact]
     public void ActionTemplate_Execute_NoHooks()
     {
@@ -117,9 +118,10 @@ public sealed class ActionTemplateTests
 
         tpl.Execute(42);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionTemplate Execute WithBefore")]
     [Fact]
     public void ActionTemplate_Execute_WithBefore()
     {
@@ -130,9 +132,10 @@ public sealed class ActionTemplateTests
 
         tpl.Execute(1);
 
-        Assert.Equal(new[] { "before", "step" }, log);
+        ScenarioExpect.Equal(new[] { "before", "step" }, log);
     }
 
+    [Scenario("ActionTemplate Execute WithAfter")]
     [Fact]
     public void ActionTemplate_Execute_WithAfter()
     {
@@ -143,9 +146,10 @@ public sealed class ActionTemplateTests
 
         tpl.Execute(1);
 
-        Assert.Equal(new[] { "step", "after" }, log);
+        ScenarioExpect.Equal(new[] { "step", "after" }, log);
     }
 
+    [Scenario("ActionTemplate Execute WithAllHooks")]
     [Fact]
     public void ActionTemplate_Execute_WithAllHooks()
     {
@@ -157,9 +161,10 @@ public sealed class ActionTemplateTests
 
         tpl.Execute(42);
 
-        Assert.Equal(new[] { "before:42", "step:42", "after:42" }, log);
+        ScenarioExpect.Equal(new[] { "before:42", "step:42", "after:42" }, log);
     }
 
+    [Scenario("ActionTemplate TryExecute Success")]
     [Fact]
     public void ActionTemplate_TryExecute_Success()
     {
@@ -168,11 +173,12 @@ public sealed class ActionTemplateTests
 
         var ok = tpl.TryExecute(42, out var error);
 
-        Assert.True(ok);
-        Assert.Null(error);
-        Assert.True(executed);
+        ScenarioExpect.True(ok);
+        ScenarioExpect.Null(error);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionTemplate TryExecute Error")]
     [Fact]
     public void ActionTemplate_TryExecute_Error()
     {
@@ -183,11 +189,12 @@ public sealed class ActionTemplateTests
 
         var ok = tpl.TryExecute(42, out var error);
 
-        Assert.False(ok);
-        Assert.Equal("boom", error);
-        Assert.Equal("boom", observedError);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.Equal("boom", error);
+        ScenarioExpect.Equal("boom", observedError);
     }
 
+    [Scenario("ActionTemplate Synchronized")]
     [Fact]
     public void ActionTemplate_Synchronized()
     {
@@ -204,9 +211,10 @@ public sealed class ActionTemplateTests
         var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(() => tpl.Execute(1))).ToArray();
         Task.WaitAll(tasks);
 
-        Assert.Equal(1, maxConcurrent);
+        ScenarioExpect.Equal(1, maxConcurrent);
     }
 
+    [Scenario("ActionTemplate MultipleHooks Compose")]
     [Fact]
     public void ActionTemplate_MultipleHooks_Compose()
     {
@@ -222,12 +230,13 @@ public sealed class ActionTemplateTests
 
         tpl.Execute(1);
 
-        Assert.Equal(4, count); // 2 before + 2 after
+        ScenarioExpect.Equal(4, count); // 2 before + 2 after
     }
 }
 
 public sealed class AsyncTemplateTests
 {
+    [Scenario("AsyncTemplate Execute Simple")]
     [Fact]
     public async Task AsyncTemplate_Execute_Simple()
     {
@@ -239,9 +248,10 @@ public sealed class AsyncTemplateTests
 
         var result = await tpl.ExecuteAsync(42);
 
-        Assert.Equal("42", result);
+        ScenarioExpect.Equal("42", result);
     }
 
+    [Scenario("AsyncTemplate Execute WithHooks")]
     [Fact]
     public async Task AsyncTemplate_Execute_WithHooks()
     {
@@ -258,10 +268,11 @@ public sealed class AsyncTemplateTests
 
         var result = await tpl.ExecuteAsync(42);
 
-        Assert.Equal("42", result);
-        Assert.Equal(new[] { "before:42", "step:42", "after:42:42" }, log);
+        ScenarioExpect.Equal("42", result);
+        ScenarioExpect.Equal(new[] { "before:42", "step:42", "after:42:42" }, log);
     }
 
+    [Scenario("AsyncTemplate TryExecuteAsync Success")]
     [Fact]
     public async Task AsyncTemplate_TryExecuteAsync_Success()
     {
@@ -273,11 +284,12 @@ public sealed class AsyncTemplateTests
 
         var (ok, result, error) = await tpl.TryExecuteAsync(42);
 
-        Assert.True(ok);
-        Assert.Equal("42", result);
-        Assert.Null(error);
+        ScenarioExpect.True(ok);
+        ScenarioExpect.Equal("42", result);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("AsyncTemplate TryExecuteAsync Error")]
     [Fact]
     public async Task AsyncTemplate_TryExecuteAsync_Error()
     {
@@ -292,11 +304,12 @@ public sealed class AsyncTemplateTests
 
         var (ok, result, error) = await tpl.TryExecuteAsync(42);
 
-        Assert.False(ok);
-        Assert.Equal("boom", error);
-        Assert.Equal("boom", observedError);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.Equal("boom", error);
+        ScenarioExpect.Equal("boom", observedError);
     }
 
+    [Scenario("AsyncTemplate Synchronized")]
     [Fact]
     public async Task AsyncTemplate_Synchronized()
     {
@@ -314,12 +327,13 @@ public sealed class AsyncTemplateTests
         var tasks = Enumerable.Range(0, 4).Select(_ => tpl.ExecuteAsync(1)).ToArray();
         await Task.WhenAll(tasks);
 
-        Assert.Equal(1, maxConcurrent);
+        ScenarioExpect.Equal(1, maxConcurrent);
     }
 }
 
 public sealed class AsyncActionTemplateTests
 {
+    [Scenario("AsyncActionTemplate Execute Simple")]
     [Fact]
     public async Task AsyncActionTemplate_Execute_Simple()
     {
@@ -332,9 +346,10 @@ public sealed class AsyncActionTemplateTests
 
         await tpl.ExecuteAsync(42);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionTemplate Execute WithHooks")]
     [Fact]
     public async Task AsyncActionTemplate_Execute_WithHooks()
     {
@@ -350,9 +365,10 @@ public sealed class AsyncActionTemplateTests
 
         await tpl.ExecuteAsync(42);
 
-        Assert.Equal(new[] { "before:42", "step:42", "after:42" }, log);
+        ScenarioExpect.Equal(new[] { "before:42", "step:42", "after:42" }, log);
     }
 
+    [Scenario("AsyncActionTemplate TryExecuteAsync Success")]
     [Fact]
     public async Task AsyncActionTemplate_TryExecuteAsync_Success()
     {
@@ -365,11 +381,12 @@ public sealed class AsyncActionTemplateTests
 
         var (ok, error) = await tpl.TryExecuteAsync(42);
 
-        Assert.True(ok);
-        Assert.Null(error);
-        Assert.True(executed);
+        ScenarioExpect.True(ok);
+        ScenarioExpect.Null(error);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionTemplate TryExecuteAsync Error")]
     [Fact]
     public async Task AsyncActionTemplate_TryExecuteAsync_Error()
     {
@@ -384,11 +401,12 @@ public sealed class AsyncActionTemplateTests
 
         var (ok, error) = await tpl.TryExecuteAsync(42);
 
-        Assert.False(ok);
-        Assert.Equal("boom", error);
-        Assert.Equal("boom", observedError);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.Equal("boom", error);
+        ScenarioExpect.Equal("boom", observedError);
     }
 
+    [Scenario("AsyncActionTemplate Synchronized")]
     [Fact]
     public async Task AsyncActionTemplate_Synchronized()
     {
@@ -405,9 +423,10 @@ public sealed class AsyncActionTemplateTests
         var tasks = Enumerable.Range(0, 4).Select(_ => tpl.ExecuteAsync(1)).ToArray();
         await Task.WhenAll(tasks);
 
-        Assert.Equal(1, maxConcurrent);
+        ScenarioExpect.Equal(1, maxConcurrent);
     }
 
+    [Scenario("AsyncActionTemplate MultipleHooks Compose")]
     [Fact]
     public async Task AsyncActionTemplate_MultipleHooks_Compose()
     {
@@ -421,9 +440,10 @@ public sealed class AsyncActionTemplateTests
 
         await tpl.ExecuteAsync(1);
 
-        Assert.Equal(4, count);
+        ScenarioExpect.Equal(4, count);
     }
 
+    [Scenario("AsyncActionTemplate Cancellation")]
     [Fact]
     public async Task AsyncActionTemplate_Cancellation()
     {
@@ -437,19 +457,21 @@ public sealed class AsyncActionTemplateTests
 
         await tpl.ExecuteAsync(1, cts.Token);
 
-        Assert.True(tokenReceived);
+        ScenarioExpect.True(tokenReceived);
     }
 }
 
 public sealed class TemplateBuilderTests
 {
+    [Scenario("Template Create NullStep Throws")]
     [Fact]
     public void Template_Create_NullStep_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             Template<int, int>.Create(null!));
     }
 
+    [Scenario("Template TryExecute Synchronized Success")]
     [Fact]
     public void Template_TryExecute_Synchronized_Success()
     {
@@ -459,11 +481,12 @@ public sealed class TemplateBuilderTests
 
         var ok = tpl.TryExecute(21, out var result, out var error);
 
-        Assert.True(ok);
-        Assert.Equal(42, result);
-        Assert.Null(error);
+        ScenarioExpect.True(ok);
+        ScenarioExpect.Equal(42, result);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("Template TryExecute Synchronized Error")]
     [Fact]
     public void Template_TryExecute_Synchronized_Error()
     {
@@ -475,18 +498,20 @@ public sealed class TemplateBuilderTests
 
         var ok = tpl.TryExecute(1, out var result, out var error);
 
-        Assert.False(ok);
-        Assert.NotNull(error);
-        Assert.True(errorObserved);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.NotNull(error);
+        ScenarioExpect.True(errorObserved);
     }
 
+    [Scenario("ActionTemplate Create NullStep Throws")]
     [Fact]
     public void ActionTemplate_Create_NullStep_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionTemplate<int>.Create(null!));
     }
 
+    [Scenario("ActionTemplate TryExecute Synchronized Success")]
     [Fact]
     public void ActionTemplate_TryExecute_Synchronized_Success()
     {
@@ -497,11 +522,12 @@ public sealed class TemplateBuilderTests
 
         var ok = tpl.TryExecute(1, out var error);
 
-        Assert.True(ok);
-        Assert.Null(error);
-        Assert.True(executed);
+        ScenarioExpect.True(ok);
+        ScenarioExpect.Null(error);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionTemplate TryExecute Synchronized Error")]
     [Fact]
     public void ActionTemplate_TryExecute_Synchronized_Error()
     {
@@ -513,9 +539,9 @@ public sealed class TemplateBuilderTests
 
         var ok = tpl.TryExecute(1, out var error);
 
-        Assert.False(ok);
-        Assert.NotNull(error);
-        Assert.True(errorObserved);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.NotNull(error);
+        ScenarioExpect.True(errorObserved);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/TemplateMethodTests.cs
+++ b/test/PatternKit.Tests/Behavioral/TemplateMethodTests.cs
@@ -84,6 +84,7 @@ public sealed class TemplateMethodBuilderTests
         protected override void OnAfter(int context, string result) => Log.Add($"after:{context}:{result}");
     }
 
+    [Scenario("Synchronized Enforces Mutual Exclusion")]
     [Fact]
     public void Synchronized_Enforces_Mutual_Exclusion()
     {
@@ -92,9 +93,10 @@ public sealed class TemplateMethodBuilderTests
         var tasks = Enumerable.Range(0, 8).Select(_ => Task.Run(() => template.Execute(1))).ToArray();
         Task.WaitAll(tasks);
 
-        Assert.Equal(1, template.MaxConcurrent);
+        ScenarioExpect.Equal(1, template.MaxConcurrent);
     }
 
+    [Scenario("Synchronized Returns Correct Results")]
     [Fact]
     public void Synchronized_Returns_Correct_Results()
     {
@@ -102,9 +104,10 @@ public sealed class TemplateMethodBuilderTests
 
         var result = template.Execute(21);
 
-        Assert.Equal(42, result);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("Minimal Template Works")]
     [Fact]
     public void Minimal_Template_Works()
     {
@@ -112,9 +115,10 @@ public sealed class TemplateMethodBuilderTests
 
         var result = template.Execute("hello");
 
-        Assert.Equal(5, result);
+        ScenarioExpect.Equal(5, result);
     }
 
+    [Scenario("Hooks Called In Order")]
     [Fact]
     public void Hooks_Called_In_Order()
     {
@@ -122,12 +126,13 @@ public sealed class TemplateMethodBuilderTests
 
         var result = template.Execute(42);
 
-        Assert.Equal("result:42", result);
-        Assert.Equal(2, template.Log.Count);
-        Assert.Equal("before:42", template.Log[0]);
-        Assert.Equal("after:42:result:42", template.Log[1]);
+        ScenarioExpect.Equal("result:42", result);
+        ScenarioExpect.Equal(2, template.Log.Count);
+        ScenarioExpect.Equal("before:42", template.Log[0]);
+        ScenarioExpect.Equal("after:42:result:42", template.Log[1]);
     }
 
+    [Scenario("Multiple Executions Independent")]
     [Fact]
     public void Multiple_Executions_Independent()
     {
@@ -137,7 +142,7 @@ public sealed class TemplateMethodBuilderTests
         template.Execute(2);
         template.Execute(3);
 
-        Assert.Equal(6, template.Log.Count);
+        ScenarioExpect.Equal(6, template.Log.Count);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/TypeDispatcher/ActionTypeDispatcherTests.cs
+++ b/test/PatternKit.Tests/Behavioral/TypeDispatcher/ActionTypeDispatcherTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Behavioral.TypeDispatcher;
+using TinyBDD;
 
 namespace PatternKit.Tests.Behavioral.TypeDispatcher;
 
@@ -11,6 +12,7 @@ public sealed class ActionTypeDispatcherTests
 
     #region ActionTypeDispatcher<TBase> Tests
 
+    [Scenario("ActionTypeDispatcher Dispatches To Correct Handler")]
     [Fact]
     public void ActionTypeDispatcher_Dispatches_To_Correct_Handler()
     {
@@ -23,10 +25,11 @@ public sealed class ActionTypeDispatcherTests
         dispatcher.Dispatch(new Circle { Radius = 5 });
         dispatcher.Dispatch(new Rectangle { Width = 3, Height = 4 });
 
-        Assert.Equal("circle-5", log[0]);
-        Assert.Equal("rect-3x4", log[1]);
+        ScenarioExpect.Equal("circle-5", log[0]);
+        ScenarioExpect.Equal("rect-3x4", log[1]);
     }
 
+    [Scenario("ActionTypeDispatcher Default Handler")]
     [Fact]
     public void ActionTypeDispatcher_Default_Handler()
     {
@@ -38,10 +41,11 @@ public sealed class ActionTypeDispatcherTests
 
         dispatcher.Dispatch(new Triangle());
 
-        Assert.Single(log);
-        Assert.Equal("default-Triangle", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default-Triangle", log[0]);
     }
 
+    [Scenario("ActionTypeDispatcher TryDispatch Returns True")]
     [Fact]
     public void ActionTypeDispatcher_TryDispatch_Returns_True()
     {
@@ -52,10 +56,11 @@ public sealed class ActionTypeDispatcherTests
 
         var result = dispatcher.TryDispatch(new Circle { Radius = 5 });
 
-        Assert.True(result);
-        Assert.Single(log);
+        ScenarioExpect.True(result);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("ActionTypeDispatcher TryDispatch Returns False When No Handler")]
     [Fact]
     public void ActionTypeDispatcher_TryDispatch_Returns_False_When_No_Handler()
     {
@@ -65,9 +70,10 @@ public sealed class ActionTypeDispatcherTests
 
         var result = dispatcher.TryDispatch(new Triangle());
 
-        Assert.False(result);
+        ScenarioExpect.False(result);
     }
 
+    [Scenario("ActionTypeDispatcher Throws When No Handler")]
     [Fact]
     public void ActionTypeDispatcher_Throws_When_No_Handler()
     {
@@ -75,10 +81,11 @@ public sealed class ActionTypeDispatcherTests
             .On<Circle>(c => { })
             .Build();
 
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             dispatcher.Dispatch(new Triangle()));
     }
 
+    [Scenario("ActionTypeDispatcher Registration Order Matters")]
     [Fact]
     public void ActionTypeDispatcher_Registration_Order_Matters()
     {
@@ -90,14 +97,15 @@ public sealed class ActionTypeDispatcherTests
 
         dispatcher.Dispatch(new Circle { Radius = 5 });
 
-        Assert.Single(log);
-        Assert.Equal("circle", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("circle", log[0]);
     }
 
     #endregion
 
     #region AsyncActionTypeDispatcher<TBase> Tests
 
+    [Scenario("AsyncActionTypeDispatcher Dispatches")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_Dispatches()
     {
@@ -110,10 +118,11 @@ public sealed class ActionTypeDispatcherTests
         await dispatcher.DispatchAsync(new Circle { Radius = 5 });
         await dispatcher.DispatchAsync(new Rectangle { Width = 3, Height = 4 });
 
-        Assert.Equal("circle-5", log[0]);
-        Assert.Equal("rect-3x4", log[1]);
+        ScenarioExpect.Equal("circle-5", log[0]);
+        ScenarioExpect.Equal("rect-3x4", log[1]);
     }
 
+    [Scenario("AsyncActionTypeDispatcher Async Handler")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_Async_Handler()
     {
@@ -128,10 +137,11 @@ public sealed class ActionTypeDispatcherTests
 
         await dispatcher.DispatchAsync(new Circle { Radius = 5 });
 
-        Assert.Single(log);
-        Assert.Equal("circle-5", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("circle-5", log[0]);
     }
 
+    [Scenario("AsyncActionTypeDispatcher Default Handler")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_Default_Handler()
     {
@@ -143,10 +153,11 @@ public sealed class ActionTypeDispatcherTests
 
         await dispatcher.DispatchAsync(new Triangle());
 
-        Assert.Single(log);
-        Assert.Equal("default-Triangle", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("default-Triangle", log[0]);
     }
 
+    [Scenario("AsyncActionTypeDispatcher TryDispatch Returns True")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_TryDispatch_Returns_True()
     {
@@ -157,10 +168,11 @@ public sealed class ActionTypeDispatcherTests
 
         var result = await dispatcher.TryDispatchAsync(new Circle { Radius = 5 });
 
-        Assert.True(result);
-        Assert.Single(log);
+        ScenarioExpect.True(result);
+        ScenarioExpect.Single(log);
     }
 
+    [Scenario("AsyncActionTypeDispatcher TryDispatch Returns False")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_TryDispatch_Returns_False()
     {
@@ -170,9 +182,10 @@ public sealed class ActionTypeDispatcherTests
 
         var result = await dispatcher.TryDispatchAsync(new Triangle());
 
-        Assert.False(result);
+        ScenarioExpect.False(result);
     }
 
+    [Scenario("AsyncActionTypeDispatcher Throws When No Handler")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_Throws_When_No_Handler()
     {
@@ -180,7 +193,7 @@ public sealed class ActionTypeDispatcherTests
             .On<Circle>(c => { })
             .Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             dispatcher.DispatchAsync(new Triangle()).AsTask());
     }
 
@@ -188,6 +201,7 @@ public sealed class ActionTypeDispatcherTests
 
     #region AsyncTypeDispatcher<TBase, TResult> Tests
 
+    [Scenario("AsyncTypeDispatcher Dispatches With Result")]
     [Fact]
     public async Task AsyncTypeDispatcher_Dispatches_With_Result()
     {
@@ -200,10 +214,11 @@ public sealed class ActionTypeDispatcherTests
         var circleArea = await dispatcher.DispatchAsync(new Circle { Radius = 2 });
         var rectArea = await dispatcher.DispatchAsync(new Rectangle { Width = 3, Height = 4 });
 
-        Assert.Equal(Math.PI * 4, circleArea);
-        Assert.Equal(12, rectArea);
+        ScenarioExpect.Equal(Math.PI * 4, circleArea);
+        ScenarioExpect.Equal(12, rectArea);
     }
 
+    [Scenario("AsyncTypeDispatcher Async Handler")]
     [Fact]
     public async Task AsyncTypeDispatcher_Async_Handler()
     {
@@ -217,9 +232,10 @@ public sealed class ActionTypeDispatcherTests
 
         var result = await dispatcher.DispatchAsync(new Circle { Radius = 5 });
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncTypeDispatcher Constant Handler")]
     [Fact]
     public async Task AsyncTypeDispatcher_Constant_Handler()
     {
@@ -229,9 +245,10 @@ public sealed class ActionTypeDispatcherTests
 
         var result = await dispatcher.DispatchAsync(new Circle { Radius = 5 });
 
-        Assert.Equal(42.0, result);
+        ScenarioExpect.Equal(42.0, result);
     }
 
+    [Scenario("AsyncTypeDispatcher TryDispatch Returns Result")]
     [Fact]
     public async Task AsyncTypeDispatcher_TryDispatch_Returns_Result()
     {
@@ -241,10 +258,11 @@ public sealed class ActionTypeDispatcherTests
 
         var (success, result) = await dispatcher.TryDispatchAsync(new Circle { Radius = 5 });
 
-        Assert.True(success);
-        Assert.Equal(10, result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncTypeDispatcher TryDispatch Returns False When No Handler")]
     [Fact]
     public async Task AsyncTypeDispatcher_TryDispatch_Returns_False_When_No_Handler()
     {
@@ -254,10 +272,11 @@ public sealed class ActionTypeDispatcherTests
 
         var (success, result) = await dispatcher.TryDispatchAsync(new Triangle());
 
-        Assert.False(success);
-        Assert.Equal(default, result);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal(default, result);
     }
 
+    [Scenario("AsyncTypeDispatcher Throws When No Handler")]
     [Fact]
     public async Task AsyncTypeDispatcher_Throws_When_No_Handler()
     {
@@ -265,10 +284,11 @@ public sealed class ActionTypeDispatcherTests
             .On<Circle>(c => c.Radius)
             .Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(() =>
             dispatcher.DispatchAsync(new Triangle()).AsTask());
     }
 
+    [Scenario("AsyncTypeDispatcher Default Handler")]
     [Fact]
     public async Task AsyncTypeDispatcher_Default_Handler()
     {
@@ -279,13 +299,14 @@ public sealed class ActionTypeDispatcherTests
 
         var result = await dispatcher.DispatchAsync(new Triangle());
 
-        Assert.Equal("default-Triangle", result);
+        ScenarioExpect.Equal("default-Triangle", result);
     }
 
     #endregion
 
     #region Null Behavior Tests
 
+    [Scenario("ActionTypeDispatcher Null Handler Throws At Dispatch")]
     [Fact]
     public void ActionTypeDispatcher_Null_Handler_Throws_At_Dispatch()
     {
@@ -294,10 +315,11 @@ public sealed class ActionTypeDispatcherTests
             .On<Circle>(null!)
             .Build();
 
-        Assert.Throws<NullReferenceException>(() =>
+        ScenarioExpect.Throws<NullReferenceException>(() =>
             dispatcher.Dispatch(new Circle { Radius = 5 }));
     }
 
+    [Scenario("ActionTypeDispatcher Null Default Throws At Dispatch")]
     [Fact]
     public void ActionTypeDispatcher_Null_Default_Throws_At_Dispatch()
     {
@@ -306,10 +328,11 @@ public sealed class ActionTypeDispatcherTests
             .Default((Action<Shape>)null!)
             .Build();
 
-        Assert.Throws<NullReferenceException>(() =>
+        ScenarioExpect.Throws<NullReferenceException>(() =>
             dispatcher.Dispatch(new Triangle()));
     }
 
+    [Scenario("AsyncActionTypeDispatcher Null Handler Throws At Dispatch")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_Null_Handler_Throws_At_Dispatch()
     {
@@ -317,10 +340,11 @@ public sealed class ActionTypeDispatcherTests
             .On<Circle>((Action<Circle>)null!)
             .Build();
 
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
+        await ScenarioExpect.ThrowsAsync<NullReferenceException>(() =>
             dispatcher.DispatchAsync(new Circle { Radius = 5 }).AsTask());
     }
 
+    [Scenario("AsyncActionTypeDispatcher Null Default Throws At Dispatch")]
     [Fact]
     public async Task AsyncActionTypeDispatcher_Null_Default_Throws_At_Dispatch()
     {
@@ -328,10 +352,11 @@ public sealed class ActionTypeDispatcherTests
             .Default((Action<Shape>)null!)
             .Build();
 
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
+        await ScenarioExpect.ThrowsAsync<NullReferenceException>(() =>
             dispatcher.DispatchAsync(new Triangle()).AsTask());
     }
 
+    [Scenario("AsyncTypeDispatcher Null Handler Throws At Dispatch")]
     [Fact]
     public async Task AsyncTypeDispatcher_Null_Handler_Throws_At_Dispatch()
     {
@@ -339,10 +364,11 @@ public sealed class ActionTypeDispatcherTests
             .On<Circle>((Func<Circle, double>)null!)
             .Build();
 
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
+        await ScenarioExpect.ThrowsAsync<NullReferenceException>(() =>
             dispatcher.DispatchAsync(new Circle { Radius = 5 }).AsTask());
     }
 
+    [Scenario("AsyncTypeDispatcher Null Default Throws At Dispatch")]
     [Fact]
     public async Task AsyncTypeDispatcher_Null_Default_Throws_At_Dispatch()
     {
@@ -350,7 +376,7 @@ public sealed class ActionTypeDispatcherTests
             .Default((Func<Shape, double>)null!)
             .Build();
 
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
+        await ScenarioExpect.ThrowsAsync<NullReferenceException>(() =>
             dispatcher.DispatchAsync(new Triangle()).AsTask());
     }
 

--- a/test/PatternKit.Tests/Behavioral/TypeDispatcherTests.cs
+++ b/test/PatternKit.Tests/Behavioral/TypeDispatcherTests.cs
@@ -150,6 +150,7 @@ public sealed class TypeDispatcherBuilderTests
     private sealed record Add(Node Left, Node Right) : Node;
     private sealed record Neg(Node Inner) : Node;
 
+    [Scenario("Default Func Overload Works")]
     [Fact]
     public void Default_Func_Overload_Works()
     {
@@ -161,10 +162,11 @@ public sealed class TypeDispatcherBuilderTests
         var result1 = dispatcher.Dispatch(new Number(5));
         var result2 = dispatcher.Dispatch(new Neg(new Number(1)));
 
-        Assert.Equal("num:5", result1);
-        Assert.Equal("default:Neg", result2);
+        ScenarioExpect.Equal("num:5", result1);
+        ScenarioExpect.Equal("default:Neg", result2);
     }
 
+    [Scenario("Default Handler Delegate Works")]
     [Fact]
     public void Default_Handler_Delegate_Works()
     {
@@ -175,9 +177,10 @@ public sealed class TypeDispatcherBuilderTests
 
         var result = dispatcher.Dispatch(new Add(new Number(1), new Number(2)));
 
-        Assert.Equal("handler:Add", result);
+        ScenarioExpect.Equal("handler:Add", result);
     }
 
+    [Scenario("TryDispatch WithDefault ReturnsTrue")]
     [Fact]
     public void TryDispatch_WithDefault_ReturnsTrue()
     {
@@ -187,10 +190,11 @@ public sealed class TypeDispatcherBuilderTests
 
         var success = dispatcher.TryDispatch(new Neg(new Number(1)), out var result);
 
-        Assert.True(success);
-        Assert.Equal("fallback", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("fallback", result);
     }
 
+    [Scenario("TryDispatch MatchesHandler ReturnsTrue")]
     [Fact]
     public void TryDispatch_MatchesHandler_ReturnsTrue()
     {
@@ -200,10 +204,11 @@ public sealed class TypeDispatcherBuilderTests
 
         var success = dispatcher.TryDispatch(new Number(42), out var result);
 
-        Assert.True(success);
-        Assert.Equal("matched:42", result);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("matched:42", result);
     }
 
+    [Scenario("TryDispatch NoMatchNoDefault ReturnsFalse")]
     [Fact]
     public void TryDispatch_NoMatchNoDefault_ReturnsFalse()
     {
@@ -213,10 +218,11 @@ public sealed class TypeDispatcherBuilderTests
 
         var success = dispatcher.TryDispatch(new Neg(new Number(1)), out var result);
 
-        Assert.False(success);
-        Assert.Null(result);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("Multiple Handlers FirstMatchWins")]
     [Fact]
     public void Multiple_Handlers_FirstMatchWins()
     {
@@ -228,11 +234,12 @@ public sealed class TypeDispatcherBuilderTests
 
         var result = dispatcher.Dispatch(new Number(5));
 
-        Assert.Equal("number", result);
-        Assert.Single(log);
-        Assert.Equal("number", log[0]);
+        ScenarioExpect.Equal("number", result);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("number", log[0]);
     }
 
+    [Scenario("Empty Dispatcher TryDispatch ReturnsFalse")]
     [Fact]
     public void Empty_Dispatcher_TryDispatch_ReturnsFalse()
     {
@@ -240,17 +247,19 @@ public sealed class TypeDispatcherBuilderTests
 
         var success = dispatcher.TryDispatch(new Number(1), out _);
 
-        Assert.False(success);
+        ScenarioExpect.False(success);
     }
 
+    [Scenario("Empty Dispatcher Dispatch Throws")]
     [Fact]
     public void Empty_Dispatcher_Dispatch_Throws()
     {
         var dispatcher = TypeDispatcher<Node, string>.Create().Build();
 
-        Assert.Throws<InvalidOperationException>(() => dispatcher.Dispatch(new Number(1)));
+        ScenarioExpect.Throws<InvalidOperationException>(() => dispatcher.Dispatch(new Number(1)));
     }
 
+    [Scenario("Constant On Multiple Types")]
     [Fact]
     public void Constant_On_Multiple_Types()
     {
@@ -260,11 +269,12 @@ public sealed class TypeDispatcherBuilderTests
             .On<Neg>(3)
             .Build();
 
-        Assert.Equal(1, dispatcher.Dispatch(new Number(100)));
-        Assert.Equal(2, dispatcher.Dispatch(new Add(new Number(1), new Number(2))));
-        Assert.Equal(3, dispatcher.Dispatch(new Neg(new Number(1))));
+        ScenarioExpect.Equal(1, dispatcher.Dispatch(new Number(100)));
+        ScenarioExpect.Equal(2, dispatcher.Dispatch(new Add(new Number(1), new Number(2))));
+        ScenarioExpect.Equal(3, dispatcher.Dispatch(new Neg(new Number(1))));
     }
 
+    [Scenario("Handler Receives Correct Type")]
     [Fact]
     public void Handler_Receives_Correct_Type()
     {
@@ -275,11 +285,12 @@ public sealed class TypeDispatcherBuilderTests
 
         dispatcher.Dispatch(new Number(42));
 
-        Assert.NotNull(captured);
-        Assert.IsType<Number>(captured);
-        Assert.Equal(42, ((Number)captured).Value);
+        ScenarioExpect.NotNull(captured);
+        ScenarioExpect.IsType<Number>(captured);
+        ScenarioExpect.Equal(42, ((Number)captured).Value);
     }
 
+    [Scenario("Null Node Works With Default")]
     [Fact]
     public void Null_Node_Works_With_Default()
     {
@@ -289,7 +300,7 @@ public sealed class TypeDispatcherBuilderTests
 
         var result = dispatcher.Dispatch(null);
 
-        Assert.Equal("null", result);
+        ScenarioExpect.Equal("null", result);
     }
 }
 

--- a/test/PatternKit.Tests/Behavioral/Visitor/VisitorBaseTests.cs
+++ b/test/PatternKit.Tests/Behavioral/Visitor/VisitorBaseTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Behavioral.Visitor;
+using TinyBDD;
 
 namespace PatternKit.Tests.Behavioral.Visitor;
 
@@ -55,6 +56,7 @@ public sealed class VisitorBaseTests
 
     #endregion
 
+    [Scenario("VisitorBase Visit NumberExpr")]
     [Fact]
     public void VisitorBase_Visit_NumberExpr()
     {
@@ -63,9 +65,10 @@ public sealed class VisitorBaseTests
 
         var result = visitor.Visit(expr);
 
-        Assert.Equal(42, result);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("VisitorBase Visit AddExpr")]
     [Fact]
     public void VisitorBase_Visit_AddExpr()
     {
@@ -78,9 +81,10 @@ public sealed class VisitorBaseTests
 
         var result = visitor.Visit(expr);
 
-        Assert.Equal(30, result);
+        ScenarioExpect.Equal(30, result);
     }
 
+    [Scenario("VisitorBase Visit NestedAddExpr")]
     [Fact]
     public void VisitorBase_Visit_NestedAddExpr()
     {
@@ -97,19 +101,21 @@ public sealed class VisitorBaseTests
 
         var result = visitor.Visit(expr);
 
-        Assert.Equal(6, result);
+        ScenarioExpect.Equal(6, result);
     }
 
+    [Scenario("VisitorBase VisitDefault ThrowsNotSupported")]
     [Fact]
     public void VisitorBase_VisitDefault_ThrowsNotSupported()
     {
         var visitor = new EvaluatorVisitor();
         var unknown = new UnknownExpr();
 
-        var ex = Assert.Throws<NotSupportedException>(() => visitor.Visit(unknown));
-        Assert.Contains("UnknownExpr", ex.Message);
+        var ex = ScenarioExpect.Throws<NotSupportedException>(() => visitor.Visit(unknown));
+        ScenarioExpect.Contains("UnknownExpr", ex.Message);
     }
 
+    [Scenario("VisitorBase VisitDefault Override ReturnsCustomValue")]
     [Fact]
     public void VisitorBase_VisitDefault_Override_ReturnsCustomValue()
     {
@@ -118,7 +124,7 @@ public sealed class VisitorBaseTests
 
         var result = visitor.Visit(unknown);
 
-        Assert.Equal(-1, result);
+        ScenarioExpect.Equal(-1, result);
     }
 }
 
@@ -190,6 +196,7 @@ public sealed class ActionVisitorBaseTests
 
     #endregion
 
+    [Scenario("ActionVisitorBase Visit TextNode")]
     [Fact]
     public void ActionVisitorBase_Visit_TextNode()
     {
@@ -198,10 +205,11 @@ public sealed class ActionVisitorBaseTests
 
         visitor.Visit(node);
 
-        Assert.Single(visitor.Output);
-        Assert.Equal("Hello", visitor.Output[0]);
+        ScenarioExpect.Single(visitor.Output);
+        ScenarioExpect.Equal("Hello", visitor.Output[0]);
     }
 
+    [Scenario("ActionVisitorBase Visit ContainerNode")]
     [Fact]
     public void ActionVisitorBase_Visit_ContainerNode()
     {
@@ -217,19 +225,21 @@ public sealed class ActionVisitorBaseTests
 
         visitor.Visit(node);
 
-        Assert.Equal(new[] { "[", "A", "B", "]" }, visitor.Output);
+        ScenarioExpect.Equal(new[] { "[", "A", "B", "]" }, visitor.Output);
     }
 
+    [Scenario("ActionVisitorBase VisitDefault ThrowsNotSupported")]
     [Fact]
     public void ActionVisitorBase_VisitDefault_ThrowsNotSupported()
     {
         var visitor = new PrintVisitor();
         var unknown = new UnknownNode();
 
-        var ex = Assert.Throws<NotSupportedException>(() => visitor.Visit(unknown));
-        Assert.Contains("UnknownNode", ex.Message);
+        var ex = ScenarioExpect.Throws<NotSupportedException>(() => visitor.Visit(unknown));
+        ScenarioExpect.Contains("UnknownNode", ex.Message);
     }
 
+    [Scenario("ActionVisitorBase VisitDefault Override HandlesUnknown")]
     [Fact]
     public void ActionVisitorBase_VisitDefault_Override_HandlesUnknown()
     {
@@ -238,8 +248,8 @@ public sealed class ActionVisitorBaseTests
 
         visitor.Visit(unknown);
 
-        Assert.Single(visitor.Output);
-        Assert.Equal("unknown", visitor.Output[0]);
+        ScenarioExpect.Single(visitor.Output);
+        ScenarioExpect.Equal("unknown", visitor.Output[0]);
     }
 }
 

--- a/test/PatternKit.Tests/Common/OptionTests.cs
+++ b/test/PatternKit.Tests/Common/OptionTests.cs
@@ -1,101 +1,115 @@
 using PatternKit.Common;
+using TinyBDD;
 
 namespace PatternKit.Tests.Common;
 
 public sealed class OptionTests
 {
+    [Scenario("Some HasValue ReturnsTrue")]
     [Fact]
     public void Some_HasValue_ReturnsTrue()
     {
         var option = Option<int>.Some(42);
-        Assert.True(option.HasValue);
+        ScenarioExpect.True(option.HasValue);
     }
 
+    [Scenario("Some ValueOrDefault ReturnsValue")]
     [Fact]
     public void Some_ValueOrDefault_ReturnsValue()
     {
         var option = Option<int>.Some(42);
-        Assert.Equal(42, option.ValueOrDefault);
+        ScenarioExpect.Equal(42, option.ValueOrDefault);
     }
 
+    [Scenario("None HasValue ReturnsFalse")]
     [Fact]
     public void None_HasValue_ReturnsFalse()
     {
         var option = Option<int>.None();
-        Assert.False(option.HasValue);
+        ScenarioExpect.False(option.HasValue);
     }
 
+    [Scenario("None ValueOrDefault ReturnsDefault")]
     [Fact]
     public void None_ValueOrDefault_ReturnsDefault()
     {
         var option = Option<int>.None();
-        Assert.Equal(0, option.ValueOrDefault);
+        ScenarioExpect.Equal(0, option.ValueOrDefault);
     }
 
+    [Scenario("OrDefault WithSome ReturnsValue")]
     [Fact]
     public void OrDefault_WithSome_ReturnsValue()
     {
         var option = Option<string>.Some("hello");
-        Assert.Equal("hello", option.OrDefault("fallback"));
+        ScenarioExpect.Equal("hello", option.OrDefault("fallback"));
     }
 
+    [Scenario("OrDefault WithNone ReturnsFallback")]
     [Fact]
     public void OrDefault_WithNone_ReturnsFallback()
     {
         var option = Option<string>.None();
-        Assert.Equal("fallback", option.OrDefault("fallback"));
+        ScenarioExpect.Equal("fallback", option.OrDefault("fallback"));
     }
 
+    [Scenario("OrDefault WithNone NoFallback ReturnsNull")]
     [Fact]
     public void OrDefault_WithNone_NoFallback_ReturnsNull()
     {
         var option = Option<string>.None();
-        Assert.Null(option.OrDefault());
+        ScenarioExpect.Null(option.OrDefault());
     }
 
+    [Scenario("OrThrow WithSome ReturnsValue")]
     [Fact]
     public void OrThrow_WithSome_ReturnsValue()
     {
         var option = Option<int>.Some(42);
-        Assert.Equal(42, option.OrThrow());
+        ScenarioExpect.Equal(42, option.OrThrow());
     }
 
+    [Scenario("OrThrow WithNone Throws")]
     [Fact]
     public void OrThrow_WithNone_Throws()
     {
         var option = Option<int>.None();
-        var ex = Assert.Throws<InvalidOperationException>(() => option.OrThrow());
-        Assert.Equal("No value.", ex.Message);
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() => option.OrThrow());
+        ScenarioExpect.Equal("No value.", ex.Message);
     }
 
+    [Scenario("OrThrow WithNone CustomMessage Throws")]
     [Fact]
     public void OrThrow_WithNone_CustomMessage_Throws()
     {
         var option = Option<int>.None();
-        var ex = Assert.Throws<InvalidOperationException>(() => option.OrThrow("Custom error"));
-        Assert.Equal("Custom error", ex.Message);
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() => option.OrThrow("Custom error"));
+        ScenarioExpect.Equal("Custom error", ex.Message);
     }
 
+    [Scenario("Map WithSome TransformsValue")]
     [Fact]
     public void Map_WithSome_TransformsValue()
     {
         var option = Option<int>.Some(5);
         var mapped = option.Map(x => x * 2);
 
-        Assert.True(mapped.HasValue);
-        Assert.Equal(10, mapped.ValueOrDefault);
+        ScenarioExpect.True(mapped.HasValue);
+        ScenarioExpect.Equal(10, mapped.ValueOrDefault);
     }
 
+    [Scenario("Map WithNone ReturnsNone")]
     [Fact]
     public void Map_WithNone_ReturnsNone()
     {
         var option = Option<int>.None();
         var mapped = option.Map(x => x * 2);
 
-        Assert.False(mapped.HasValue);
-        Assert.Equal(0, mapped.ValueOrDefault);
+        ScenarioExpect.False(mapped.HasValue);
+        ScenarioExpect.Equal(0, mapped.ValueOrDefault);
     }
 
+    [Scenario("Map ChainedTransformations")]
     [Fact]
     public void Map_ChainedTransformations()
     {
@@ -106,65 +120,72 @@ public sealed class OptionTests
             .Map(s => $"Result: {s}")
             .OrDefault("nothing");
 
-        Assert.Equal("Result: 10", result);
+        ScenarioExpect.Equal("Result: 10", result);
     }
 
+    [Scenario("Some WithNull StillHasValue")]
     [Fact]
     public void Some_WithNull_StillHasValue()
     {
         var option = Option<string>.Some(null);
-        Assert.True(option.HasValue);
-        Assert.Null(option.ValueOrDefault);
+        ScenarioExpect.True(option.HasValue);
+        ScenarioExpect.Null(option.ValueOrDefault);
     }
 
+    [Scenario("Map WithNullResult ReturnsSomeNull")]
     [Fact]
     public void Map_WithNullResult_ReturnsSomeNull()
     {
         var option = Option<string>.Some("test");
         var mapped = option.Map<string?>(_ => null);
 
-        Assert.True(mapped.HasValue);
-        Assert.Null(mapped.ValueOrDefault);
+        ScenarioExpect.True(mapped.HasValue);
+        ScenarioExpect.Null(mapped.ValueOrDefault);
     }
 
+    [Scenario("Some ValueType Works")]
     [Fact]
     public void Some_ValueType_Works()
     {
         var option = Option<DateTime>.Some(DateTime.UnixEpoch);
-        Assert.True(option.HasValue);
-        Assert.Equal(DateTime.UnixEpoch, option.ValueOrDefault);
+        ScenarioExpect.True(option.HasValue);
+        ScenarioExpect.Equal(DateTime.UnixEpoch, option.ValueOrDefault);
     }
 
+    [Scenario("None ValueType ReturnsDefaultValue")]
     [Fact]
     public void None_ValueType_ReturnsDefaultValue()
     {
         var option = Option<DateTime>.None();
-        Assert.False(option.HasValue);
-        Assert.Equal(default(DateTime), option.ValueOrDefault);
+        ScenarioExpect.False(option.HasValue);
+        ScenarioExpect.Equal(default(DateTime), option.ValueOrDefault);
     }
 
+    [Scenario("Map TypeChange Works")]
     [Fact]
     public void Map_TypeChange_Works()
     {
         var option = Option<int>.Some(42);
         var mapped = option.Map(x => new { Value = x });
 
-        Assert.True(mapped.HasValue);
-        Assert.Equal(42, mapped.ValueOrDefault!.Value);
+        ScenarioExpect.True(mapped.HasValue);
+        ScenarioExpect.Equal(42, mapped.ValueOrDefault!.Value);
     }
 
+    [Scenario("OrDefault WithValue IgnoresFallback")]
     [Fact]
     public void OrDefault_WithValue_IgnoresFallback()
     {
         var option = Option<int>.Some(42);
-        Assert.Equal(42, option.OrDefault(999));
+        ScenarioExpect.Equal(42, option.OrDefault(999));
     }
 
+    [Scenario("OrThrow Null Message Uses Default")]
     [Fact]
     public void OrThrow_Null_Message_Uses_Default()
     {
         var option = Option<int>.None();
-        var ex = Assert.Throws<InvalidOperationException>(() => option.OrThrow(null));
-        Assert.Equal("No value.", ex.Message);
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() => option.OrThrow(null));
+        ScenarioExpect.Equal("No value.", ex.Message);
     }
 }

--- a/test/PatternKit.Tests/Creational/Builder/BranchBuilderTests.cs
+++ b/test/PatternKit.Tests/Creational/Builder/BranchBuilderTests.cs
@@ -49,17 +49,17 @@ public sealed class BranchBuilderTests(ITestOutputHelper output) : TinyBddXunitB
             })
             .Then("should have 2 predicates and 2 handlers in registration order", p =>
             {
-                Assert.Equal(2, p.Preds.Length);
-                Assert.Equal(2, p.Handlers.Length);
+                ScenarioExpect.Equal(2, p.Preds.Length);
+                ScenarioExpect.Equal(2, p.Handlers.Length);
 
                 // Invoke to prove order: first is IsEven -> true on 2, second IsPositive -> true on 1
                 var v2 = 2; var v1 = 1;
-                Assert.True(p.Preds[0](in v2));
-                Assert.True(p.Preds[1](in v1));
+                ScenarioExpect.True(p.Preds[0](in v2));
+                ScenarioExpect.True(p.Preds[1](in v1));
 
                 // Handlers return expected labels
-                Assert.Equal("even", p.Handlers[0](in v2));
-                Assert.Equal("pos", p.Handlers[1](in v1));
+                ScenarioExpect.Equal("even", p.Handlers[0](in v2));
+                ScenarioExpect.Equal("pos", p.Handlers[1](in v1));
                 return true;
             })
             .And("HasDefault=false and Default==fallback", p =>
@@ -135,15 +135,15 @@ public sealed class BranchBuilderTests(ITestOutputHelper output) : TinyBddXunitB
             })
             .Then("P1 has 1 pair; P2 has 2 pairs", t =>
             {
-                Assert.Single(t.P1.Preds);
-                Assert.Single(t.P1.Handlers);
-                Assert.Equal(2, t.P2.Preds.Length);
-                Assert.Equal(2, t.P2.Handlers.Length);
+                ScenarioExpect.Single(t.P1.Preds);
+                ScenarioExpect.Single(t.P1.Handlers);
+                ScenarioExpect.Equal(2, t.P2.Preds.Length);
+                ScenarioExpect.Equal(2, t.P2.Handlers.Length);
 
                 // Prove P1 refers to its own array instance (not resized/mutated):
                 var v2 = 2;
-                Assert.True(t.P1.Preds[0](in v2));
-                Assert.Equal("even", t.P1.Handlers[0](in v2));
+                ScenarioExpect.True(t.P1.Preds[0](in v2));
+                ScenarioExpect.Equal("even", t.P1.Handlers[0](in v2));
                 return true;
             })
             .AssertPassed();

--- a/test/PatternKit.Tests/Creational/Factory/FactoryTests.cs
+++ b/test/PatternKit.Tests/Creational/Factory/FactoryTests.cs
@@ -144,6 +144,7 @@ public sealed class FactoryTests(ITestOutputHelper output) : TinyBddXunitBase(ou
 
 public sealed class FactoryBuilderTests
 {
+    [Scenario("TryCreate ValidKey ReturnsTrue")]
     [Fact]
     public void TryCreate_ValidKey_ReturnsTrue()
     {
@@ -154,10 +155,11 @@ public sealed class FactoryBuilderTests
 
         var success = factory.TryCreate("one", out var value);
 
-        Assert.True(success);
-        Assert.Equal(1, value);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal(1, value);
     }
 
+    [Scenario("TryCreate MissingKey WithDefault ReturnsTrue")]
     [Fact]
     public void TryCreate_MissingKey_WithDefault_ReturnsTrue()
     {
@@ -168,10 +170,11 @@ public sealed class FactoryBuilderTests
 
         var success = factory.TryCreate("unknown", out var value);
 
-        Assert.True(success);
-        Assert.Equal(-1, value);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal(-1, value);
     }
 
+    [Scenario("TryCreate MissingKey NoDefault ReturnsFalse")]
     [Fact]
     public void TryCreate_MissingKey_NoDefault_ReturnsFalse()
     {
@@ -181,10 +184,11 @@ public sealed class FactoryBuilderTests
 
         var success = factory.TryCreate("unknown", out var value);
 
-        Assert.False(success);
-        Assert.Equal(default, value);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal(default, value);
     }
 
+    [Scenario("Create MultipleKeys AllWork")]
     [Fact]
     public void Create_MultipleKeys_AllWork()
     {
@@ -194,11 +198,12 @@ public sealed class FactoryBuilderTests
             .Map(3, () => "three")
             .Build();
 
-        Assert.Equal("one", factory.Create(1));
-        Assert.Equal("two", factory.Create(2));
-        Assert.Equal("three", factory.Create(3));
+        ScenarioExpect.Equal("one", factory.Create(1));
+        ScenarioExpect.Equal("two", factory.Create(2));
+        ScenarioExpect.Equal("three", factory.Create(3));
     }
 
+    [Scenario("Create EnumKey Works")]
     [Fact]
     public void Create_EnumKey_Works()
     {
@@ -208,11 +213,12 @@ public sealed class FactoryBuilderTests
             .Default(() => "Mid week")
             .Build();
 
-        Assert.Equal("Start of week", factory.Create(DayOfWeek.Monday));
-        Assert.Equal("End of week", factory.Create(DayOfWeek.Friday));
-        Assert.Equal("Mid week", factory.Create(DayOfWeek.Wednesday));
+        ScenarioExpect.Equal("Start of week", factory.Create(DayOfWeek.Monday));
+        ScenarioExpect.Equal("End of week", factory.Create(DayOfWeek.Friday));
+        ScenarioExpect.Equal("Mid week", factory.Create(DayOfWeek.Wednesday));
     }
 
+    [Scenario("Default CalledMultipleTimes LastWins")]
     [Fact]
     public void Default_CalledMultipleTimes_LastWins()
     {
@@ -222,9 +228,10 @@ public sealed class FactoryBuilderTests
             .Default(() => "third")
             .Build();
 
-        Assert.Equal("third", factory.Create("unknown"));
+        ScenarioExpect.Equal("third", factory.Create("unknown"));
     }
 
+    [Scenario("Factory WithInput ValidKey UsesMapping")]
     [Fact]
     public void Factory_WithInput_ValidKey_UsesMapping()
     {
@@ -234,9 +241,10 @@ public sealed class FactoryBuilderTests
 
         var result = factory.Create("repeat", 5);
 
-        Assert.Equal("xxxxx", result);
+        ScenarioExpect.Equal("xxxxx", result);
     }
 
+    [Scenario("Factory WithInput TryCreate ValidKey")]
     [Fact]
     public void Factory_WithInput_TryCreate_ValidKey()
     {
@@ -247,10 +255,11 @@ public sealed class FactoryBuilderTests
 
         var success = factory.TryCreate("triple", 10, out var value);
 
-        Assert.True(success);
-        Assert.Equal(30, value);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal(30, value);
     }
 
+    [Scenario("Factory WithInput TryCreate MissingKey WithDefault")]
     [Fact]
     public void Factory_WithInput_TryCreate_MissingKey_WithDefault()
     {
@@ -261,10 +270,11 @@ public sealed class FactoryBuilderTests
 
         var success = factory.TryCreate("noop", 42, out var value);
 
-        Assert.True(success);
-        Assert.Equal(42, value);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal(42, value);
     }
 
+    [Scenario("Factory WithInput Comparer Works")]
     [Fact]
     public void Factory_WithInput_Comparer_Works()
     {
@@ -274,9 +284,10 @@ public sealed class FactoryBuilderTests
 
         var result = factory.Create("MULTIPLY", 5);
 
-        Assert.Equal(50, result);
+        ScenarioExpect.Equal(50, result);
     }
 
+    [Scenario("Factory WithInput MultipleBuilds Independent")]
     [Fact]
     public void Factory_WithInput_MultipleBuilds_Independent()
     {
@@ -287,10 +298,11 @@ public sealed class FactoryBuilderTests
         builder.Map("add", (in int x) => x + 10);
         var f2 = builder.Build();
 
-        Assert.Equal(6, f1.Create("add", 5));
-        Assert.Equal(15, f2.Create("add", 5));
+        ScenarioExpect.Equal(6, f1.Create("add", 5));
+        ScenarioExpect.Equal(15, f2.Create("add", 5));
     }
 
+    [Scenario("Factory CreatorReturnsNull Works")]
     [Fact]
     public void Factory_CreatorReturnsNull_Works()
     {
@@ -300,9 +312,10 @@ public sealed class FactoryBuilderTests
 
         var result = factory.Create("null");
 
-        Assert.Null(result);
+        ScenarioExpect.Null(result);
     }
 
+    [Scenario("Factory WithComplexOutput Works")]
     [Fact]
     public void Factory_WithComplexOutput_Works()
     {
@@ -314,22 +327,24 @@ public sealed class FactoryBuilderTests
         var widget = factory.Create("widget");
         var gadget = factory.Create("gadget");
 
-        Assert.Equal("Widget", widget.Name);
-        Assert.Equal(10.0m, widget.Price);
-        Assert.Equal("Gadget", gadget.Name);
-        Assert.Equal(25.0m, gadget.Price);
+        ScenarioExpect.Equal("Widget", widget.Name);
+        ScenarioExpect.Equal(10.0m, widget.Price);
+        ScenarioExpect.Equal("Gadget", gadget.Name);
+        ScenarioExpect.Equal(25.0m, gadget.Price);
     }
 
     private record TestProduct(string Name, decimal Price);
 
+    [Scenario("Factory EmptyFactory Create Throws")]
     [Fact]
     public void Factory_EmptyFactory_Create_Throws()
     {
         var factory = Factory<string, string>.Create().Build();
 
-        Assert.Throws<InvalidOperationException>(() => factory.Create("any"));
+        ScenarioExpect.Throws<InvalidOperationException>(() => factory.Create("any"));
     }
 
+    [Scenario("Factory EmptyFactory TryCreate ReturnsFalse")]
     [Fact]
     public void Factory_EmptyFactory_TryCreate_ReturnsFalse()
     {
@@ -337,18 +352,20 @@ public sealed class FactoryBuilderTests
 
         var success = factory.TryCreate("any", out var value);
 
-        Assert.False(success);
-        Assert.Null(value);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(value);
     }
 
+    [Scenario("Factory WithInput EmptyFactory Create Throws")]
     [Fact]
     public void Factory_WithInput_EmptyFactory_Create_Throws()
     {
         var factory = Factory<string, int, int>.Create().Build();
 
-        Assert.Throws<InvalidOperationException>(() => factory.Create("any", 1));
+        ScenarioExpect.Throws<InvalidOperationException>(() => factory.Create("any", 1));
     }
 
+    [Scenario("Factory WithInput EmptyFactory TryCreate ReturnsFalse")]
     [Fact]
     public void Factory_WithInput_EmptyFactory_TryCreate_ReturnsFalse()
     {
@@ -356,10 +373,11 @@ public sealed class FactoryBuilderTests
 
         var success = factory.TryCreate("any", 1, out var value);
 
-        Assert.False(success);
-        Assert.Equal(default, value);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal(default, value);
     }
 
+    [Scenario("Factory IntKey Works")]
     [Fact]
     public void Factory_IntKey_Works()
     {
@@ -369,11 +387,12 @@ public sealed class FactoryBuilderTests
             .Default(() => "unknown")
             .Build();
 
-        Assert.Equal("one", factory.Create(1));
-        Assert.Equal("two", factory.Create(2));
-        Assert.Equal("unknown", factory.Create(999));
+        ScenarioExpect.Equal("one", factory.Create(1));
+        ScenarioExpect.Equal("two", factory.Create(2));
+        ScenarioExpect.Equal("unknown", factory.Create(999));
     }
 
+    [Scenario("Factory NullComparer UsesDefault")]
     [Fact]
     public void Factory_NullComparer_UsesDefault()
     {
@@ -381,9 +400,10 @@ public sealed class FactoryBuilderTests
             .Map("test", () => "value")
             .Build();
 
-        Assert.Equal("value", factory.Create("test"));
+        ScenarioExpect.Equal("value", factory.Create("test"));
     }
 
+    [Scenario("Factory WithInput NullComparer UsesDefault")]
     [Fact]
     public void Factory_WithInput_NullComparer_UsesDefault()
     {
@@ -391,7 +411,7 @@ public sealed class FactoryBuilderTests
             .Map("double", (in int x) => x * 2)
             .Build();
 
-        Assert.Equal(20, factory.Create("double", 10));
+        ScenarioExpect.Equal(20, factory.Create("double", 10));
     }
 }
 

--- a/test/PatternKit.Tests/Messaging/Mailboxes/MailboxTests.cs
+++ b/test/PatternKit.Tests/Messaging/Mailboxes/MailboxTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Mailboxes;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Mailboxes;
 
 public sealed class MailboxTests
 {
+    [Scenario("PostAsync ProcessesMessagesInOrder")]
     [Fact]
     public async Task PostAsync_ProcessesMessagesInOrder()
     {
@@ -21,13 +23,14 @@ public sealed class MailboxTests
         var second = await mailbox.PostAsync(Message<int>.Create(2));
         await mailbox.StopAsync();
 
-        Assert.True(first.Accepted);
-        Assert.True(second.Accepted);
-        Assert.Equal([1, 2], processed);
-        Assert.Equal(1, first.Sequence);
-        Assert.Equal(2, second.Sequence);
+        ScenarioExpect.True(first.Accepted);
+        ScenarioExpect.True(second.Accepted);
+        ScenarioExpect.Equal([1, 2], processed);
+        ScenarioExpect.Equal(1, first.Sequence);
+        ScenarioExpect.Equal(2, second.Sequence);
     }
 
+    [Scenario("PostAsync SerializesConcurrentPosts")]
     [Fact]
     public async Task PostAsync_SerializesConcurrentPosts()
     {
@@ -51,11 +54,12 @@ public sealed class MailboxTests
         var results = await Task.WhenAll(posts);
         await mailbox.StopAsync();
 
-        Assert.All(results, result => Assert.True(result.Accepted));
-        Assert.Equal(50, processed);
-        Assert.Equal(1, maxActive);
+        ScenarioExpect.All(results, result => ScenarioExpect.True(result.Accepted));
+        ScenarioExpect.Equal(50, processed);
+        ScenarioExpect.Equal(1, maxActive);
     }
 
+    [Scenario("BoundedRejectPolicy RejectsWhenFull")]
     [Fact]
     public async Task BoundedRejectPolicy_RejectsWhenFull()
     {
@@ -80,12 +84,13 @@ public sealed class MailboxTests
         release.SetResult(null);
         await mailbox.StopAsync();
 
-        Assert.True(first.Accepted);
-        Assert.True(second.Accepted);
-        Assert.Equal(MailboxPostStatus.Rejected, third.Status);
-        Assert.Equal("mailbox-full", third.Reason);
+        ScenarioExpect.True(first.Accepted);
+        ScenarioExpect.True(second.Accepted);
+        ScenarioExpect.Equal(MailboxPostStatus.Rejected, third.Status);
+        ScenarioExpect.Equal("mailbox-full", third.Reason);
     }
 
+    [Scenario("BoundedDropNewestPolicy DropsIncomingWhenFull")]
     [Fact]
     public async Task BoundedDropNewestPolicy_DropsIncomingWhenFull()
     {
@@ -112,12 +117,13 @@ public sealed class MailboxTests
         release.SetResult(null);
         await mailbox.StopAsync();
 
-        Assert.True(first.Accepted);
-        Assert.True(second.Accepted);
-        Assert.Equal(MailboxPostStatus.Dropped, third.Status);
-        Assert.Equal([1, 2], processed);
+        ScenarioExpect.True(first.Accepted);
+        ScenarioExpect.True(second.Accepted);
+        ScenarioExpect.Equal(MailboxPostStatus.Dropped, third.Status);
+        ScenarioExpect.Equal([1, 2], processed);
     }
 
+    [Scenario("BoundedDropOldestPolicy DropsOldestQueuedMessage")]
     [Fact]
     public async Task BoundedDropOldestPolicy_DropsOldestQueuedMessage()
     {
@@ -144,12 +150,13 @@ public sealed class MailboxTests
         release.SetResult(null);
         await mailbox.StopAsync();
 
-        Assert.True(first.Accepted);
-        Assert.True(second.Accepted);
-        Assert.True(third.Accepted);
-        Assert.Equal([1, 3], processed);
+        ScenarioExpect.True(first.Accepted);
+        ScenarioExpect.True(second.Accepted);
+        ScenarioExpect.True(third.Accepted);
+        ScenarioExpect.Equal([1, 3], processed);
     }
 
+    [Scenario("BoundedWaitPolicy WaitsForQueueSpace")]
     [Fact]
     public async Task BoundedWaitPolicy_WaitsForQueueSpace()
     {
@@ -172,15 +179,16 @@ public sealed class MailboxTests
         await mailbox.PostAsync(Message<int>.Create(2));
         var third = mailbox.PostAsync(Message<int>.Create(3)).AsTask();
 
-        Assert.False(third.IsCompleted);
+        ScenarioExpect.False(third.IsCompleted);
 
         release.SetResult(null);
         var result = await third;
         await mailbox.StopAsync();
 
-        Assert.True(result.Accepted);
+        ScenarioExpect.True(result.Accepted);
     }
 
+    [Scenario("StopAsync WhenDrainFalse DropsQueuedMessages")]
     [Fact]
     public async Task StopAsync_WhenDrainFalse_DropsQueuedMessages()
     {
@@ -205,9 +213,10 @@ public sealed class MailboxTests
         await mailbox.PostAsync(Message<int>.Create(3));
         await mailbox.StopAsync(drain: false);
 
-        Assert.Equal([1], processed);
+        ScenarioExpect.Equal([1], processed);
     }
 
+    [Scenario("ErrorPolicyContinue RoutesFailureAndContinues")]
     [Fact]
     public async Task ErrorPolicyContinue_RoutesFailureAndContinues()
     {
@@ -235,10 +244,11 @@ public sealed class MailboxTests
         await mailbox.PostAsync(Message<int>.Create(2));
         await mailbox.StopAsync();
 
-        Assert.Equal(["boom"], errors);
-        Assert.Equal([1, 2], processed);
+        ScenarioExpect.Equal(["boom"], errors);
+        ScenarioExpect.Equal([1, 2], processed);
     }
 
+    [Scenario("ErrorPolicyStop StopsAcceptingAndDropsQueuedMessages")]
     [Fact]
     public async Task ErrorPolicyStop_StopsAcceptingAndDropsQueuedMessages()
     {
@@ -260,10 +270,11 @@ public sealed class MailboxTests
 
         var afterFailure = await mailbox.PostAsync(Message<int>.Create(3));
 
-        Assert.Equal(MailboxPostStatus.Rejected, afterFailure.Status);
-        Assert.False(mailbox.IsAccepting);
+        ScenarioExpect.Equal(MailboxPostStatus.Rejected, afterFailure.Status);
+        ScenarioExpect.False(mailbox.IsAccepting);
     }
 
+    [Scenario("PostAsync PassesMessageContextAndCancellation")]
     [Fact]
     public async Task PostAsync_PassesMessageContextAndCancellation()
     {
@@ -283,10 +294,11 @@ public sealed class MailboxTests
         await mailbox.PostAsync(Message<int>.Create(1), context);
         await mailbox.StopAsync();
 
-        Assert.Equal("north", tenant);
-        Assert.True(observed.CanBeCanceled);
+        ScenarioExpect.Equal("north", tenant);
+        ScenarioExpect.True(observed.CanBeCanceled);
     }
 
+    [Scenario("OnEvent ReceivesLifecycleAndProcessingEvents")]
     [Fact]
     public async Task OnEvent_ReceivesLifecycleAndProcessingEvents()
     {
@@ -299,13 +311,14 @@ public sealed class MailboxTests
         await mailbox.PostAsync(Message<int>.Create(1));
         await mailbox.StopAsync();
 
-        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.Started);
-        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.Accepted && evt.Sequence == 1);
-        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.ProcessingStarted && evt.QueuedCount >= 0);
-        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.ProcessingCompleted && evt.Exception is null);
-        Assert.Contains(events, evt => evt.Kind == MailboxEventKind.Stopped);
+        ScenarioExpect.Contains(events, evt => evt.Kind == MailboxEventKind.Started);
+        ScenarioExpect.Contains(events, evt => evt.Kind == MailboxEventKind.Accepted && evt.Sequence == 1);
+        ScenarioExpect.Contains(events, evt => evt.Kind == MailboxEventKind.ProcessingStarted && evt.QueuedCount >= 0);
+        ScenarioExpect.Contains(events, evt => evt.Kind == MailboxEventKind.ProcessingCompleted && evt.Exception is null);
+        ScenarioExpect.Contains(events, evt => evt.Kind == MailboxEventKind.Stopped);
     }
 
+    [Scenario("StartAsync WhenAlreadyStarted IsNoOp")]
     [Fact]
     public async Task StartAsync_WhenAlreadyStarted_IsNoOp()
     {
@@ -316,9 +329,10 @@ public sealed class MailboxTests
         var result = await mailbox.PostAsync(Message<int>.Create(1));
         await mailbox.StopAsync();
 
-        Assert.True(result.Accepted);
+        ScenarioExpect.True(result.Accepted);
     }
 
+    [Scenario("OnEvent WhenSinkThrows DoesNotAffectProcessing")]
     [Fact]
     public async Task OnEvent_WhenSinkThrows_DoesNotAffectProcessing()
     {
@@ -339,10 +353,11 @@ public sealed class MailboxTests
         var second = await mailbox.PostAsync(Message<int>.Create(2));
         await mailbox.StopAsync();
 
-        Assert.True(first.Accepted);
-        Assert.True(second.Accepted);
+        ScenarioExpect.True(first.Accepted);
+        ScenarioExpect.True(second.Accepted);
     }
 
+    [Scenario("BoundedWaitPolicy RejectsAfterStop")]
     [Fact]
     public async Task BoundedWaitPolicy_RejectsAfterStop()
     {
@@ -354,10 +369,11 @@ public sealed class MailboxTests
         await mailbox.StopAsync();
         var result = await mailbox.PostAsync(Message<int>.Create(1));
 
-        Assert.Equal(MailboxPostStatus.Rejected, result.Status);
-        Assert.Equal("mailbox-not-accepting", result.Reason);
+        ScenarioExpect.Equal(MailboxPostStatus.Rejected, result.Status);
+        ScenarioExpect.Equal("mailbox-not-accepting", result.Reason);
     }
 
+    [Scenario("StopAsync ObservesStopCancellation")]
     [Fact]
     public async Task StopAsync_ObservesStopCancellation()
     {
@@ -376,12 +392,13 @@ public sealed class MailboxTests
         await started.Task;
         source.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await mailbox.StopAsync(cancellationToken: source.Token));
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () => await mailbox.StopAsync(cancellationToken: source.Token));
 
         release.SetResult(null);
         await mailbox.StopAsync();
     }
 
+    [Scenario("Properties ReportCapacityAndQueuedCount")]
     [Fact]
     public async Task Properties_ReportCapacityAndQueuedCount()
     {
@@ -403,13 +420,14 @@ public sealed class MailboxTests
         await started.Task;
         await mailbox.PostAsync(Message<int>.Create(2));
 
-        Assert.Equal(2, mailbox.Capacity);
-        Assert.Equal(1, mailbox.QueuedCount);
+        ScenarioExpect.Equal(2, mailbox.Capacity);
+        ScenarioExpect.Equal(1, mailbox.QueuedCount);
 
         release.SetResult(null);
         await mailbox.StopAsync();
     }
 
+    [Scenario("Dispose IsIdempotentAndRejectsLaterUse")]
     [Fact]
     public void Dispose_IsIdempotentAndRejectsLaterUse()
     {
@@ -418,9 +436,10 @@ public sealed class MailboxTests
         mailbox.Dispose();
         mailbox.Dispose();
 
-        Assert.Throws<ObjectDisposedException>(() => { _ = mailbox.StartAsync(); });
+        ScenarioExpect.Throws<ObjectDisposedException>(() => { _ = mailbox.StartAsync(); });
     }
 
+    [Scenario("PostAsync ObservesCanceledEnqueueToken")]
     [Fact]
     public async Task PostAsync_ObservesCanceledEnqueueToken()
     {
@@ -430,28 +449,30 @@ public sealed class MailboxTests
 
         await mailbox.StartAsync();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await mailbox.PostAsync(Message<int>.Create(1), cancellationToken: source.Token));
 
         await mailbox.StopAsync();
     }
 
+    [Scenario("Builder RejectsInvalidArguments")]
     [Fact]
     public void Builder_RejectsInvalidArguments()
     {
-        Assert.Throws<ArgumentNullException>(() => Mailbox<int>.Create(null!));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Mailbox<int>.Create((_, _, _) => default).Bounded(0));
-        Assert.Throws<ArgumentNullException>(() => Mailbox<int>.Create((_, _, _) => default).OnEvent(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => Mailbox<int>.Create(null!));
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() => Mailbox<int>.Create((_, _, _) => default).Bounded(0));
+        ScenarioExpect.Throws<ArgumentNullException>(() => Mailbox<int>.Create((_, _, _) => default).OnEvent(null!));
 
         var mailbox = Mailbox<int>.Create((_, _, _) => default).Unbounded().Build();
-        Assert.Null(mailbox.Capacity);
+        ScenarioExpect.Null(mailbox.Capacity);
     }
 
+    [Scenario("PostAsync RejectsNullMessage")]
     [Fact]
     public async Task PostAsync_RejectsNullMessage()
     {
         using var mailbox = Mailbox<int>.Create((_, _, _) => default).Build();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await mailbox.PostAsync(null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await mailbox.PostAsync(null!));
     }
 }

--- a/test/PatternKit.Tests/Messaging/MessageContextTests.cs
+++ b/test/PatternKit.Tests/Messaging/MessageContextTests.cs
@@ -1,32 +1,37 @@
 using PatternKit.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging;
 
 public sealed class MessageContextTests
 {
+    [Scenario("Empty HasEmptyHeadersAndItems")]
     [Fact]
     public void Empty_HasEmptyHeadersAndItems()
     {
-        Assert.Same(MessageHeaders.Empty, MessageContext.Empty.Headers);
-        Assert.Empty(MessageContext.Empty.Items);
+        ScenarioExpect.Same(MessageHeaders.Empty, MessageContext.Empty.Headers);
+        ScenarioExpect.Empty(MessageContext.Empty.Items);
     }
 
+    [Scenario("From CopiesMessageHeaders")]
     [Fact]
     public void From_CopiesMessageHeaders()
     {
         var message = Message<string>.Create("hello").WithCorrelationId("corr-1");
         var context = MessageContext.From(message);
 
-        Assert.Same(message.Headers, context.Headers);
-        Assert.Equal("corr-1", context.Headers.CorrelationId);
+        ScenarioExpect.Same(message.Headers, context.Headers);
+        ScenarioExpect.Equal("corr-1", context.Headers.CorrelationId);
     }
 
+    [Scenario("From RejectsNullMessage")]
     [Fact]
     public void From_RejectsNullMessage()
     {
-        Assert.Throws<ArgumentNullException>(() => MessageContext.From<string>(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => MessageContext.From<string>(null!));
     }
 
+    [Scenario("Constructor AcceptsHeadersAndCancellation")]
     [Fact]
     public void Constructor_AcceptsHeadersAndCancellation()
     {
@@ -35,75 +40,83 @@ public sealed class MessageContextTests
 
         var context = new MessageContext(headers, cts.Token);
 
-        Assert.Same(headers, context.Headers);
-        Assert.Equal(cts.Token, context.CancellationToken);
+        ScenarioExpect.Same(headers, context.Headers);
+        ScenarioExpect.Equal(cts.Token, context.CancellationToken);
     }
 
+    [Scenario("WithHeader ReturnsNewContext WithoutMutatingOriginal")]
     [Fact]
     public void WithHeader_ReturnsNewContext_WithoutMutatingOriginal()
     {
         var original = MessageContext.Empty;
         var updated = original.WithHeader("tenant", "north");
 
-        Assert.False(original.Headers.ContainsKey("tenant"));
-        Assert.Equal("north", updated.Headers.GetString("tenant"));
+        ScenarioExpect.False(original.Headers.ContainsKey("tenant"));
+        ScenarioExpect.Equal("north", updated.Headers.GetString("tenant"));
     }
 
+    [Scenario("WithHeaders ReplacesHeaders")]
     [Fact]
     public void WithHeaders_ReplacesHeaders()
     {
         var headers = MessageHeaders.Empty.WithCorrelationId("corr-1");
         var context = MessageContext.Empty.WithHeaders(headers);
 
-        Assert.Same(headers, context.Headers);
+        ScenarioExpect.Same(headers, context.Headers);
     }
 
+    [Scenario("WithHeaders RejectsNullHeaders")]
     [Fact]
     public void WithHeaders_RejectsNullHeaders()
     {
-        Assert.Throws<ArgumentNullException>(() => MessageContext.Empty.WithHeaders(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => MessageContext.Empty.WithHeaders(null!));
     }
 
+    [Scenario("WithItem ReturnsNewContext WithoutMutatingOriginal")]
     [Fact]
     public void WithItem_ReturnsNewContext_WithoutMutatingOriginal()
     {
         var original = MessageContext.Empty;
         var updated = original.WithItem("attempt", 2);
 
-        Assert.Empty(original.Items);
-        Assert.True(updated.TryGetItem<int>("attempt", out var attempt));
-        Assert.Equal(2, attempt);
+        ScenarioExpect.Empty(original.Items);
+        ScenarioExpect.True(updated.TryGetItem<int>("attempt", out var attempt));
+        ScenarioExpect.Equal(2, attempt);
     }
 
+    [Scenario("WithoutItem RemovesItem WithoutMutatingOriginal")]
     [Fact]
     public void WithoutItem_RemovesItem_WithoutMutatingOriginal()
     {
         var original = MessageContext.Empty.WithItem("attempt", 2);
         var updated = original.WithoutItem("attempt");
 
-        Assert.True(original.TryGetItem<int>("attempt", out _));
-        Assert.False(updated.TryGetItem<int>("attempt", out _));
+        ScenarioExpect.True(original.TryGetItem<int>("attempt", out _));
+        ScenarioExpect.False(updated.TryGetItem<int>("attempt", out _));
     }
 
+    [Scenario("WithoutItem MissingItem ReturnsSameInstance")]
     [Fact]
     public void WithoutItem_MissingItem_ReturnsSameInstance()
     {
         var context = MessageContext.Empty.WithItem("attempt", 2);
 
-        Assert.Same(context, context.WithoutItem("missing"));
+        ScenarioExpect.Same(context, context.WithoutItem("missing"));
     }
 
+    [Scenario("TryGetItem ReturnsFalseForMissingOrWrongType")]
     [Fact]
     public void TryGetItem_ReturnsFalseForMissingOrWrongType()
     {
         var context = MessageContext.Empty.WithItem("attempt", 2);
 
-        Assert.False(context.TryGetItem<int>("missing", out var missing));
-        Assert.False(context.TryGetItem<string>("attempt", out var wrongType));
-        Assert.Equal(0, missing);
-        Assert.Null(wrongType);
+        ScenarioExpect.False(context.TryGetItem<int>("missing", out var missing));
+        ScenarioExpect.False(context.TryGetItem<string>("attempt", out var wrongType));
+        ScenarioExpect.Equal(0, missing);
+        ScenarioExpect.Null(wrongType);
     }
 
+    [Scenario("WithCancellation ReturnsNewContextWithSameHeadersAndItems")]
     [Fact]
     public void WithCancellation_ReturnsNewContextWithSameHeadersAndItems()
     {
@@ -114,34 +127,37 @@ public sealed class MessageContextTests
 
         var updated = context.WithCancellation(cts.Token);
 
-        Assert.Equal(cts.Token, updated.CancellationToken);
-        Assert.Same(context.Headers, updated.Headers);
-        Assert.True(updated.TryGetItem<int>("attempt", out var attempt));
-        Assert.Equal(2, attempt);
+        ScenarioExpect.Equal(cts.Token, updated.CancellationToken);
+        ScenarioExpect.Same(context.Headers, updated.Headers);
+        ScenarioExpect.True(updated.TryGetItem<int>("attempt", out var attempt));
+        ScenarioExpect.Equal(2, attempt);
     }
 
+    [Scenario("Items AreReadOnlySnapshot")]
     [Fact]
     public void Items_AreReadOnlySnapshot()
     {
         var context = MessageContext.Empty.WithItem("attempt", 2);
 
-        Assert.Throws<NotSupportedException>(() =>
+        ScenarioExpect.Throws<NotSupportedException>(() =>
             ((IDictionary<string, object?>)context.Items).Add("other", 3));
     }
 
+    [Scenario("WithItem RejectsInvalidKeys")]
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
     public void WithItem_RejectsInvalidKeys(string key)
     {
-        Assert.Throws<ArgumentException>(() => MessageContext.Empty.WithItem(key, 1));
+        ScenarioExpect.Throws<ArgumentException>(() => MessageContext.Empty.WithItem(key, 1));
     }
 
+    [Scenario("WithoutItem RejectsInvalidKeys")]
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
     public void WithoutItem_RejectsInvalidKeys(string key)
     {
-        Assert.Throws<ArgumentException>(() => MessageContext.Empty.WithoutItem(key));
+        ScenarioExpect.Throws<ArgumentException>(() => MessageContext.Empty.WithoutItem(key));
     }
 }

--- a/test/PatternKit.Tests/Messaging/MessageHeadersTests.cs
+++ b/test/PatternKit.Tests/Messaging/MessageHeadersTests.cs
@@ -1,47 +1,53 @@
 using System.Collections;
 using PatternKit.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging;
 
 public sealed class MessageHeadersTests
 {
+    [Scenario("Empty HasNoValues")]
     [Fact]
     public void Empty_HasNoValues()
     {
-        Assert.Empty(MessageHeaders.Empty);
-        Assert.Null(MessageHeaders.Empty.MessageId);
+        ScenarioExpect.Empty(MessageHeaders.Empty);
+        ScenarioExpect.Null(MessageHeaders.Empty.MessageId);
     }
 
+    [Scenario("Constructor CreatesEmptyCollection")]
     [Fact]
     public void Constructor_CreatesEmptyCollection()
     {
         var headers = new MessageHeaders();
 
-        Assert.True(headers.Count == 0);
-        Assert.Empty(headers.Keys);
-        Assert.Empty(headers.Values);
+        ScenarioExpect.True(headers.Count == 0);
+        ScenarioExpect.Empty(headers.Keys);
+        ScenarioExpect.Empty(headers.Values);
     }
 
+    [Scenario("With ReturnsNewCollection WithoutMutatingOriginal")]
     [Fact]
     public void With_ReturnsNewCollection_WithoutMutatingOriginal()
     {
         var original = MessageHeaders.Empty;
         var updated = original.With("tenant", "north");
 
-        Assert.False(original.ContainsKey("tenant"));
-        Assert.True(updated.ContainsKey("tenant"));
-        Assert.Equal("north", updated.GetString("tenant"));
+        ScenarioExpect.False(original.ContainsKey("tenant"));
+        ScenarioExpect.True(updated.ContainsKey("tenant"));
+        ScenarioExpect.Equal("north", updated.GetString("tenant"));
     }
 
+    [Scenario("Headers AreCaseInsensitive")]
     [Fact]
     public void Headers_AreCaseInsensitive()
     {
         var headers = MessageHeaders.Empty.With("Correlation-Id", "corr-1");
 
-        Assert.True(headers.ContainsKey("correlation-id"));
-        Assert.Equal("corr-1", headers.CorrelationId);
+        ScenarioExpect.True(headers.ContainsKey("correlation-id"));
+        ScenarioExpect.Equal("corr-1", headers.CorrelationId);
     }
 
+    [Scenario("WellKnownHeaders AreExposedAsProperties")]
     [Fact]
     public void WellKnownHeaders_AreExposedAsProperties()
     {
@@ -56,44 +62,48 @@ public sealed class MessageHeadersTests
             .WithReplyTo("queue:reply")
             .WithTimestamp(timestamp);
 
-        Assert.Equal("msg-1", headers.MessageId);
-        Assert.Equal("corr-1", headers.CorrelationId);
-        Assert.Equal("cause-1", headers.CausationId);
-        Assert.Equal("idem-1", headers.IdempotencyKey);
-        Assert.Equal("application/json", headers.ContentType);
-        Assert.Equal("queue:reply", headers.ReplyTo);
-        Assert.Equal(timestamp, headers.Timestamp);
+        ScenarioExpect.Equal("msg-1", headers.MessageId);
+        ScenarioExpect.Equal("corr-1", headers.CorrelationId);
+        ScenarioExpect.Equal("cause-1", headers.CausationId);
+        ScenarioExpect.Equal("idem-1", headers.IdempotencyKey);
+        ScenarioExpect.Equal("application/json", headers.ContentType);
+        ScenarioExpect.Equal("queue:reply", headers.ReplyTo);
+        ScenarioExpect.Equal(timestamp, headers.Timestamp);
     }
 
+    [Scenario("Indexer And TryGetValue ReadExistingValue")]
     [Fact]
     public void Indexer_And_TryGetValue_ReadExistingValue()
     {
         var headers = MessageHeaders.Empty.With("tenant", "north");
 
-        Assert.Equal("north", headers["tenant"]);
-        Assert.True(headers.TryGetValue("tenant", out var value));
-        Assert.Equal("north", value);
+        ScenarioExpect.Equal("north", headers["tenant"]);
+        ScenarioExpect.True(headers.TryGetValue("tenant", out var value));
+        ScenarioExpect.Equal("north", value);
     }
 
+    [Scenario("Without RemovesExistingValue WithoutMutatingOriginal")]
     [Fact]
     public void Without_RemovesExistingValue_WithoutMutatingOriginal()
     {
         var original = MessageHeaders.Empty.With("tenant", "north");
         var updated = original.Without("tenant");
 
-        Assert.True(original.ContainsKey("tenant"));
-        Assert.False(updated.ContainsKey("tenant"));
-        Assert.Same(MessageHeaders.Empty, updated);
+        ScenarioExpect.True(original.ContainsKey("tenant"));
+        ScenarioExpect.False(updated.ContainsKey("tenant"));
+        ScenarioExpect.Same(MessageHeaders.Empty, updated);
     }
 
+    [Scenario("Without MissingValue ReturnsSameInstance")]
     [Fact]
     public void Without_MissingValue_ReturnsSameInstance()
     {
         var headers = MessageHeaders.Empty.With("tenant", "north");
 
-        Assert.Same(headers, headers.Without("missing"));
+        ScenarioExpect.Same(headers, headers.Without("missing"));
     }
 
+    [Scenario("Constructor CopiesInputDictionary")]
     [Fact]
     public void Constructor_CopiesInputDictionary()
     {
@@ -102,15 +112,17 @@ public sealed class MessageHeadersTests
 
         source["tenant"] = "south";
 
-        Assert.Equal("north", headers.GetString("tenant"));
+        ScenarioExpect.Equal("north", headers.GetString("tenant"));
     }
 
+    [Scenario("Constructor RejectsNullInput")]
     [Fact]
     public void Constructor_RejectsNullInput()
     {
-        Assert.Throws<ArgumentNullException>(() => new MessageHeaders(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new MessageHeaders(null!));
     }
 
+    [Scenario("Constructor RejectsInvalidHeaderNames")]
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
@@ -118,36 +130,40 @@ public sealed class MessageHeadersTests
     {
         var values = new[] { new KeyValuePair<string, object?>(name, "value") };
 
-        Assert.Throws<ArgumentException>(() => new MessageHeaders(values));
+        ScenarioExpect.Throws<ArgumentException>(() => new MessageHeaders(values));
     }
 
+    [Scenario("TryGet ReadsTypedValues")]
     [Fact]
     public void TryGet_ReadsTypedValues()
     {
         var headers = MessageHeaders.Empty.With("attempt", 3);
 
-        Assert.True(headers.TryGet<int>("attempt", out var attempt));
-        Assert.Equal(3, attempt);
-        Assert.False(headers.TryGet<string>("attempt", out _));
+        ScenarioExpect.True(headers.TryGet<int>("attempt", out var attempt));
+        ScenarioExpect.Equal(3, attempt);
+        ScenarioExpect.False(headers.TryGet<string>("attempt", out _));
     }
 
+    [Scenario("GetString ConvertsNonStringValues")]
     [Fact]
     public void GetString_ConvertsNonStringValues()
     {
         var headers = MessageHeaders.Empty.With("attempt", 3);
 
-        Assert.Equal("3", headers.GetString("attempt"));
+        ScenarioExpect.Equal("3", headers.GetString("attempt"));
     }
 
+    [Scenario("GetString ReturnsNullForMissingOrNullValues")]
     [Fact]
     public void GetString_ReturnsNullForMissingOrNullValues()
     {
         var headers = MessageHeaders.Empty.With("empty", null);
 
-        Assert.Null(headers.GetString("missing"));
-        Assert.Null(headers.GetString("empty"));
+        ScenarioExpect.Null(headers.GetString("missing"));
+        ScenarioExpect.Null(headers.GetString("empty"));
     }
 
+    [Scenario("TryGetGuid ReadsGuidAndStringValues")]
     [Fact]
     public void TryGetGuid_ReadsGuidAndStringValues()
     {
@@ -156,23 +172,25 @@ public sealed class MessageHeadersTests
             .With("typed", id)
             .With("text", id.ToString("D"));
 
-        Assert.True(headers.TryGetGuid("typed", out var typed));
-        Assert.True(headers.TryGetGuid("text", out var text));
-        Assert.Equal(id, typed);
-        Assert.Equal(id, text);
+        ScenarioExpect.True(headers.TryGetGuid("typed", out var typed));
+        ScenarioExpect.True(headers.TryGetGuid("text", out var text));
+        ScenarioExpect.Equal(id, typed);
+        ScenarioExpect.Equal(id, text);
     }
 
+    [Scenario("TryGetGuid ReturnsFalseForMissingOrInvalidValues")]
     [Fact]
     public void TryGetGuid_ReturnsFalseForMissingOrInvalidValues()
     {
         var headers = MessageHeaders.Empty.With("operation-id", "not-a-guid");
 
-        Assert.False(headers.TryGetGuid("missing", out var missing));
-        Assert.False(headers.TryGetGuid("operation-id", out var invalid));
-        Assert.Equal(Guid.Empty, missing);
-        Assert.Equal(Guid.Empty, invalid);
+        ScenarioExpect.False(headers.TryGetGuid("missing", out var missing));
+        ScenarioExpect.False(headers.TryGetGuid("operation-id", out var invalid));
+        ScenarioExpect.Equal(Guid.Empty, missing);
+        ScenarioExpect.Equal(Guid.Empty, invalid);
     }
 
+    [Scenario("TryGetDateTimeOffset ReadsDateTimeOffsetDateTimeAndStringValues")]
     [Fact]
     public void TryGetDateTimeOffset_ReadsDateTimeOffsetDateTimeAndStringValues()
     {
@@ -183,59 +201,64 @@ public sealed class MessageHeadersTests
             .With("date", dateTime)
             .With("text", timestamp.ToString("O"));
 
-        Assert.True(headers.TryGetDateTimeOffset("dto", out var dto));
-        Assert.True(headers.TryGetDateTimeOffset("date", out var date));
-        Assert.True(headers.TryGetDateTimeOffset("text", out var text));
-        Assert.Equal(timestamp, dto);
-        Assert.Equal(new DateTimeOffset(dateTime), date);
-        Assert.Equal(timestamp, text);
+        ScenarioExpect.True(headers.TryGetDateTimeOffset("dto", out var dto));
+        ScenarioExpect.True(headers.TryGetDateTimeOffset("date", out var date));
+        ScenarioExpect.True(headers.TryGetDateTimeOffset("text", out var text));
+        ScenarioExpect.Equal(timestamp, dto);
+        ScenarioExpect.Equal(new DateTimeOffset(dateTime), date);
+        ScenarioExpect.Equal(timestamp, text);
     }
 
+    [Scenario("Timestamp ReturnsNullWhenHeaderIsMissingOrInvalid")]
     [Fact]
     public void Timestamp_ReturnsNullWhenHeaderIsMissingOrInvalid()
     {
-        Assert.Null(MessageHeaders.Empty.Timestamp);
-        Assert.Null(MessageHeaders.Empty.With(MessageHeaderNames.Timestamp, "not-a-date").Timestamp);
+        ScenarioExpect.Null(MessageHeaders.Empty.Timestamp);
+        ScenarioExpect.Null(MessageHeaders.Empty.With(MessageHeaderNames.Timestamp, "not-a-date").Timestamp);
     }
 
+    [Scenario("TryGetDateTimeOffset ReturnsFalseForMissingOrInvalidValues")]
     [Fact]
     public void TryGetDateTimeOffset_ReturnsFalseForMissingOrInvalidValues()
     {
         var headers = MessageHeaders.Empty.With("accepted-at", "not-a-date");
 
-        Assert.False(headers.TryGetDateTimeOffset("missing", out var missing));
-        Assert.False(headers.TryGetDateTimeOffset("accepted-at", out var invalid));
-        Assert.Equal(default, missing);
-        Assert.Equal(default, invalid);
+        ScenarioExpect.False(headers.TryGetDateTimeOffset("missing", out var missing));
+        ScenarioExpect.False(headers.TryGetDateTimeOffset("accepted-at", out var invalid));
+        ScenarioExpect.Equal(default, missing);
+        ScenarioExpect.Equal(default, invalid);
     }
 
+    [Scenario("Enumerators ReturnHeaderPairs")]
     [Fact]
     public void Enumerators_ReturnHeaderPairs()
     {
         var headers = MessageHeaders.Empty.With("tenant", "north");
 
-        Assert.Contains(headers, pair => pair.Key == "tenant" && (string?)pair.Value == "north");
+        ScenarioExpect.Contains(headers, pair => pair.Key == "tenant" && (string?)pair.Value == "north");
 
         var enumerator = ((IEnumerable)headers).GetEnumerator();
-        Assert.True(enumerator.MoveNext());
-        var pair = Assert.IsType<KeyValuePair<string, object?>>(enumerator.Current);
-        Assert.Equal("tenant", pair.Key);
-        Assert.Equal("north", pair.Value);
+        ScenarioExpect.True(enumerator.MoveNext());
+        var pair = ScenarioExpect.IsType<KeyValuePair<string, object?>>(enumerator.Current);
+        ScenarioExpect.Equal("tenant", pair.Key);
+        ScenarioExpect.Equal("north", pair.Value);
     }
 
+    [Scenario("With RejectsInvalidHeaderNames")]
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
     public void With_RejectsInvalidHeaderNames(string name)
     {
-        Assert.Throws<ArgumentException>(() => MessageHeaders.Empty.With(name, "value"));
+        ScenarioExpect.Throws<ArgumentException>(() => MessageHeaders.Empty.With(name, "value"));
     }
 
+    [Scenario("WellKnownStringHeaders RejectInvalidValues")]
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
     public void WellKnownStringHeaders_RejectInvalidValues(string value)
     {
-        Assert.Throws<ArgumentException>(() => MessageHeaders.Empty.WithCorrelationId(value));
+        ScenarioExpect.Throws<ArgumentException>(() => MessageHeaders.Empty.WithCorrelationId(value));
     }
 }

--- a/test/PatternKit.Tests/Messaging/MessageTests.cs
+++ b/test/PatternKit.Tests/Messaging/MessageTests.cs
@@ -1,47 +1,53 @@
 using PatternKit.Messaging;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging;
 
 public sealed class MessageTests
 {
+    [Scenario("Create UsesEmptyHeaders")]
     [Fact]
     public void Create_UsesEmptyHeaders()
     {
         var message = Message<string>.Create("hello");
 
-        Assert.Equal("hello", message.Payload);
-        Assert.Same(MessageHeaders.Empty, message.Headers);
+        ScenarioExpect.Equal("hello", message.Payload);
+        ScenarioExpect.Same(MessageHeaders.Empty, message.Headers);
     }
 
+    [Scenario("WithPayload PreservesHeaders")]
     [Fact]
     public void WithPayload_PreservesHeaders()
     {
         var message = Message<string>.Create("hello").WithCorrelationId("corr-1");
         var mapped = message.WithPayload(42);
 
-        Assert.Equal(42, mapped.Payload);
-        Assert.Same(message.Headers, mapped.Headers);
-        Assert.Equal("corr-1", mapped.Headers.CorrelationId);
+        ScenarioExpect.Equal(42, mapped.Payload);
+        ScenarioExpect.Same(message.Headers, mapped.Headers);
+        ScenarioExpect.Equal("corr-1", mapped.Headers.CorrelationId);
     }
 
+    [Scenario("WithHeaders ReplacesHeaders")]
     [Fact]
     public void WithHeaders_ReplacesHeaders()
     {
         var headers = MessageHeaders.Empty.WithMessageId("msg-1");
         var message = Message<string>.Create("hello").WithHeaders(headers);
 
-        Assert.Same(headers, message.Headers);
-        Assert.Equal("msg-1", message.Headers.MessageId);
+        ScenarioExpect.Same(headers, message.Headers);
+        ScenarioExpect.Equal("msg-1", message.Headers.MessageId);
     }
 
+    [Scenario("WithHeaders RejectsNullHeaders")]
     [Fact]
     public void WithHeaders_RejectsNullHeaders()
     {
         var message = Message<string>.Create("hello");
 
-        Assert.Throws<ArgumentNullException>(() => message.WithHeaders(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => message.WithHeaders(null!));
     }
 
+    [Scenario("Enrich AppliesHeaderTransformation")]
     [Fact]
     public void Enrich_AppliesHeaderTransformation()
     {
@@ -50,26 +56,29 @@ public sealed class MessageTests
                 .WithCorrelationId("corr-1")
                 .WithCausationId("cause-1"));
 
-        Assert.Equal("corr-1", message.Headers.CorrelationId);
-        Assert.Equal("cause-1", message.Headers.CausationId);
+        ScenarioExpect.Equal("corr-1", message.Headers.CorrelationId);
+        ScenarioExpect.Equal("cause-1", message.Headers.CausationId);
     }
 
+    [Scenario("Enrich RejectsNullDelegate")]
     [Fact]
     public void Enrich_RejectsNullDelegate()
     {
         var message = Message<string>.Create("hello");
 
-        Assert.Throws<ArgumentNullException>(() => message.Enrich(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => message.Enrich(null!));
     }
 
+    [Scenario("Enrich RejectsNullHeaders")]
     [Fact]
     public void Enrich_RejectsNullHeaders()
     {
         var message = Message<string>.Create("hello");
 
-        Assert.Throws<InvalidOperationException>(() => message.Enrich(_ => null!));
+        ScenarioExpect.Throws<InvalidOperationException>(() => message.Enrich(_ => null!));
     }
 
+    [Scenario("WellKnownHeaderHelpers ReturnNewMessage")]
     [Fact]
     public void WellKnownHeaderHelpers_ReturnNewMessage()
     {
@@ -82,28 +91,30 @@ public sealed class MessageTests
             .WithContentType("application/json")
             .WithReplyTo("queue:reply");
 
-        Assert.Null(original.Headers.MessageId);
-        Assert.Equal("msg-1", updated.Headers.MessageId);
-        Assert.Equal("corr-1", updated.Headers.CorrelationId);
-        Assert.Equal("cause-1", updated.Headers.CausationId);
-        Assert.Equal("idem-1", updated.Headers.IdempotencyKey);
-        Assert.Equal("application/json", updated.Headers.ContentType);
-        Assert.Equal("queue:reply", updated.Headers.ReplyTo);
+        ScenarioExpect.Null(original.Headers.MessageId);
+        ScenarioExpect.Equal("msg-1", updated.Headers.MessageId);
+        ScenarioExpect.Equal("corr-1", updated.Headers.CorrelationId);
+        ScenarioExpect.Equal("cause-1", updated.Headers.CausationId);
+        ScenarioExpect.Equal("idem-1", updated.Headers.IdempotencyKey);
+        ScenarioExpect.Equal("application/json", updated.Headers.ContentType);
+        ScenarioExpect.Equal("queue:reply", updated.Headers.ReplyTo);
     }
 
+    [Scenario("WithHeader AddsCustomHeader")]
     [Fact]
     public void WithHeader_AddsCustomHeader()
     {
         var message = Message<string>.Create("hello").WithHeader("tenant", "north");
 
-        Assert.Equal("north", message.Headers.GetString("tenant"));
+        ScenarioExpect.Equal("north", message.Headers.GetString("tenant"));
     }
 
+    [Scenario("WithReplyTo AddsReplyAddress")]
     [Fact]
     public void WithReplyTo_AddsReplyAddress()
     {
         var message = Message<string>.Create("hello").WithReplyTo("queue:reply");
 
-        Assert.Equal("queue:reply", message.Headers.ReplyTo);
+        ScenarioExpect.Equal("queue:reply", message.Headers.ReplyTo);
     }
 }

--- a/test/PatternKit.Tests/Messaging/Reliability/IdempotentReceiverTests.cs
+++ b/test/PatternKit.Tests/Messaging/Reliability/IdempotentReceiverTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Reliability;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Reliability;
 
 public sealed class IdempotentReceiverTests
 {
+    [Scenario("HandleAsync ProcessesFirstMessageAndSuppressesDuplicate")]
     [Fact]
     public async Task HandleAsync_ProcessesFirstMessageAndSuppressesDuplicate()
     {
@@ -23,15 +25,16 @@ public sealed class IdempotentReceiverTests
         var first = await receiver.HandleAsync(message);
         var duplicate = await receiver.HandleAsync(message);
 
-        Assert.True(first.Processed);
-        Assert.Equal("processed:order-1", first.Result);
-        Assert.Equal(IdempotentReceiverStatus.Duplicate, duplicate.Status);
-        Assert.Equal("idem-1", duplicate.Key);
-        Assert.Equal(1, calls);
-        Assert.True(store.TryGet("idem-1", out var claim));
-        Assert.Equal(IdempotencyEntryStatus.Completed, claim!.Status);
+        ScenarioExpect.True(first.Processed);
+        ScenarioExpect.Equal("processed:order-1", first.Result);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.Duplicate, duplicate.Status);
+        ScenarioExpect.Equal("idem-1", duplicate.Key);
+        ScenarioExpect.Equal(1, calls);
+        ScenarioExpect.True(store.TryGet("idem-1", out var claim));
+        ScenarioExpect.Equal(IdempotencyEntryStatus.Completed, claim!.Status);
     }
 
+    [Scenario("HandleAsync ReplaysCompletedResultWhenConfigured")]
     [Fact]
     public async Task HandleAsync_ReplaysCompletedResultWhenConfigured()
     {
@@ -46,11 +49,12 @@ public sealed class IdempotentReceiverTests
         var first = await receiver.HandleAsync(message);
         var duplicate = await receiver.HandleAsync(message);
 
-        Assert.Equal(IdempotentReceiverStatus.Processed, first.Status);
-        Assert.Equal(IdempotentReceiverStatus.Replayed, duplicate.Status);
-        Assert.Equal("processed:order-1", duplicate.Result);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.Processed, first.Status);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.Replayed, duplicate.Status);
+        ScenarioExpect.Equal("processed:order-1", duplicate.Result);
     }
 
+    [Scenario("HandleAsync SuppressesDuplicateWhenStoredResultHasWrongType")]
     [Fact]
     public async Task HandleAsync_SuppressesDuplicateWhenStoredResultHasWrongType()
     {
@@ -65,10 +69,11 @@ public sealed class IdempotentReceiverTests
 
         var result = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1"));
 
-        Assert.Equal(IdempotentReceiverStatus.Duplicate, result.Status);
-        Assert.Null(result.Result);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.Duplicate, result.Status);
+        ScenarioExpect.Null(result.Result);
     }
 
+    [Scenario("HandleAsync RejectsMissingKeyByDefault")]
     [Fact]
     public async Task HandleAsync_RejectsMissingKeyByDefault()
     {
@@ -84,10 +89,11 @@ public sealed class IdempotentReceiverTests
 
         var result = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
 
-        Assert.Equal(IdempotentReceiverStatus.MissingKey, result.Status);
-        Assert.Equal(0, calls);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.MissingKey, result.Status);
+        ScenarioExpect.Equal(0, calls);
     }
 
+    [Scenario("HandleAsync CanProcessMissingKeyWhenConfigured")]
     [Fact]
     public async Task HandleAsync_CanProcessMissingKeyWhenConfigured()
     {
@@ -99,11 +105,12 @@ public sealed class IdempotentReceiverTests
 
         var result = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
 
-        Assert.Equal(IdempotentReceiverStatus.Processed, result.Status);
-        Assert.Null(result.Key);
-        Assert.Equal("processed", result.Result);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.Processed, result.Status);
+        ScenarioExpect.Null(result.Key);
+        ScenarioExpect.Equal("processed", result.Result);
     }
 
+    [Scenario("HandleAsync UsesCustomKeySelector")]
     [Fact]
     public async Task HandleAsync_UsesCustomKeySelector()
     {
@@ -116,11 +123,12 @@ public sealed class IdempotentReceiverTests
         var first = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
         var duplicate = await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")));
 
-        Assert.True(first.Processed);
-        Assert.Equal(IdempotentReceiverStatus.Duplicate, duplicate.Status);
-        Assert.Equal("order-1", duplicate.Key);
+        ScenarioExpect.True(first.Processed);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.Duplicate, duplicate.Status);
+        ScenarioExpect.Equal("order-1", duplicate.Key);
     }
 
+    [Scenario("HandleAsync PreservesSuppliedContextAndAppliesExplicitCancellation")]
     [Fact]
     public async Task HandleAsync_PreservesSuppliedContextAndAppliesExplicitCancellation()
     {
@@ -143,11 +151,12 @@ public sealed class IdempotentReceiverTests
             context,
             source.Token);
 
-        Assert.Equal(IdempotentReceiverStatus.Processed, result.Status);
-        Assert.Equal("north", observedTenant);
-        Assert.True(observedCancellation.CanBeCanceled);
+        ScenarioExpect.Equal(IdempotentReceiverStatus.Processed, result.Status);
+        ScenarioExpect.Equal("north", observedTenant);
+        ScenarioExpect.True(observedCancellation.CanBeCanceled);
     }
 
+    [Scenario("HandleAsync MarksFailedAndRethrowsHandlerFailure")]
     [Fact]
     public async Task HandleAsync_MarksFailedAndRethrowsHandlerFailure()
     {
@@ -157,14 +166,15 @@ public sealed class IdempotentReceiverTests
                 (_, _, _) => throw new InvalidOperationException("handler failed"))
             .Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () =>
             await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1")));
 
-        Assert.True(store.TryGet("idem-1", out var claim));
-        Assert.Equal(IdempotencyEntryStatus.Failed, claim!.Status);
-        Assert.Equal("handler failed", claim.FailureReason);
+        ScenarioExpect.True(store.TryGet("idem-1", out var claim));
+        ScenarioExpect.Equal(IdempotencyEntryStatus.Failed, claim!.Status);
+        ScenarioExpect.Equal("handler failed", claim.FailureReason);
     }
 
+    [Scenario("HandleAsync PropagatesStoreFailure")]
     [Fact]
     public async Task HandleAsync_PropagatesStoreFailure()
     {
@@ -173,10 +183,11 @@ public sealed class IdempotentReceiverTests
                 (_, _, _) => new ValueTask<string>("processed"))
             .Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () =>
             await receiver.HandleAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1")));
     }
 
+    [Scenario("HandleAsync PropagatesCancellation")]
     [Fact]
     public async Task HandleAsync_PropagatesCancellation()
     {
@@ -187,12 +198,13 @@ public sealed class IdempotentReceiverTests
                 (_, _, _) => new ValueTask<string>("processed"))
             .Build();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await receiver.HandleAsync(
                 Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1"),
                 cancellationToken: source.Token));
     }
 
+    [Scenario("InboxProcessor DelegatesToIdempotentReceiver")]
     [Fact]
     public async Task InboxProcessor_DelegatesToIdempotentReceiver()
     {
@@ -204,48 +216,52 @@ public sealed class IdempotentReceiverTests
 
         var result = await inbox.ProcessAsync(Message<Order>.Create(new Order("order-1")).WithIdempotencyKey("idem-1"));
 
-        Assert.Equal("order-1", result.Result);
+        ScenarioExpect.Equal("order-1", result.Result);
     }
 
+    [Scenario("Builder RejectsInvalidArguments")]
     [Fact]
     public void Builder_RejectsInvalidArguments()
     {
-        Assert.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(null!, (_, _, _) => default).Build());
-        Assert.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), null!).Build());
-        Assert.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), (_, _, _) => default).KeyBy(null!));
-        Assert.Throws<ArgumentNullException>(() => InboxProcessor<Order, string>.Create(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(null!, (_, _, _) => default).Build());
+        ScenarioExpect.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), null!).Build());
+        ScenarioExpect.Throws<ArgumentNullException>(() => IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), (_, _, _) => default).KeyBy(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => InboxProcessor<Order, string>.Create(null!));
     }
 
+    [Scenario("InMemoryIdempotencyStore ValidatesKeysAndTracksCount")]
     [Fact]
     public async Task InMemoryIdempotencyStore_ValidatesKeysAndTracksCount()
     {
         var store = new InMemoryIdempotencyStore();
 
-        await Assert.ThrowsAsync<ArgumentException>(async () => await store.TryClaimAsync(""));
+        await ScenarioExpect.ThrowsAsync<ArgumentException>(async () => await store.TryClaimAsync(""));
         await store.TryClaimAsync("idem-1");
         await store.MarkFailedAsync("idem-2", "failed");
 
-        Assert.Equal(2, store.Count);
-        Assert.False(store.TryGet("missing", out var missing));
-        Assert.Null(missing);
-        Assert.True(store.TryGet("idem-2", out var claim));
-        Assert.Equal(IdempotencyEntryStatus.Failed, claim!.Status);
-        Assert.Equal("failed", claim.FailureReason);
+        ScenarioExpect.Equal(2, store.Count);
+        ScenarioExpect.False(store.TryGet("missing", out var missing));
+        ScenarioExpect.Null(missing);
+        ScenarioExpect.True(store.TryGet("idem-2", out var claim));
+        ScenarioExpect.Equal(IdempotencyEntryStatus.Failed, claim!.Status);
+        ScenarioExpect.Equal("failed", claim.FailureReason);
     }
 
+    [Scenario("IdempotencyClaim ValidatesFactoryKeys")]
     [Fact]
     public void IdempotencyClaim_ValidatesFactoryKeys()
     {
-        Assert.Throws<ArgumentException>(() => IdempotencyClaim.ClaimedKey(""));
-        Assert.Throws<ArgumentException>(() => IdempotencyClaim.Existing(" ", IdempotencyEntryStatus.Completed));
+        ScenarioExpect.Throws<ArgumentException>(() => IdempotencyClaim.ClaimedKey(""));
+        ScenarioExpect.Throws<ArgumentException>(() => IdempotencyClaim.Existing(" ", IdempotencyEntryStatus.Completed));
     }
 
+    [Scenario("HandleAsync RejectsNullMessage")]
     [Fact]
     public async Task HandleAsync_RejectsNullMessage()
     {
         var receiver = IdempotentReceiver<Order, string>.Create(new InMemoryIdempotencyStore(), (_, _, _) => default).Build();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await receiver.HandleAsync(null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await receiver.HandleAsync(null!));
     }
 
     private sealed record Order(string Id);

--- a/test/PatternKit.Tests/Messaging/Reliability/OutboxTests.cs
+++ b/test/PatternKit.Tests/Messaging/Reliability/OutboxTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Reliability;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Reliability;
 
 public sealed class OutboxTests
 {
+    [Scenario("EnqueueAsync AddsOutboxRecord")]
     [Fact]
     public async Task EnqueueAsync_AddsOutboxRecord()
     {
@@ -16,12 +18,13 @@ public sealed class OutboxTests
             "outbox-1",
             createdAt);
 
-        Assert.Equal("outbox-1", record.Id);
-        Assert.Equal(createdAt, record.CreatedAt);
-        Assert.False(record.Dispatched);
-        Assert.Single(outbox.Records);
+        ScenarioExpect.Equal("outbox-1", record.Id);
+        ScenarioExpect.Equal(createdAt, record.CreatedAt);
+        ScenarioExpect.False(record.Dispatched);
+        ScenarioExpect.Single(outbox.Records);
     }
 
+    [Scenario("DispatchPendingAsync DispatchesPendingRecordsAndMarksThemDispatched")]
     [Fact]
     public async Task DispatchPendingAsync_DispatchesPendingRecordsAndMarksThemDispatched()
     {
@@ -33,17 +36,18 @@ public sealed class OutboxTests
         var dispatched = await outbox.DispatchPendingAsync(dispatcher);
         var secondPass = await outbox.DispatchPendingAsync(dispatcher);
 
-        Assert.Equal(2, dispatched);
-        Assert.Equal(0, secondPass);
-        Assert.Equal(["order-1", "order-2"], dispatcher.Dispatched);
-        Assert.All(outbox.Records, record =>
+        ScenarioExpect.Equal(2, dispatched);
+        ScenarioExpect.Equal(0, secondPass);
+        ScenarioExpect.Equal(["order-1", "order-2"], dispatcher.Dispatched);
+        ScenarioExpect.All(outbox.Records, record =>
         {
-            Assert.True(record.Dispatched);
-            Assert.Equal(1, record.Attempts);
-            Assert.Null(record.LastError);
+            ScenarioExpect.True(record.Dispatched);
+            ScenarioExpect.Equal(1, record.Attempts);
+            ScenarioExpect.Null(record.LastError);
         });
     }
 
+    [Scenario("DispatchPendingAsync RecordsFailedAttemptAndRethrows")]
     [Fact]
     public async Task DispatchPendingAsync_RecordsFailedAttemptAndRethrows()
     {
@@ -51,14 +55,15 @@ public sealed class OutboxTests
         await outbox.EnqueueAsync(Message<Order>.Create(new Order("order-1")), "outbox-1");
         var dispatcher = new FailingDispatcher();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outbox.DispatchPendingAsync(dispatcher));
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () => await outbox.DispatchPendingAsync(dispatcher));
 
-        var record = Assert.Single(outbox.Records);
-        Assert.False(record.Dispatched);
-        Assert.Equal(1, record.Attempts);
-        Assert.Equal("dispatch failed", record.LastError);
+        var record = ScenarioExpect.Single(outbox.Records);
+        ScenarioExpect.False(record.Dispatched);
+        ScenarioExpect.Equal(1, record.Attempts);
+        ScenarioExpect.Equal("dispatch failed", record.LastError);
     }
 
+    [Scenario("DispatchPendingAsync ObservesCancellation")]
     [Fact]
     public async Task DispatchPendingAsync_ObservesCancellation()
     {
@@ -67,24 +72,26 @@ public sealed class OutboxTests
         source.Cancel();
         await outbox.EnqueueAsync(Message<Order>.Create(new Order("order-1")), "outbox-1");
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await outbox.DispatchPendingAsync(new RecordingDispatcher(), source.Token));
     }
 
+    [Scenario("OutboxMessage ValidatesArguments")]
     [Fact]
     public void OutboxMessage_ValidatesArguments()
     {
-        Assert.Throws<ArgumentException>(() => new OutboxMessage<Order>("", Message<Order>.Create(new Order("order-1")), DateTimeOffset.UtcNow));
-        Assert.Throws<ArgumentNullException>(() => new OutboxMessage<Order>("outbox-1", null!, DateTimeOffset.UtcNow));
+        ScenarioExpect.Throws<ArgumentException>(() => new OutboxMessage<Order>("", Message<Order>.Create(new Order("order-1")), DateTimeOffset.UtcNow));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new OutboxMessage<Order>("outbox-1", null!, DateTimeOffset.UtcNow));
     }
 
+    [Scenario("EnqueueAsync ValidatesArguments")]
     [Fact]
     public async Task EnqueueAsync_ValidatesArguments()
     {
         var outbox = new InMemoryOutbox<Order>();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await outbox.EnqueueAsync(null!));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await outbox.DispatchPendingAsync(null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await outbox.EnqueueAsync(null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await outbox.DispatchPendingAsync(null!));
     }
 
     private sealed record Order(string Id);

--- a/test/PatternKit.Tests/Messaging/Routing/AggregatorTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/AggregatorTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Routing;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Routing;
 
 public sealed class AggregatorTests
 {
+    [Scenario("Add ReturnsPendingUntilCompletionPolicyMatches")]
     [Fact]
     public void Add_ReturnsPendingUntilCompletionPolicyMatches()
     {
@@ -13,19 +15,20 @@ public sealed class AggregatorTests
         var first = aggregator.Add(Item("order-1", "msg-1", 10m));
         var second = aggregator.Add(Item("order-1", "msg-2", 15m));
 
-        Assert.False(first.Completed);
-        Assert.True(first.Accepted);
-        Assert.Equal("order-1", first.Key);
-        Assert.Equal(1, first.Count);
-        Assert.Equal(default, first.Result);
-        Assert.True(second.Completed);
-        Assert.True(second.Accepted);
-        Assert.Equal("order-1", second.Key);
-        Assert.Equal(2, second.Count);
-        Assert.Equal(25m, second.Result);
-        Assert.Equal(0, aggregator.OpenGroupCount);
+        ScenarioExpect.False(first.Completed);
+        ScenarioExpect.True(first.Accepted);
+        ScenarioExpect.Equal("order-1", first.Key);
+        ScenarioExpect.Equal(1, first.Count);
+        ScenarioExpect.Equal(default, first.Result);
+        ScenarioExpect.True(second.Completed);
+        ScenarioExpect.True(second.Accepted);
+        ScenarioExpect.Equal("order-1", second.Key);
+        ScenarioExpect.Equal(2, second.Count);
+        ScenarioExpect.Equal(25m, second.Result);
+        ScenarioExpect.Equal(0, aggregator.OpenGroupCount);
     }
 
+    [Scenario("Add GroupsMessagesBySelectedKey")]
     [Fact]
     public void Add_GroupsMessagesBySelectedKey()
     {
@@ -34,11 +37,12 @@ public sealed class AggregatorTests
         var first = aggregator.Add(Item("order-1", "msg-1", 10m));
         var second = aggregator.Add(Item("order-2", "msg-2", 15m));
 
-        Assert.False(first.Completed);
-        Assert.False(second.Completed);
-        Assert.Equal(2, aggregator.OpenGroupCount);
+        ScenarioExpect.False(first.Completed);
+        ScenarioExpect.False(second.Completed);
+        ScenarioExpect.Equal(2, aggregator.OpenGroupCount);
     }
 
+    [Scenario("Add IgnoresDuplicateMessageIdsByDefault")]
     [Fact]
     public void Add_IgnoresDuplicateMessageIdsByDefault()
     {
@@ -47,12 +51,13 @@ public sealed class AggregatorTests
         var first = aggregator.Add(Item("order-1", "msg-1", 10m));
         var duplicate = aggregator.Add(Item("order-1", "msg-1", 15m));
 
-        Assert.True(first.Accepted);
-        Assert.False(duplicate.Accepted);
-        Assert.False(duplicate.Completed);
-        Assert.Equal(1, duplicate.Count);
+        ScenarioExpect.True(first.Accepted);
+        ScenarioExpect.False(duplicate.Accepted);
+        ScenarioExpect.False(duplicate.Completed);
+        ScenarioExpect.Equal(1, duplicate.Count);
     }
 
+    [Scenario("Add CanReplaceDuplicateMessageIds")]
     [Fact]
     public void Add_CanReplaceDuplicateMessageIds()
     {
@@ -62,10 +67,11 @@ public sealed class AggregatorTests
         aggregator.Add(Item("order-1", "msg-1", 15m));
         var result = aggregator.Add(Item("order-1", "msg-2", 5m));
 
-        Assert.True(result.Completed);
-        Assert.Equal(20m, result.Result);
+        ScenarioExpect.True(result.Completed);
+        ScenarioExpect.Equal(20m, result.Result);
     }
 
+    [Scenario("Add CanIncludeDuplicateMessageIds")]
     [Fact]
     public void Add_CanIncludeDuplicateMessageIds()
     {
@@ -74,10 +80,11 @@ public sealed class AggregatorTests
         aggregator.Add(Item("order-1", "msg-1", 10m));
         var result = aggregator.Add(Item("order-1", "msg-1", 15m));
 
-        Assert.True(result.Completed);
-        Assert.Equal(25m, result.Result);
+        ScenarioExpect.True(result.Completed);
+        ScenarioExpect.Equal(25m, result.Result);
     }
 
+    [Scenario("Add AllowsMessagesWithoutMessageIds")]
     [Fact]
     public void Add_AllowsMessagesWithoutMessageIds()
     {
@@ -90,39 +97,42 @@ public sealed class AggregatorTests
         aggregator.Add(Message<InvoiceLine>.Create(new InvoiceLine("order-1", 10m)));
         var result = aggregator.Add(Message<InvoiceLine>.Create(new InvoiceLine("order-1", 15m)));
 
-        Assert.True(result.Completed);
-        Assert.Equal(25m, result.Result);
+        ScenarioExpect.True(result.Completed);
+        ScenarioExpect.Equal(25m, result.Result);
     }
 
+    [Scenario("Add RejectsNullMessage")]
     [Fact]
     public void Add_RejectsNullMessage()
     {
         var aggregator = CreateCountAggregator(1);
 
-        Assert.Throws<ArgumentNullException>(() => aggregator.Add(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => aggregator.Add(null!));
     }
 
+    [Scenario("Builder RequiresAllDelegates")]
     [Fact]
     public void Builder_RequiresAllDelegates()
     {
-        Assert.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create().Build());
-        Assert.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create()
+        ScenarioExpect.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create().Build());
+        ScenarioExpect.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create()
             .KeyBy((m, _) => m.Payload.OrderId)
             .Build());
-        Assert.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create()
+        ScenarioExpect.Throws<InvalidOperationException>(() => Aggregator<string, InvoiceLine, decimal>.Create()
             .KeyBy((m, _) => m.Payload.OrderId)
             .CompleteWhen((_, _, _) => true)
             .Build());
     }
 
+    [Scenario("Builder RejectsNullDelegates")]
     [Fact]
     public void Builder_RejectsNullDelegates()
     {
         var builder = Aggregator<string, InvoiceLine, decimal>.Create();
 
-        Assert.Throws<ArgumentNullException>(() => builder.KeyBy(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.Project(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.KeyBy(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.Project(null!));
     }
 
     private static Aggregator<string, InvoiceLine, decimal> CreateCountAggregator(

--- a/test/PatternKit.Tests/Messaging/Routing/ContentRouterTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/ContentRouterTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Routing;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Routing;
 
 public sealed class ContentRouterTests
 {
+    [Scenario("Route UsesFirstMatchingRoute")]
     [Fact]
     public void Route_UsesFirstMatchingRoute()
     {
@@ -15,9 +17,10 @@ public sealed class ContentRouterTests
 
         var result = router.Route(Message<Order>.Create(new Order("o-1", 150m)));
 
-        Assert.Equal("priority", result);
+        ScenarioExpect.Equal("priority", result);
     }
 
+    [Scenario("Route UsesDefaultWhenNothingMatches")]
     [Fact]
     public void Route_UsesDefaultWhenNothingMatches()
     {
@@ -28,9 +31,10 @@ public sealed class ContentRouterTests
 
         var result = router.Route(Message<Order>.Create(new Order("o-1", 10m)));
 
-        Assert.Equal("default", result);
+        ScenarioExpect.Equal("default", result);
     }
 
+    [Scenario("Route ThrowsWhenNothingMatchesAndNoDefaultExists")]
     [Fact]
     public void Route_ThrowsWhenNothingMatchesAndNoDefaultExists()
     {
@@ -38,9 +42,10 @@ public sealed class ContentRouterTests
             .When((m, _) => m.Payload.Total < 0).Then((_, _) => "invalid")
             .Build();
 
-        Assert.Throws<InvalidOperationException>(() => router.Route(Message<Order>.Create(new Order("o-1", 10m))));
+        ScenarioExpect.Throws<InvalidOperationException>(() => router.Route(Message<Order>.Create(new Order("o-1", 10m))));
     }
 
+    [Scenario("Route PassesContextToPredicateAndHandler")]
     [Fact]
     public void Route_PassesContextToPredicateAndHandler()
     {
@@ -52,19 +57,21 @@ public sealed class ContentRouterTests
         var message = Message<Order>.Create(new Order("o-1", 10m));
         var context = new MessageContext(MessageHeaders.Empty.WithCorrelationId("corr-1"));
 
-        Assert.Equal("corr-1:o-1", router.Route(message, context));
+        ScenarioExpect.Equal("corr-1:o-1", router.Route(message, context));
     }
 
+    [Scenario("Builder RejectsNullDelegates")]
     [Fact]
     public void Builder_RejectsNullDelegates()
     {
         var builder = ContentRouter<Order, string>.Create();
 
-        Assert.Throws<ArgumentNullException>(() => builder.When(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.Default(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.When((_, _) => true).Then(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.Default(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When((_, _) => true).Then(null!));
     }
 
+    [Scenario("Route RejectsNullMessage")]
     [Fact]
     public void Route_RejectsNullMessage()
     {
@@ -72,9 +79,10 @@ public sealed class ContentRouterTests
             .Default((_, _) => "default")
             .Build();
 
-        Assert.Throws<ArgumentNullException>(() => router.Route(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => router.Route(null!));
     }
 
+    [Scenario("AsyncRoute UsesFirstMatchingRoute")]
     [Fact]
     public async Task AsyncRoute_UsesFirstMatchingRoute()
     {
@@ -85,9 +93,10 @@ public sealed class ContentRouterTests
 
         var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 150m)));
 
-        Assert.Equal("priority", result);
+        ScenarioExpect.Equal("priority", result);
     }
 
+    [Scenario("AsyncRoute UsesDefaultWhenNothingMatches")]
     [Fact]
     public async Task AsyncRoute_UsesDefaultWhenNothingMatches()
     {
@@ -98,9 +107,10 @@ public sealed class ContentRouterTests
 
         var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)));
 
-        Assert.Equal("default", result);
+        ScenarioExpect.Equal("default", result);
     }
 
+    [Scenario("AsyncRoute ObservesCancellation")]
     [Fact]
     public async Task AsyncRoute_ObservesCancellation()
     {
@@ -110,10 +120,11 @@ public sealed class ContentRouterTests
             .When((_, _, _) => new ValueTask<bool>(true)).Then((_, _, _) => new ValueTask<string>("never"))
             .Build();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)), cancellationToken: cts.Token));
     }
 
+    [Scenario("AsyncRoute PreservesProvidedContextCancellationWhenNoTokenIsSupplied")]
     [Fact]
     public async Task AsyncRoute_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
     {
@@ -130,10 +141,11 @@ public sealed class ContentRouterTests
 
         var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)), context);
 
-        Assert.Equal("ok", result);
-        Assert.Equal(cts.Token, seenToken);
+        ScenarioExpect.Equal("ok", result);
+        ScenarioExpect.Equal(cts.Token, seenToken);
     }
 
+    [Scenario("AsyncRoute UsesExplicitCancellationTokenOverProvidedContext")]
     [Fact]
     public async Task AsyncRoute_UsesExplicitCancellationTokenOverProvidedContext()
     {
@@ -146,9 +158,10 @@ public sealed class ContentRouterTests
 
         var result = await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m)), context, callCts.Token);
 
-        Assert.Equal(callCts.Token, result);
+        ScenarioExpect.Equal(callCts.Token, result);
     }
 
+    [Scenario("AsyncRoute ThrowsWhenNothingMatchesAndNoDefaultExists")]
     [Fact]
     public async Task AsyncRoute_ThrowsWhenNothingMatchesAndNoDefaultExists()
     {
@@ -156,20 +169,22 @@ public sealed class ContentRouterTests
             .When((m, _, _) => new ValueTask<bool>(m.Payload.Total < 0)).Then((_, _, _) => new ValueTask<string>("invalid"))
             .Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () =>
             await router.RouteAsync(Message<Order>.Create(new Order("o-1", 10m))));
     }
 
+    [Scenario("AsyncBuilder RejectsNullDelegates")]
     [Fact]
     public void AsyncBuilder_RejectsNullDelegates()
     {
         var builder = AsyncContentRouter<Order, string>.Create();
 
-        Assert.Throws<ArgumentNullException>(() => builder.When(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.Default(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.When((_, _, _) => new ValueTask<bool>(true)).Then(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.Default(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When((_, _, _) => new ValueTask<bool>(true)).Then(null!));
     }
 
+    [Scenario("AsyncRoute RejectsNullMessage")]
     [Fact]
     public async Task AsyncRoute_RejectsNullMessage()
     {
@@ -177,7 +192,7 @@ public sealed class ContentRouterTests
             .Default((_, _, _) => new ValueTask<string>("default"))
             .Build();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await router.RouteAsync(null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await router.RouteAsync(null!));
     }
 
     private sealed record Order(string Id, decimal Total);

--- a/test/PatternKit.Tests/Messaging/Routing/RecipientListTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/RecipientListTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Routing;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Routing;
 
 public sealed class RecipientListTests
 {
+    [Scenario("Dispatch SendsToMatchingRecipientsInOrder")]
     [Fact]
     public void Dispatch_SendsToMatchingRecipientsInOrder()
     {
@@ -17,11 +19,12 @@ public sealed class RecipientListTests
 
         var result = list.Dispatch(Message<Order>.Create(new Order("o-1", 100m)));
 
-        Assert.Equal(["audit", "billing"], log);
-        Assert.Equal(["audit", "billing"], result.DeliveredRecipients);
-        Assert.Equal(2, result.Count);
+        ScenarioExpect.Equal(["audit", "billing"], log);
+        ScenarioExpect.Equal(["audit", "billing"], result.DeliveredRecipients);
+        ScenarioExpect.Equal(2, result.Count);
     }
 
+    [Scenario("Dispatch ReturnsEmptyResultWhenNoRecipientsMatch")]
     [Fact]
     public void Dispatch_ReturnsEmptyResultWhenNoRecipientsMatch()
     {
@@ -31,10 +34,11 @@ public sealed class RecipientListTests
 
         var result = list.Dispatch(Message<Order>.Create(new Order("o-1", 100m)));
 
-        Assert.Empty(result.DeliveredRecipients);
-        Assert.Equal(0, result.Count);
+        ScenarioExpect.Empty(result.DeliveredRecipients);
+        ScenarioExpect.Equal(0, result.Count);
     }
 
+    [Scenario("To AddsUnconditionalRecipient")]
     [Fact]
     public void To_AddsUnconditionalRecipient()
     {
@@ -45,29 +49,32 @@ public sealed class RecipientListTests
 
         var result = list.Dispatch(Message<Order>.Create(new Order("o-1", 100m)));
 
-        Assert.True(delivered);
-        Assert.Equal(["audit"], result.DeliveredRecipients);
+        ScenarioExpect.True(delivered);
+        ScenarioExpect.Equal(["audit"], result.DeliveredRecipients);
     }
 
+    [Scenario("Dispatch RejectsNullMessage")]
     [Fact]
     public void Dispatch_RejectsNullMessage()
     {
         var list = RecipientList<Order>.Create().To("audit", (_, _) => { }).Build();
 
-        Assert.Throws<ArgumentNullException>(() => list.Dispatch(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => list.Dispatch(null!));
     }
 
+    [Scenario("Builder RejectsInvalidArguments")]
     [Fact]
     public void Builder_RejectsInvalidArguments()
     {
         var builder = RecipientList<Order>.Create();
 
-        Assert.Throws<ArgumentException>(() => builder.When("", (_, _) => true));
-        Assert.Throws<ArgumentNullException>(() => builder.When("audit", null!));
-        Assert.Throws<ArgumentNullException>(() => builder.To("audit", null!));
-        Assert.Throws<ArgumentNullException>(() => builder.When("audit", (_, _) => true).Then(null!));
+        ScenarioExpect.Throws<ArgumentException>(() => builder.When("", (_, _) => true));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When("audit", null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.To("audit", null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When("audit", (_, _) => true).Then(null!));
     }
 
+    [Scenario("RecipientListResult CopiesDeliveredRecipients")]
     [Fact]
     public void RecipientListResult_CopiesDeliveredRecipients()
     {
@@ -76,15 +83,17 @@ public sealed class RecipientListTests
 
         delivered.Add("billing");
 
-        Assert.Equal(["audit"], result.DeliveredRecipients);
+        ScenarioExpect.Equal(["audit"], result.DeliveredRecipients);
     }
 
+    [Scenario("RecipientListResult RejectsNullRecipients")]
     [Fact]
     public void RecipientListResult_RejectsNullRecipients()
     {
-        Assert.Throws<ArgumentNullException>(() => new RecipientListResult(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new RecipientListResult(null!));
     }
 
+    [Scenario("AsyncDispatch SendsToMatchingRecipientsInOrder")]
     [Fact]
     public async Task AsyncDispatch_SendsToMatchingRecipientsInOrder()
     {
@@ -104,10 +113,11 @@ public sealed class RecipientListTests
 
         var result = await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)));
 
-        Assert.Equal(["audit", "billing"], log);
-        Assert.Equal(["audit", "billing"], result.DeliveredRecipients);
+        ScenarioExpect.Equal(["audit", "billing"], log);
+        ScenarioExpect.Equal(["audit", "billing"], result.DeliveredRecipients);
     }
 
+    [Scenario("AsyncDispatch ObservesCancellation")]
     [Fact]
     public async Task AsyncDispatch_ObservesCancellation()
     {
@@ -117,10 +127,11 @@ public sealed class RecipientListTests
             .To("audit", (_, _, _) => ValueTask.CompletedTask)
             .Build();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)), cancellationToken: cts.Token));
     }
 
+    [Scenario("AsyncDispatch PreservesProvidedContextCancellationWhenNoTokenIsSupplied")]
     [Fact]
     public async Task AsyncDispatch_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
     {
@@ -130,7 +141,7 @@ public sealed class RecipientListTests
             .To("audit", (_, ctx, token) =>
             {
                 seenToken = ctx.CancellationToken;
-                Assert.Equal(CancellationToken.None, token);
+                ScenarioExpect.Equal(CancellationToken.None, token);
                 return ValueTask.CompletedTask;
             })
             .Build();
@@ -138,9 +149,10 @@ public sealed class RecipientListTests
 
         await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)), context);
 
-        Assert.Equal(cts.Token, seenToken);
+        ScenarioExpect.Equal(cts.Token, seenToken);
     }
 
+    [Scenario("AsyncDispatch UsesExplicitCancellationTokenOverProvidedContext")]
     [Fact]
     public async Task AsyncDispatch_UsesExplicitCancellationTokenOverProvidedContext()
     {
@@ -158,9 +170,10 @@ public sealed class RecipientListTests
 
         await list.DispatchAsync(Message<Order>.Create(new Order("o-1", 100m)), context, callCts.Token);
 
-        Assert.Equal(callCts.Token, seenToken);
+        ScenarioExpect.Equal(callCts.Token, seenToken);
     }
 
+    [Scenario("AsyncDispatch RejectsNullMessage")]
     [Fact]
     public async Task AsyncDispatch_RejectsNullMessage()
     {
@@ -168,18 +181,19 @@ public sealed class RecipientListTests
             .To("audit", (_, _, _) => ValueTask.CompletedTask)
             .Build();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await list.DispatchAsync(null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await list.DispatchAsync(null!));
     }
 
+    [Scenario("AsyncBuilder RejectsInvalidArguments")]
     [Fact]
     public void AsyncBuilder_RejectsInvalidArguments()
     {
         var builder = AsyncRecipientList<Order>.Create();
 
-        Assert.Throws<ArgumentException>(() => builder.When("", (_, _, _) => new ValueTask<bool>(true)));
-        Assert.Throws<ArgumentNullException>(() => builder.When("audit", null!));
-        Assert.Throws<ArgumentNullException>(() => builder.To("audit", null!));
-        Assert.Throws<ArgumentNullException>(() => builder.When("audit", (_, _, _) => new ValueTask<bool>(true)).Then(null!));
+        ScenarioExpect.Throws<ArgumentException>(() => builder.When("", (_, _, _) => new ValueTask<bool>(true)));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When("audit", null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.To("audit", null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When("audit", (_, _, _) => new ValueTask<bool>(true)).Then(null!));
     }
 
     private sealed record Order(string Id, decimal Total);

--- a/test/PatternKit.Tests/Messaging/Routing/RoutingSlipTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/RoutingSlipTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Routing;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Routing;
 
 public sealed class RoutingSlipTests
 {
+    [Scenario("Execute RunsStepsInOrderAndReturnsFinalMessage")]
     [Fact]
     public void Execute_RunsStepsInOrderAndReturnsFinalMessage()
     {
@@ -24,12 +26,13 @@ public sealed class RoutingSlipTests
 
         var result = slip.Execute(Message<Order>.Create(new Order("order-1", "new")));
 
-        Assert.Equal("validated,reserved", result.Message.Payload.Status);
-        Assert.Equal(["0:validate", "1:reserve"], log);
-        Assert.Equal(["validate", "reserve"], result.CompletedSteps);
-        Assert.Equal(2, result.Count);
+        ScenarioExpect.Equal("validated,reserved", result.Message.Payload.Status);
+        ScenarioExpect.Equal(["0:validate", "1:reserve"], log);
+        ScenarioExpect.Equal(["validate", "reserve"], result.CompletedSteps);
+        ScenarioExpect.Equal(2, result.Count);
     }
 
+    [Scenario("Execute WritesItineraryProgressAndCompletedHeaders")]
     [Fact]
     public void Execute_WritesItineraryProgressAndCompletedHeaders()
     {
@@ -40,13 +43,14 @@ public sealed class RoutingSlipTests
 
         var result = slip.Execute(Message<Order>.Create(new Order("order-1", "new")));
 
-        Assert.True(result.Message.Headers.TryGet<string[]>(MessageHeaderNames.RoutingSlip, out var itinerary));
-        Assert.True(result.Message.Headers.TryGet<string[]>(MessageHeaderNames.RoutingSlipCompleted, out var completed));
-        Assert.Equal(["validate", "ship"], itinerary!);
-        Assert.Equal(["validate", "ship"], completed!);
-        Assert.Equal(2, result.Message.Headers[MessageHeaderNames.RoutingSlipIndex]);
+        ScenarioExpect.True(result.Message.Headers.TryGet<string[]>(MessageHeaderNames.RoutingSlip, out var itinerary));
+        ScenarioExpect.True(result.Message.Headers.TryGet<string[]>(MessageHeaderNames.RoutingSlipCompleted, out var completed));
+        ScenarioExpect.Equal(["validate", "ship"], itinerary!);
+        ScenarioExpect.Equal(["validate", "ship"], completed!);
+        ScenarioExpect.Equal(2, result.Message.Headers[MessageHeaderNames.RoutingSlipIndex]);
     }
 
+    [Scenario("Execute ClearsPreviousCompletedHeader")]
     [Fact]
     public void Execute_ClearsPreviousCompletedHeader()
     {
@@ -59,28 +63,31 @@ public sealed class RoutingSlipTests
 
         var result = slip.Execute(message);
 
-        Assert.Equal(["validate"], Assert.IsType<string[]>(result.Message.Headers[MessageHeaderNames.RoutingSlipCompleted]));
+        ScenarioExpect.Equal(["validate"], ScenarioExpect.IsType<string[]>(result.Message.Headers[MessageHeaderNames.RoutingSlipCompleted]));
     }
 
+    [Scenario("Execute AllowsEmptyItinerary")]
     [Fact]
     public void Execute_AllowsEmptyItinerary()
     {
         var message = Message<Order>.Create(new Order("order-1", "new"));
         var result = RoutingSlip<Order>.Create().Build().Execute(message);
 
-        Assert.Same(message.Payload, result.Message.Payload);
-        Assert.Empty(result.CompletedSteps);
-        Assert.Equal(0, result.Message.Headers[MessageHeaderNames.RoutingSlipIndex]);
+        ScenarioExpect.Same(message.Payload, result.Message.Payload);
+        ScenarioExpect.Empty(result.CompletedSteps);
+        ScenarioExpect.Equal(0, result.Message.Headers[MessageHeaderNames.RoutingSlipIndex]);
     }
 
+    [Scenario("Execute RejectsNullMessage")]
     [Fact]
     public void Execute_RejectsNullMessage()
     {
         var slip = RoutingSlip<Order>.Create().Build();
 
-        Assert.Throws<ArgumentNullException>(() => slip.Execute(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => slip.Execute(null!));
     }
 
+    [Scenario("Execute RejectsNullStepResult")]
     [Fact]
     public void Execute_RejectsNullStepResult()
     {
@@ -88,18 +95,20 @@ public sealed class RoutingSlipTests
             .Step("bad", (_, _) => null!)
             .Build();
 
-        Assert.Throws<InvalidOperationException>(() => slip.Execute(Message<Order>.Create(new Order("order-1", "new"))));
+        ScenarioExpect.Throws<InvalidOperationException>(() => slip.Execute(Message<Order>.Create(new Order("order-1", "new"))));
     }
 
+    [Scenario("Builder RejectsInvalidArguments")]
     [Fact]
     public void Builder_RejectsInvalidArguments()
     {
         var builder = RoutingSlip<Order>.Create();
 
-        Assert.Throws<ArgumentException>(() => builder.Step("", (m, _) => m));
-        Assert.Throws<ArgumentNullException>(() => builder.Step("validate", null!));
+        ScenarioExpect.Throws<ArgumentException>(() => builder.Step("", (m, _) => m));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.Step("validate", null!));
     }
 
+    [Scenario("RoutingSlipResult RejectsInvalidArgumentsAndCopiesSteps")]
     [Fact]
     public void RoutingSlipResult_RejectsInvalidArgumentsAndCopiesSteps()
     {
@@ -108,11 +117,12 @@ public sealed class RoutingSlipTests
 
         steps.Add("ship");
 
-        Assert.Equal(["validate"], result.CompletedSteps);
-        Assert.Throws<ArgumentNullException>(() => new RoutingSlipResult<Order>(null!, steps));
-        Assert.Throws<ArgumentNullException>(() => new RoutingSlipResult<Order>(Message<Order>.Create(new Order("order-1", "new")), null!));
+        ScenarioExpect.Equal(["validate"], result.CompletedSteps);
+        ScenarioExpect.Throws<ArgumentNullException>(() => new RoutingSlipResult<Order>(null!, steps));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new RoutingSlipResult<Order>(Message<Order>.Create(new Order("order-1", "new")), null!));
     }
 
+    [Scenario("AsyncExecute RunsStepsInOrder")]
     [Fact]
     public async Task AsyncExecute_RunsStepsInOrder()
     {
@@ -132,11 +142,12 @@ public sealed class RoutingSlipTests
 
         var result = await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")));
 
-        Assert.Equal(["validate", "ship"], log);
-        Assert.Equal("validated,shipped", result.Message.Payload.Status);
-        Assert.Equal(["validate", "ship"], result.CompletedSteps);
+        ScenarioExpect.Equal(["validate", "ship"], log);
+        ScenarioExpect.Equal("validated,shipped", result.Message.Payload.Status);
+        ScenarioExpect.Equal(["validate", "ship"], result.CompletedSteps);
     }
 
+    [Scenario("AsyncExecute ObservesCancellation")]
     [Fact]
     public async Task AsyncExecute_ObservesCancellation()
     {
@@ -146,10 +157,11 @@ public sealed class RoutingSlipTests
             .Step("validate", (m, _, _) => new ValueTask<Message<Order>>(m))
             .Build();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")), cancellationToken: cts.Token));
     }
 
+    [Scenario("AsyncExecute PreservesProvidedContextCancellationWhenNoTokenIsSupplied")]
     [Fact]
     public async Task AsyncExecute_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
     {
@@ -159,7 +171,7 @@ public sealed class RoutingSlipTests
             .Step("validate", (m, ctx, token) =>
             {
                 seenToken = ctx.CancellationToken;
-                Assert.Equal(CancellationToken.None, token);
+                ScenarioExpect.Equal(CancellationToken.None, token);
                 return new ValueTask<Message<Order>>(m);
             })
             .Build();
@@ -167,9 +179,10 @@ public sealed class RoutingSlipTests
 
         await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")), context);
 
-        Assert.Equal(cts.Token, seenToken);
+        ScenarioExpect.Equal(cts.Token, seenToken);
     }
 
+    [Scenario("AsyncExecute UsesExplicitCancellationTokenOverProvidedContext")]
     [Fact]
     public async Task AsyncExecute_UsesExplicitCancellationTokenOverProvidedContext()
     {
@@ -187,30 +200,32 @@ public sealed class RoutingSlipTests
 
         await slip.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new")), context, callCts.Token);
 
-        Assert.Equal(callCts.Token, seenToken);
+        ScenarioExpect.Equal(callCts.Token, seenToken);
     }
 
+    [Scenario("AsyncExecute RejectsNullMessageAndStepResult")]
     [Fact]
     public async Task AsyncExecute_RejectsNullMessageAndStepResult()
     {
         var valid = AsyncRoutingSlip<Order>.Create().Build();
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await valid.ExecuteAsync(null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await valid.ExecuteAsync(null!));
 
         var invalid = AsyncRoutingSlip<Order>.Create()
             .Step("bad", (_, _, _) => new ValueTask<Message<Order>>((Message<Order>)null!))
             .Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await ScenarioExpect.ThrowsAsync<InvalidOperationException>(async () =>
             await invalid.ExecuteAsync(Message<Order>.Create(new Order("order-1", "new"))));
     }
 
+    [Scenario("AsyncBuilder RejectsInvalidArguments")]
     [Fact]
     public void AsyncBuilder_RejectsInvalidArguments()
     {
         var builder = AsyncRoutingSlip<Order>.Create();
 
-        Assert.Throws<ArgumentException>(() => builder.Step("", (m, _, _) => new ValueTask<Message<Order>>(m)));
-        Assert.Throws<ArgumentNullException>(() => builder.Step("validate", null!));
+        ScenarioExpect.Throws<ArgumentException>(() => builder.Step("", (m, _, _) => new ValueTask<Message<Order>>(m)));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.Step("validate", null!));
     }
 
     private sealed record Order(string Id, string Status);

--- a/test/PatternKit.Tests/Messaging/Routing/SplitterTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/SplitterTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Routing;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Routing;
 
 public sealed class SplitterTests
 {
+    [Scenario("Split ReturnsItemMessages")]
     [Fact]
     public void Split_ReturnsItemMessages()
     {
@@ -18,12 +20,13 @@ public sealed class SplitterTests
 
         var parts = splitter.Split(message);
 
-        Assert.Equal(2, parts.Count);
-        Assert.Equal("a", parts[0].Payload.Sku);
-        Assert.Equal("corr-1", parts[0].Headers.CorrelationId);
-        Assert.Equal("msg-1", parts[0].Headers.CausationId);
+        ScenarioExpect.Equal(2, parts.Count);
+        ScenarioExpect.Equal("a", parts[0].Payload.Sku);
+        ScenarioExpect.Equal("corr-1", parts[0].Headers.CorrelationId);
+        ScenarioExpect.Equal("msg-1", parts[0].Headers.CausationId);
     }
 
+    [Scenario("Split PreservesExistingCausationId")]
     [Fact]
     public void Split_PreservesExistingCausationId()
     {
@@ -36,9 +39,10 @@ public sealed class SplitterTests
 
         var parts = splitter.Split(message);
 
-        Assert.Equal("cause-1", parts[0].Headers.CausationId);
+        ScenarioExpect.Equal("cause-1", parts[0].Headers.CausationId);
     }
 
+    [Scenario("Split AllowsEmptyResults")]
     [Fact]
     public void Split_AllowsEmptyResults()
     {
@@ -48,9 +52,10 @@ public sealed class SplitterTests
 
         var parts = splitter.Split(Message<Order>.Create(new Order("o-1", [])));
 
-        Assert.Empty(parts);
+        ScenarioExpect.Empty(parts);
     }
 
+    [Scenario("Split RejectsNullMessage")]
     [Fact]
     public void Split_RejectsNullMessage()
     {
@@ -58,9 +63,10 @@ public sealed class SplitterTests
             .Use((m, _) => m.Payload.Items)
             .Build();
 
-        Assert.Throws<ArgumentNullException>(() => splitter.Split(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => splitter.Split(null!));
     }
 
+    [Scenario("Split RejectsNullHandlerResult")]
     [Fact]
     public void Split_RejectsNullHandlerResult()
     {
@@ -68,19 +74,21 @@ public sealed class SplitterTests
             .Use((_, _) => null!)
             .Build();
 
-        Assert.Throws<InvalidOperationException>(() => splitter.Split(Message<Order>.Create(new Order("o-1", []))));
+        ScenarioExpect.Throws<InvalidOperationException>(() => splitter.Split(Message<Order>.Create(new Order("o-1", []))));
     }
 
+    [Scenario("Builder RequiresHandler")]
     [Fact]
     public void Builder_RequiresHandler()
     {
-        Assert.Throws<InvalidOperationException>(() => Splitter<Order, LineItem>.Create().Build());
+        ScenarioExpect.Throws<InvalidOperationException>(() => Splitter<Order, LineItem>.Create().Build());
     }
 
+    [Scenario("Builder RejectsNullHandler")]
     [Fact]
     public void Builder_RejectsNullHandler()
     {
-        Assert.Throws<ArgumentNullException>(() => Splitter<Order, LineItem>.Create().Use(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => Splitter<Order, LineItem>.Create().Use(null!));
     }
 
     private sealed record Order(string Id, IReadOnlyList<LineItem> Items);

--- a/test/PatternKit.Tests/Messaging/Sagas/SagaTests.cs
+++ b/test/PatternKit.Tests/Messaging/Sagas/SagaTests.cs
@@ -1,10 +1,12 @@
 using PatternKit.Messaging;
 using PatternKit.Messaging.Sagas;
+using TinyBDD;
 
 namespace PatternKit.Tests.Messaging.Sagas;
 
 public sealed class SagaTests
 {
+    [Scenario("Handle AppliesMatchingTypedStepsInOrder")]
     [Fact]
     public void Handle_AppliesMatchingTypedStepsInOrder()
     {
@@ -17,14 +19,15 @@ public sealed class SagaTests
         var started = saga.Handle(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")));
         var paid = saga.Handle(started.State, Message<PaymentAccepted>.Create(new PaymentAccepted("order-1")));
 
-        Assert.True(started.Matched);
-        Assert.False(started.Completed);
-        Assert.Equal("order-1", started.State.OrderId);
-        Assert.True(paid.Matched);
-        Assert.True(paid.Completed);
-        Assert.True(paid.State.Paid);
+        ScenarioExpect.True(started.Matched);
+        ScenarioExpect.False(started.Completed);
+        ScenarioExpect.Equal("order-1", started.State.OrderId);
+        ScenarioExpect.True(paid.Matched);
+        ScenarioExpect.True(paid.Completed);
+        ScenarioExpect.True(paid.State.Paid);
     }
 
+    [Scenario("Handle UsesGuardPredicate")]
     [Fact]
     public void Handle_UsesGuardPredicate()
     {
@@ -35,10 +38,11 @@ public sealed class SagaTests
 
         var result = saga.Handle(new OrderState("order-1", Started: true, Paid: false), Message<PaymentAccepted>.Create(new PaymentAccepted("order-2")));
 
-        Assert.False(result.Matched);
-        Assert.False(result.State.Paid);
+        ScenarioExpect.False(result.Matched);
+        ScenarioExpect.False(result.State.Paid);
     }
 
+    [Scenario("Handle ReturnsUnmatchedForUnknownMessageType")]
     [Fact]
     public void Handle_ReturnsUnmatchedForUnknownMessageType()
     {
@@ -48,10 +52,11 @@ public sealed class SagaTests
 
         var result = saga.Handle(OrderState.Empty, Message<PaymentAccepted>.Create(new PaymentAccepted("order-1")));
 
-        Assert.False(result.Matched);
-        Assert.Equal(OrderState.Empty, result.State);
+        ScenarioExpect.False(result.Matched);
+        ScenarioExpect.Equal(OrderState.Empty, result.State);
     }
 
+    [Scenario("Handle PassesMessageContext")]
     [Fact]
     public void Handle_PassesMessageContext()
     {
@@ -62,27 +67,30 @@ public sealed class SagaTests
 
         var result = saga.Handle(OrderState.Empty, message);
 
-        Assert.Equal("corr-1", result.State.OrderId);
+        ScenarioExpect.Equal("corr-1", result.State.OrderId);
     }
 
+    [Scenario("Handle RejectsNullMessage")]
     [Fact]
     public void Handle_RejectsNullMessage()
     {
         var saga = Saga<OrderState>.Create().Build();
 
-        Assert.Throws<ArgumentNullException>(() => saga.Handle(OrderState.Empty, (Message<OrderStarted>)null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => saga.Handle(OrderState.Empty, (Message<OrderStarted>)null!));
     }
 
+    [Scenario("Builder RejectsNullDelegates")]
     [Fact]
     public void Builder_RejectsNullDelegates()
     {
         var builder = Saga<OrderState>.Create();
 
-        Assert.Throws<ArgumentNullException>(() => builder.When<OrderStarted>(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.On<OrderStarted>().Then(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When<OrderStarted>(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.On<OrderStarted>().Then(null!));
     }
 
+    [Scenario("AsyncHandle AppliesMatchingTypedStepsInOrder")]
     [Fact]
     public async Task AsyncHandle_AppliesMatchingTypedStepsInOrder()
     {
@@ -95,12 +103,13 @@ public sealed class SagaTests
         var started = await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")));
         var paid = await saga.HandleAsync(started.State, Message<PaymentAccepted>.Create(new PaymentAccepted("order-1")));
 
-        Assert.True(started.Matched);
-        Assert.False(started.Completed);
-        Assert.True(paid.Completed);
-        Assert.True(paid.State.Paid);
+        ScenarioExpect.True(started.Matched);
+        ScenarioExpect.False(started.Completed);
+        ScenarioExpect.True(paid.Completed);
+        ScenarioExpect.True(paid.State.Paid);
     }
 
+    [Scenario("AsyncHandle UsesGuardPredicate")]
     [Fact]
     public async Task AsyncHandle_UsesGuardPredicate()
     {
@@ -111,10 +120,11 @@ public sealed class SagaTests
 
         var result = await saga.HandleAsync(new OrderState("order-1", Started: true, Paid: false), Message<PaymentAccepted>.Create(new PaymentAccepted("order-2")));
 
-        Assert.False(result.Matched);
-        Assert.False(result.State.Paid);
+        ScenarioExpect.False(result.Matched);
+        ScenarioExpect.False(result.State.Paid);
     }
 
+    [Scenario("AsyncHandle ObservesCancellation")]
     [Fact]
     public async Task AsyncHandle_ObservesCancellation()
     {
@@ -124,10 +134,11 @@ public sealed class SagaTests
             .On<OrderStarted>().Then((state, _, _, _) => new ValueTask<OrderState>(state with { Started = true }))
             .Build();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await ScenarioExpect.ThrowsAsync<OperationCanceledException>(async () =>
             await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")), cancellationToken: cts.Token));
     }
 
+    [Scenario("AsyncHandle PreservesProvidedContextCancellationWhenNoTokenIsSupplied")]
     [Fact]
     public async Task AsyncHandle_PreservesProvidedContextCancellationWhenNoTokenIsSupplied()
     {
@@ -137,7 +148,7 @@ public sealed class SagaTests
             .On<OrderStarted>().Then((state, _, context, token) =>
             {
                 seenToken = context.CancellationToken;
-                Assert.Equal(CancellationToken.None, token);
+                ScenarioExpect.Equal(CancellationToken.None, token);
                 return new ValueTask<OrderState>(state);
             })
             .Build();
@@ -145,9 +156,10 @@ public sealed class SagaTests
 
         await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")), context);
 
-        Assert.Equal(cts.Token, seenToken);
+        ScenarioExpect.Equal(cts.Token, seenToken);
     }
 
+    [Scenario("AsyncHandle UsesExplicitCancellationTokenOverProvidedContext")]
     [Fact]
     public async Task AsyncHandle_UsesExplicitCancellationTokenOverProvidedContext()
     {
@@ -165,25 +177,27 @@ public sealed class SagaTests
 
         await saga.HandleAsync(OrderState.Empty, Message<OrderStarted>.Create(new OrderStarted("order-1")), context, callCts.Token);
 
-        Assert.Equal(callCts.Token, seenToken);
+        ScenarioExpect.Equal(callCts.Token, seenToken);
     }
 
+    [Scenario("AsyncHandle RejectsNullMessage")]
     [Fact]
     public async Task AsyncHandle_RejectsNullMessage()
     {
         var saga = AsyncSaga<OrderState>.Create().Build();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await saga.HandleAsync(OrderState.Empty, (Message<OrderStarted>)null!));
+        await ScenarioExpect.ThrowsAsync<ArgumentNullException>(async () => await saga.HandleAsync(OrderState.Empty, (Message<OrderStarted>)null!));
     }
 
+    [Scenario("AsyncBuilder RejectsNullDelegates")]
     [Fact]
     public void AsyncBuilder_RejectsNullDelegates()
     {
         var builder = AsyncSaga<OrderState>.Create();
 
-        Assert.Throws<ArgumentNullException>(() => builder.When<OrderStarted>(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
-        Assert.Throws<ArgumentNullException>(() => builder.On<OrderStarted>().Then(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.When<OrderStarted>(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.CompleteWhen(null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => builder.On<OrderStarted>().Then(null!));
     }
 
     private sealed record OrderState(string? OrderId, bool Started, bool Paid)

--- a/test/PatternKit.Tests/PatternKit.Tests.csproj
+++ b/test/PatternKit.Tests/PatternKit.Tests.csproj
@@ -40,6 +40,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="..\ScenarioExpect.cs" Link="ScenarioExpect.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
       <Folder Include="Structural\" />
     </ItemGroup>
 

--- a/test/PatternKit.Tests/Structural/Adapters/AdapterTests.cs
+++ b/test/PatternKit.Tests/Structural/Adapters/AdapterTests.cs
@@ -99,6 +99,7 @@ public sealed class AdapterEdgeCaseTests
         public int Age { get; set; }
     }
 
+    [Scenario("TryAdapt Exception In Seed Returns False")]
     [Fact]
     public void TryAdapt_Exception_In_Seed_Returns_False()
     {
@@ -108,11 +109,12 @@ public sealed class AdapterEdgeCaseTests
 
         var ok = adapter.TryAdapt(new Source("A", "B", 30), out var dest, out var error);
 
-        Assert.False(ok);
-        Assert.Null(dest);
-        Assert.Equal("Seed failed", error);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.Null(dest);
+        ScenarioExpect.Equal("Seed failed", error);
     }
 
+    [Scenario("TryAdapt Exception In Map Returns False")]
     [Fact]
     public void TryAdapt_Exception_In_Map_Returns_False()
     {
@@ -123,11 +125,12 @@ public sealed class AdapterEdgeCaseTests
 
         var ok = adapter.TryAdapt(new Source("A", "B", 30), out var dest, out var error);
 
-        Assert.False(ok);
-        Assert.Null(dest);
-        Assert.Equal("Map failed", error);
+        ScenarioExpect.False(ok);
+        ScenarioExpect.Null(dest);
+        ScenarioExpect.Equal("Map failed", error);
     }
 
+    [Scenario("TryAdapt Success NoValidators")]
     [Fact]
     public void TryAdapt_Success_NoValidators()
     {
@@ -138,12 +141,13 @@ public sealed class AdapterEdgeCaseTests
 
         var ok = adapter.TryAdapt(new Source("Ada", "L", 30), out var dest, out var error);
 
-        Assert.True(ok);
-        Assert.NotNull(dest);
-        Assert.Equal("Ada", dest.FullName);
-        Assert.Null(error);
+        ScenarioExpect.True(ok);
+        ScenarioExpect.NotNull(dest);
+        ScenarioExpect.Equal("Ada", dest.FullName);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("Adapt NoMaps NoValidators Works")]
     [Fact]
     public void Adapt_NoMaps_NoValidators_Works()
     {
@@ -153,21 +157,23 @@ public sealed class AdapterEdgeCaseTests
 
         var result = adapter.Adapt(new Source("X", "Y", 42));
 
-        Assert.Equal(42, result.Age);
-        Assert.Null(result.FullName);
+        ScenarioExpect.Equal(42, result.Age);
+        ScenarioExpect.Null(result.FullName);
     }
 
+    [Scenario("Builder Null Seed Throws")]
     [Fact]
     public void Builder_Null_Seed_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             Adapter<Source, Dest>.Create((Adapter<Source, Dest>.Seed)null!));
     }
 
+    [Scenario("Builder Null SeedFrom Throws")]
     [Fact]
     public void Builder_Null_SeedFrom_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             Adapter<Source, Dest>.Create((Adapter<Source, Dest>.SeedFrom)null!));
     }
 }
@@ -186,6 +192,7 @@ public sealed class AsyncAdapterTests
         public List<string> Log { get; } = [];
     }
 
+    [Scenario("AsyncAdapter Basic Adapt")]
     [Fact]
     public async Task AsyncAdapter_Basic_Adapt()
     {
@@ -200,10 +207,11 @@ public sealed class AsyncAdapterTests
 
         var result = await adapter.AdaptAsync(new Source("Ada", "Lovelace", 30));
 
-        Assert.Equal("Ada Lovelace", result.FullName);
-        Assert.Equal(30, result.Age);
+        ScenarioExpect.Equal("Ada Lovelace", result.FullName);
+        ScenarioExpect.Equal(30, result.Age);
     }
 
+    [Scenario("AsyncAdapter Async Seed")]
     [Fact]
     public async Task AsyncAdapter_Async_Seed()
     {
@@ -218,10 +226,11 @@ public sealed class AsyncAdapterTests
 
         var result = await adapter.AdaptAsync(new Source("Test", "User", 25));
 
-        Assert.Contains("async-seed", result.Log);
-        Assert.Equal("Test", result.FullName);
+        ScenarioExpect.Contains("async-seed", result.Log);
+        ScenarioExpect.Equal("Test", result.FullName);
     }
 
+    [Scenario("AsyncAdapter SeedFrom Uses Input")]
     [Fact]
     public async Task AsyncAdapter_SeedFrom_Uses_Input()
     {
@@ -232,10 +241,11 @@ public sealed class AsyncAdapterTests
 
         var result = await adapter.AdaptAsync(new Source("X", "Y", 42));
 
-        Assert.Equal(42, result.Age);
-        Assert.Equal("X", result.FullName);
+        ScenarioExpect.Equal(42, result.Age);
+        ScenarioExpect.Equal("X", result.FullName);
     }
 
+    [Scenario("AsyncAdapter Async SeedFrom")]
     [Fact]
     public async Task AsyncAdapter_Async_SeedFrom()
     {
@@ -250,10 +260,11 @@ public sealed class AsyncAdapterTests
 
         var result = await adapter.AdaptAsync(new Source("X", "Y", 10));
 
-        Assert.Equal(20, result.Age);
-        Assert.Equal("X", result.FullName);
+        ScenarioExpect.Equal(20, result.Age);
+        ScenarioExpect.Equal("X", result.FullName);
     }
 
+    [Scenario("AsyncAdapter Async Map Step")]
     [Fact]
     public async Task AsyncAdapter_Async_Map_Step()
     {
@@ -268,9 +279,10 @@ public sealed class AsyncAdapterTests
 
         var result = await adapter.AdaptAsync(new Source("Ada", "Lovelace", 30));
 
-        Assert.Equal("Ada Lovelace", result.FullName);
+        ScenarioExpect.Equal("Ada Lovelace", result.FullName);
     }
 
+    [Scenario("AsyncAdapter Require Validation Passes")]
     [Fact]
     public async Task AsyncAdapter_Require_Validation_Passes()
     {
@@ -282,9 +294,10 @@ public sealed class AsyncAdapterTests
 
         var result = await adapter.AdaptAsync(new Source("A", "B", 30));
 
-        Assert.Equal(30, result.Age);
+        ScenarioExpect.Equal(30, result.Age);
     }
 
+    [Scenario("AsyncAdapter Require Validation Fails")]
     [Fact]
     public async Task AsyncAdapter_Require_Validation_Fails()
     {
@@ -294,12 +307,13 @@ public sealed class AsyncAdapterTests
             .Require((src, dest) => dest.Age > 0 ? null : "Age must be positive")
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => adapter.AdaptAsync(new Source("A", "B", -1)).AsTask());
 
-        Assert.Equal("Age must be positive", ex.Message);
+        ScenarioExpect.Equal("Age must be positive", ex.Message);
     }
 
+    [Scenario("AsyncAdapter Async Require Validation")]
     [Fact]
     public async Task AsyncAdapter_Async_Require_Validation()
     {
@@ -313,12 +327,13 @@ public sealed class AsyncAdapterTests
             })
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => adapter.AdaptAsync(new Source("A", "B", -5)).AsTask());
 
-        Assert.Equal("Age must be positive", ex.Message);
+        ScenarioExpect.Equal("Age must be positive", ex.Message);
     }
 
+    [Scenario("AsyncAdapter TryAdapt Returns Success")]
     [Fact]
     public async Task AsyncAdapter_TryAdapt_Returns_Success()
     {
@@ -329,12 +344,13 @@ public sealed class AsyncAdapterTests
 
         var (success, result, error) = await adapter.TryAdaptAsync(new Source("Ada", "L", 30));
 
-        Assert.True(success);
-        Assert.NotNull(result);
-        Assert.Equal("Ada", result.FullName);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.NotNull(result);
+        ScenarioExpect.Equal("Ada", result.FullName);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("AsyncAdapter TryAdapt Returns Validation Error")]
     [Fact]
     public async Task AsyncAdapter_TryAdapt_Returns_Validation_Error()
     {
@@ -346,11 +362,12 @@ public sealed class AsyncAdapterTests
 
         var (success, result, error) = await adapter.TryAdaptAsync(new Source("A", "B", -1));
 
-        Assert.False(success);
-        Assert.Null(result);
-        Assert.Equal("Age must be positive", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(result);
+        ScenarioExpect.Equal("Age must be positive", error);
     }
 
+    [Scenario("AsyncAdapter TryAdapt Catches Exception")]
     [Fact]
     public async Task AsyncAdapter_TryAdapt_Catches_Exception()
     {
@@ -361,11 +378,12 @@ public sealed class AsyncAdapterTests
 
         var (success, result, error) = await adapter.TryAdaptAsync(new Source("A", "B", 30));
 
-        Assert.False(success);
-        Assert.Null(result);
-        Assert.Equal("Map failed", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Null(result);
+        ScenarioExpect.Equal("Map failed", error);
     }
 
+    [Scenario("AsyncAdapter Multiple Maps In Order")]
     [Fact]
     public async Task AsyncAdapter_Multiple_Maps_In_Order()
     {
@@ -378,16 +396,17 @@ public sealed class AsyncAdapterTests
 
         var result = await adapter.AdaptAsync(new Source("A", "B", 30));
 
-        Assert.Equal(3, result.Log.Count);
-        Assert.Equal("map1", result.Log[0]);
-        Assert.Equal("map2", result.Log[1]);
-        Assert.Equal("map3", result.Log[2]);
+        ScenarioExpect.Equal(3, result.Log.Count);
+        ScenarioExpect.Equal("map1", result.Log[0]);
+        ScenarioExpect.Equal("map2", result.Log[1]);
+        ScenarioExpect.Equal("map3", result.Log[2]);
     }
 
+    [Scenario("AsyncAdapter Seed Null Throws")]
     [Fact]
     public void AsyncAdapter_Seed_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncAdapter<Source, Dest>.Create((AsyncAdapter<Source, Dest>.Seed)null!));
     }
 }

--- a/test/PatternKit.Tests/Structural/Bridge/AsyncBridgeTests.cs
+++ b/test/PatternKit.Tests/Structural/Bridge/AsyncBridgeTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Structural.Bridge;
+using TinyBDD;
 
 namespace PatternKit.Tests.Structural.Bridge;
 
@@ -6,6 +7,7 @@ public sealed class AsyncBridgeTests
 {
     #region AsyncBridge<TIn, TOut, TImpl> Tests
 
+    [Scenario("AsyncBridge Executes With Provider")]
     [Fact]
     public async Task AsyncBridge_Executes_With_Provider()
     {
@@ -15,9 +17,10 @@ public sealed class AsyncBridgeTests
 
         var result = await bridge.ExecuteAsync("hello");
 
-        Assert.Equal("hello-42", result);
+        ScenarioExpect.Equal("hello-42", result);
     }
 
+    [Scenario("AsyncBridge Async Provider Works")]
     [Fact]
     public async Task AsyncBridge_Async_Provider_Works()
     {
@@ -31,9 +34,10 @@ public sealed class AsyncBridgeTests
 
         var result = await bridge.ExecuteAsync("test");
 
-        Assert.Equal("test-100", result);
+        ScenarioExpect.Equal("test-100", result);
     }
 
+    [Scenario("AsyncBridge Async Operation Works")]
     [Fact]
     public async Task AsyncBridge_Async_Operation_Works()
     {
@@ -47,9 +51,10 @@ public sealed class AsyncBridgeTests
 
         var result = await bridge.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncBridge TryExecute Returns Success")]
     [Fact]
     public async Task AsyncBridge_TryExecute_Returns_Success()
     {
@@ -59,11 +64,12 @@ public sealed class AsyncBridgeTests
 
         var (success, result, error) = await bridge.TryExecuteAsync("hello");
 
-        Assert.True(success);
-        Assert.Equal("hello-42", result);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("hello-42", result);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("AsyncBridge TryExecute Catches Exception")]
     [Fact]
     public async Task AsyncBridge_TryExecute_Catches_Exception()
     {
@@ -73,11 +79,12 @@ public sealed class AsyncBridgeTests
 
         var (success, result, error) = await bridge.TryExecuteAsync(5);
 
-        Assert.False(success);
-        Assert.Equal(default, result);
-        Assert.Equal("test error", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal(default, result);
+        ScenarioExpect.Equal("test error", error);
     }
 
+    [Scenario("AsyncBridge Before Hook Executes")]
     [Fact]
     public async Task AsyncBridge_Before_Hook_Executes()
     {
@@ -93,10 +100,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("test");
 
-        Assert.Equal("before-test-42", log[0]);
-        Assert.Equal("operation", log[1]);
+        ScenarioExpect.Equal("before-test-42", log[0]);
+        ScenarioExpect.Equal("operation", log[1]);
     }
 
+    [Scenario("AsyncBridge After Hook Executes")]
     [Fact]
     public async Task AsyncBridge_After_Hook_Executes()
     {
@@ -116,11 +124,12 @@ public sealed class AsyncBridgeTests
 
         var result = await bridge.ExecuteAsync("test");
 
-        Assert.Equal("operation", log[0]);
-        Assert.Equal("after-test-42", log[1]);
-        Assert.Equal("test-42-modified", result);
+        ScenarioExpect.Equal("operation", log[0]);
+        ScenarioExpect.Equal("after-test-42", log[1]);
+        ScenarioExpect.Equal("test-42-modified", result);
     }
 
+    [Scenario("AsyncBridge Require Validation Passes")]
     [Fact]
     public async Task AsyncBridge_Require_Validation_Passes()
     {
@@ -131,9 +140,10 @@ public sealed class AsyncBridgeTests
 
         var result = await bridge.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncBridge Require Validation Fails")]
     [Fact]
     public async Task AsyncBridge_Require_Validation_Fails()
     {
@@ -142,12 +152,13 @@ public sealed class AsyncBridgeTests
             .Require((input, impl) => input > 0 ? null : "Input must be positive")
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => bridge.ExecuteAsync(-5).AsTask());
 
-        Assert.Equal("Input must be positive", ex.Message);
+        ScenarioExpect.Equal("Input must be positive", ex.Message);
     }
 
+    [Scenario("AsyncBridge RequireResult Validation Passes")]
     [Fact]
     public async Task AsyncBridge_RequireResult_Validation_Passes()
     {
@@ -158,9 +169,10 @@ public sealed class AsyncBridgeTests
 
         var result = await bridge.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncBridge RequireResult Validation Fails")]
     [Fact]
     public async Task AsyncBridge_RequireResult_Validation_Fails()
     {
@@ -169,12 +181,13 @@ public sealed class AsyncBridgeTests
             .RequireResult((input, impl, result) => result > 0 ? null : "Result must be positive")
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => bridge.ExecuteAsync(-5).AsTask());
 
-        Assert.Equal("Result must be positive", ex.Message);
+        ScenarioExpect.Equal("Result must be positive", ex.Message);
     }
 
+    [Scenario("AsyncBridge ProviderFrom Depends On Input")]
     [Fact]
     public async Task AsyncBridge_ProviderFrom_Depends_On_Input()
     {
@@ -185,13 +198,14 @@ public sealed class AsyncBridgeTests
 
         var result = await bridge.ExecuteAsync(5);
 
-        Assert.Equal(55, result); // 5 + (5*10)
+        ScenarioExpect.Equal(55, result); // 5 + (5*10)
     }
 
+    [Scenario("AsyncBridge Build Throws Without Operation")]
     [Fact]
     public void AsyncBridge_Build_Throws_Without_Operation()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncBridge<int, int, int>.Create(() => 1).Build());
     }
 
@@ -199,6 +213,7 @@ public sealed class AsyncBridgeTests
 
     #region ActionBridge<TIn, TImpl> Tests
 
+    [Scenario("ActionBridge Executes")]
     [Fact]
     public void ActionBridge_Executes()
     {
@@ -209,10 +224,11 @@ public sealed class AsyncBridgeTests
 
         bridge.Execute("hello");
 
-        Assert.Single(log);
-        Assert.Equal("hello-42", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("hello-42", log[0]);
     }
 
+    [Scenario("ActionBridge Before Hook Executes")]
     [Fact]
     public void ActionBridge_Before_Hook_Executes()
     {
@@ -224,10 +240,11 @@ public sealed class AsyncBridgeTests
 
         bridge.Execute("test");
 
-        Assert.Equal("before-test", log[0]);
-        Assert.Equal("operation", log[1]);
+        ScenarioExpect.Equal("before-test", log[0]);
+        ScenarioExpect.Equal("operation", log[1]);
     }
 
+    [Scenario("ActionBridge After Hook Executes")]
     [Fact]
     public void ActionBridge_After_Hook_Executes()
     {
@@ -239,10 +256,11 @@ public sealed class AsyncBridgeTests
 
         bridge.Execute("test");
 
-        Assert.Equal("operation", log[0]);
-        Assert.Equal("after-test", log[1]);
+        ScenarioExpect.Equal("operation", log[0]);
+        ScenarioExpect.Equal("after-test", log[1]);
     }
 
+    [Scenario("ActionBridge TryExecute Returns Success")]
     [Fact]
     public void ActionBridge_TryExecute_Returns_Success()
     {
@@ -253,11 +271,12 @@ public sealed class AsyncBridgeTests
 
         var success = bridge.TryExecute("hello", out var error);
 
-        Assert.True(success);
-        Assert.True(executed);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.True(executed);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("ActionBridge TryExecute Catches Exception")]
     [Fact]
     public void ActionBridge_TryExecute_Catches_Exception()
     {
@@ -267,10 +286,11 @@ public sealed class AsyncBridgeTests
 
         var success = bridge.TryExecute("hello", out var error);
 
-        Assert.False(success);
-        Assert.Equal("test error", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("test error", error);
     }
 
+    [Scenario("ActionBridge Require Validation Passes")]
     [Fact]
     public void ActionBridge_Require_Validation_Passes()
     {
@@ -282,9 +302,10 @@ public sealed class AsyncBridgeTests
 
         bridge.Execute(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionBridge Require Validation Fails")]
     [Fact]
     public void ActionBridge_Require_Validation_Fails()
     {
@@ -293,18 +314,20 @@ public sealed class AsyncBridgeTests
             .Require((in input, impl) => input > 0 ? null : "Input must be positive")
             .Build();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => bridge.Execute(-5));
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() => bridge.Execute(-5));
 
-        Assert.Equal("Input must be positive", ex.Message);
+        ScenarioExpect.Equal("Input must be positive", ex.Message);
     }
 
+    [Scenario("ActionBridge Build Throws Without Operation")]
     [Fact]
     public void ActionBridge_Build_Throws_Without_Operation()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             ActionBridge<int, int>.Create(() => 1).Build());
     }
 
+    [Scenario("ActionBridge ProviderFrom Depends On Input")]
     [Fact]
     public void ActionBridge_ProviderFrom_Depends_On_Input()
     {
@@ -315,13 +338,14 @@ public sealed class AsyncBridgeTests
 
         bridge.Execute(5);
 
-        Assert.Equal(50, capturedImpl);
+        ScenarioExpect.Equal(50, capturedImpl);
     }
 
     #endregion
 
     #region AsyncActionBridge<TIn, TImpl> Tests
 
+    [Scenario("AsyncActionBridge Executes")]
     [Fact]
     public async Task AsyncActionBridge_Executes()
     {
@@ -332,10 +356,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("hello");
 
-        Assert.Single(log);
-        Assert.Equal("hello-42", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("hello-42", log[0]);
     }
 
+    [Scenario("AsyncActionBridge Async Provider Works")]
     [Fact]
     public async Task AsyncActionBridge_Async_Provider_Works()
     {
@@ -350,10 +375,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("test");
 
-        Assert.Single(log);
-        Assert.Equal("test-100", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("test-100", log[0]);
     }
 
+    [Scenario("AsyncActionBridge Sync Operation")]
     [Fact]
     public async Task AsyncActionBridge_Sync_Operation()
     {
@@ -364,10 +390,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("test");
 
-        Assert.Single(log);
-        Assert.Equal("sync-test-42", log[0]);
+        ScenarioExpect.Single(log);
+        ScenarioExpect.Equal("sync-test-42", log[0]);
     }
 
+    [Scenario("AsyncActionBridge Before Hook Executes")]
     [Fact]
     public async Task AsyncActionBridge_Before_Hook_Executes()
     {
@@ -379,10 +406,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("test");
 
-        Assert.Equal("before-test", log[0]);
-        Assert.Equal("operation", log[1]);
+        ScenarioExpect.Equal("before-test", log[0]);
+        ScenarioExpect.Equal("operation", log[1]);
     }
 
+    [Scenario("AsyncActionBridge Before Sync Hook")]
     [Fact]
     public async Task AsyncActionBridge_Before_Sync_Hook()
     {
@@ -394,10 +422,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("test");
 
-        Assert.Equal("sync-before", log[0]);
-        Assert.Equal("operation", log[1]);
+        ScenarioExpect.Equal("sync-before", log[0]);
+        ScenarioExpect.Equal("operation", log[1]);
     }
 
+    [Scenario("AsyncActionBridge After Hook Executes")]
     [Fact]
     public async Task AsyncActionBridge_After_Hook_Executes()
     {
@@ -409,10 +438,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("test");
 
-        Assert.Equal("operation", log[0]);
-        Assert.Equal("after-test", log[1]);
+        ScenarioExpect.Equal("operation", log[0]);
+        ScenarioExpect.Equal("after-test", log[1]);
     }
 
+    [Scenario("AsyncActionBridge After Sync Hook")]
     [Fact]
     public async Task AsyncActionBridge_After_Sync_Hook()
     {
@@ -424,10 +454,11 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync("test");
 
-        Assert.Equal("operation", log[0]);
-        Assert.Equal("sync-after", log[1]);
+        ScenarioExpect.Equal("operation", log[0]);
+        ScenarioExpect.Equal("sync-after", log[1]);
     }
 
+    [Scenario("AsyncActionBridge TryExecute Returns Success")]
     [Fact]
     public async Task AsyncActionBridge_TryExecute_Returns_Success()
     {
@@ -438,11 +469,12 @@ public sealed class AsyncBridgeTests
 
         var (success, error) = await bridge.TryExecuteAsync("hello");
 
-        Assert.True(success);
-        Assert.True(executed);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.True(executed);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("AsyncActionBridge TryExecute Catches Exception")]
     [Fact]
     public async Task AsyncActionBridge_TryExecute_Catches_Exception()
     {
@@ -452,10 +484,11 @@ public sealed class AsyncBridgeTests
 
         var (success, error) = await bridge.TryExecuteAsync("hello");
 
-        Assert.False(success);
-        Assert.Equal("test error", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("test error", error);
     }
 
+    [Scenario("AsyncActionBridge Require Validation Passes")]
     [Fact]
     public async Task AsyncActionBridge_Require_Validation_Passes()
     {
@@ -467,9 +500,10 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionBridge Require Validation Fails")]
     [Fact]
     public async Task AsyncActionBridge_Require_Validation_Fails()
     {
@@ -478,12 +512,13 @@ public sealed class AsyncBridgeTests
             .Require(async (input, impl, ct) => input > 0 ? null : "Input must be positive")
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => bridge.ExecuteAsync(-5).AsTask());
 
-        Assert.Equal("Input must be positive", ex.Message);
+        ScenarioExpect.Equal("Input must be positive", ex.Message);
     }
 
+    [Scenario("AsyncActionBridge Require Sync Validation")]
     [Fact]
     public async Task AsyncActionBridge_Require_Sync_Validation()
     {
@@ -492,12 +527,13 @@ public sealed class AsyncBridgeTests
             .Require((input, impl) => input > 0 ? null : "Sync validation failed")
             .Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await ScenarioExpect.ThrowsAsync<InvalidOperationException>(
             () => bridge.ExecuteAsync(-5).AsTask());
 
-        Assert.Equal("Sync validation failed", ex.Message);
+        ScenarioExpect.Equal("Sync validation failed", ex.Message);
     }
 
+    [Scenario("AsyncActionBridge TryExecute Returns Validation Error")]
     [Fact]
     public async Task AsyncActionBridge_TryExecute_Returns_Validation_Error()
     {
@@ -508,10 +544,11 @@ public sealed class AsyncBridgeTests
 
         var (success, error) = await bridge.TryExecuteAsync(-5);
 
-        Assert.False(success);
-        Assert.Equal("Input must be positive", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("Input must be positive", error);
     }
 
+    [Scenario("AsyncActionBridge ProviderFrom Depends On Input")]
     [Fact]
     public async Task AsyncActionBridge_ProviderFrom_Depends_On_Input()
     {
@@ -523,13 +560,14 @@ public sealed class AsyncBridgeTests
 
         await bridge.ExecuteAsync(5);
 
-        Assert.Equal(50, capturedImpl);
+        ScenarioExpect.Equal(50, capturedImpl);
     }
 
+    [Scenario("AsyncActionBridge Build Throws Without Operation")]
     [Fact]
     public void AsyncActionBridge_Build_Throws_Without_Operation()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncActionBridge<int, int>.Create(() => 1).Build());
     }
 
@@ -537,17 +575,19 @@ public sealed class AsyncBridgeTests
 
     #region Null Argument Tests
 
+    [Scenario("AsyncBridge Provider Null Throws")]
     [Fact]
     public void AsyncBridge_Provider_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncBridge<int, int, int>.Create((AsyncBridge<int, int, int>.Provider)null!));
     }
 
+    [Scenario("ActionBridge Provider Null Throws")]
     [Fact]
     public void ActionBridge_Provider_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionBridge<int, int>.Create((ActionBridge<int, int>.Provider)null!));
     }
 

--- a/test/PatternKit.Tests/Structural/Bridge/BridgeTests.cs
+++ b/test/PatternKit.Tests/Structural/Bridge/BridgeTests.cs
@@ -124,6 +124,7 @@ public sealed class BridgeBuilderTests
         public List<string> Log { get; } = [];
     }
 
+    [Scenario("TryExecute Success ReturnsTrue")]
     [Fact]
     public void TryExecute_Success_ReturnsTrue()
     {
@@ -134,11 +135,12 @@ public sealed class BridgeBuilderTests
 
         var success = bridge.TryExecute(new Job("test"), out var output, out var error);
 
-        Assert.True(success);
-        Assert.Equal("default:test", output);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("default:test", output);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("TryExecute PreValidationFails ReturnsFalse")]
     [Fact]
     public void TryExecute_PreValidationFails_ReturnsFalse()
     {
@@ -150,10 +152,11 @@ public sealed class BridgeBuilderTests
 
         var success = bridge.TryExecute(new Job(""), out var output, out var error);
 
-        Assert.False(success);
-        Assert.Equal("data required", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("data required", error);
     }
 
+    [Scenario("TryExecute ResultValidationFails ReturnsFalse")]
     [Fact]
     public void TryExecute_ResultValidationFails_ReturnsFalse()
     {
@@ -165,10 +168,11 @@ public sealed class BridgeBuilderTests
 
         var success = bridge.TryExecute(new Job("this is long data"), out var output, out var error);
 
-        Assert.False(success);
-        Assert.Equal("result too long", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("result too long", error);
     }
 
+    [Scenario("TryExecute OperationThrows ReturnsFalse")]
     [Fact]
     public void TryExecute_OperationThrows_ReturnsFalse()
     {
@@ -179,10 +183,11 @@ public sealed class BridgeBuilderTests
 
         var success = bridge.TryExecute(new Job("test"), out var output, out var error);
 
-        Assert.False(success);
-        Assert.Equal("operation failed", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("operation failed", error);
     }
 
+    [Scenario("TryExecute PreHookThrows ReturnsFalse")]
     [Fact]
     public void TryExecute_PreHookThrows_ReturnsFalse()
     {
@@ -194,10 +199,11 @@ public sealed class BridgeBuilderTests
 
         var success = bridge.TryExecute(new Job("test"), out var output, out var error);
 
-        Assert.False(success);
-        Assert.Equal("pre hook failed", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("pre hook failed", error);
     }
 
+    [Scenario("TryExecute PostHookThrows ReturnsFalse")]
     [Fact]
     public void TryExecute_PostHookThrows_ReturnsFalse()
     {
@@ -209,10 +215,11 @@ public sealed class BridgeBuilderTests
 
         var success = bridge.TryExecute(new Job("test"), out var output, out var error);
 
-        Assert.False(success);
-        Assert.Equal("post hook failed", error);
+        ScenarioExpect.False(success);
+        ScenarioExpect.Equal("post hook failed", error);
     }
 
+    [Scenario("Multiple PreHooks ExecuteInOrder")]
     [Fact]
     public void Multiple_PreHooks_ExecuteInOrder()
     {
@@ -227,9 +234,10 @@ public sealed class BridgeBuilderTests
 
         bridge.Execute(new Job("test"));
 
-        Assert.Equal(new[] { "pre1", "pre2", "pre3" }, log);
+        ScenarioExpect.Equal(new[] { "pre1", "pre2", "pre3" }, log);
     }
 
+    [Scenario("Multiple PostHooks TransformInOrder")]
     [Fact]
     public void Multiple_PostHooks_TransformInOrder()
     {
@@ -243,9 +251,10 @@ public sealed class BridgeBuilderTests
 
         var result = bridge.Execute(new Job("test"));
 
-        Assert.Equal("(<[test]>)", result);
+        ScenarioExpect.Equal("(<[test]>)", result);
     }
 
+    [Scenario("Multiple Validators FirstFailStops")]
     [Fact]
     public void Multiple_Validators_FirstFailStops()
     {
@@ -258,12 +267,13 @@ public sealed class BridgeBuilderTests
             .Operation((in j, r) => "result")
             .Build();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => bridge.Execute(new Job("test")));
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() => bridge.Execute(new Job("test")));
 
-        Assert.Equal("fail at 2", ex.Message);
-        Assert.Equal(new[] { 1, 2 }, validatorCalls); // Third validator not called
+        ScenarioExpect.Equal("fail at 2", ex.Message);
+        ScenarioExpect.Equal(new[] { 1, 2 }, validatorCalls); // Third validator not called
     }
 
+    [Scenario("Multiple ResultValidators FirstFailStops")]
     [Fact]
     public void Multiple_ResultValidators_FirstFailStops()
     {
@@ -276,19 +286,21 @@ public sealed class BridgeBuilderTests
             .RequireResult((in j, _, in result) => { validatorCalls.Add(3); return null; })
             .Build();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => bridge.Execute(new Job("test")));
+        var ex = ScenarioExpect.Throws<InvalidOperationException>(() => bridge.Execute(new Job("test")));
 
-        Assert.Equal("result fail at 2", ex.Message);
-        Assert.Equal(new[] { 1, 2 }, validatorCalls);
+        ScenarioExpect.Equal("result fail at 2", ex.Message);
+        ScenarioExpect.Equal(new[] { 1, 2 }, validatorCalls);
     }
 
+    [Scenario("ProviderFrom WithNull Throws")]
     [Fact]
     public void ProviderFrom_WithNull_Throws()
     {
-        var ex = Assert.Throws<ArgumentNullException>(() =>
+        var ex = ScenarioExpect.Throws<ArgumentNullException>(() =>
             Bridge<Job, string, Renderer>.Create((Bridge<Job, string, Renderer>.ProviderFrom)null!));
     }
 
+    [Scenario("Execute ProviderFrom ReceivesInput")]
     [Fact]
     public void Execute_ProviderFrom_ReceivesInput()
     {
@@ -300,11 +312,12 @@ public sealed class BridgeBuilderTests
 
         var result = bridge.Execute(new Job("data", Format: "custom"));
 
-        Assert.NotNull(capturedImpl);
-        Assert.Equal("custom", capturedImpl!.Name);
-        Assert.Equal("custom", result);
+        ScenarioExpect.NotNull(capturedImpl);
+        ScenarioExpect.Equal("custom", capturedImpl!.Name);
+        ScenarioExpect.Equal("custom", result);
     }
 
+    [Scenario("TryExecute ProviderFrom UsesCorrectProvider")]
     [Fact]
     public void TryExecute_ProviderFrom_UsesCorrectProvider()
     {
@@ -315,9 +328,10 @@ public sealed class BridgeBuilderTests
 
         bridge.TryExecute(new Job("test", Format: "pdf"), out var output, out _);
 
-        Assert.Equal("pdf", output);
+        ScenarioExpect.Equal("pdf", output);
     }
 
+    [Scenario("TryExecute WithValidatorsButAllPass ReturnsTrue")]
     [Fact]
     public void TryExecute_WithValidatorsButAllPass_ReturnsTrue()
     {
@@ -331,11 +345,12 @@ public sealed class BridgeBuilderTests
 
         var success = bridge.TryExecute(new Job("data"), out var output, out var error);
 
-        Assert.True(success);
-        Assert.Equal("result", output);
-        Assert.Null(error);
+        ScenarioExpect.True(success);
+        ScenarioExpect.Equal("result", output);
+        ScenarioExpect.Null(error);
     }
 
+    [Scenario("TryExecute WithPostHooks AppliesTransformations")]
     [Fact]
     public void TryExecute_WithPostHooks_AppliesTransformations()
     {
@@ -347,7 +362,7 @@ public sealed class BridgeBuilderTests
 
         bridge.TryExecute(new Job("hello"), out var output, out _);
 
-        Assert.Equal("HELLO", output);
+        ScenarioExpect.Equal("HELLO", output);
     }
 }
 

--- a/test/PatternKit.Tests/Structural/Composite/AsyncCompositeTests.cs
+++ b/test/PatternKit.Tests/Structural/Composite/AsyncCompositeTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Structural.Composite;
+using TinyBDD;
 
 namespace PatternKit.Tests.Structural.Composite;
 
@@ -6,6 +7,7 @@ public sealed class AsyncCompositeTests
 {
     #region AsyncComposite<TIn, TOut> Tests
 
+    [Scenario("AsyncComposite Leaf Executes")]
     [Fact]
     public async Task AsyncComposite_Leaf_Executes()
     {
@@ -18,9 +20,10 @@ public sealed class AsyncCompositeTests
 
         var result = await leaf.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncComposite Leaf Sync Executes")]
     [Fact]
     public async Task AsyncComposite_Leaf_Sync_Executes()
     {
@@ -29,9 +32,10 @@ public sealed class AsyncCompositeTests
 
         var result = await leaf.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncComposite Node Aggregates Results")]
     [Fact]
     public async Task AsyncComposite_Node_Aggregates_Results()
     {
@@ -44,9 +48,10 @@ public sealed class AsyncCompositeTests
 
         var result = await composite.ExecuteAsync(5);
 
-        Assert.Equal(25, result); // 10 + 15
+        ScenarioExpect.Equal(25, result); // 10 + 15
     }
 
+    [Scenario("AsyncComposite Node Sync Aggregates")]
     [Fact]
     public async Task AsyncComposite_Node_Sync_Aggregates()
     {
@@ -59,9 +64,10 @@ public sealed class AsyncCompositeTests
 
         var result = await composite.ExecuteAsync(5);
 
-        Assert.Equal(10, result); // 5 + 5
+        ScenarioExpect.Equal(10, result); // 5 + 5
     }
 
+    [Scenario("AsyncComposite Nested Composites")]
     [Fact]
     public async Task AsyncComposite_Nested_Composites()
     {
@@ -82,9 +88,10 @@ public sealed class AsyncCompositeTests
         // Note: This test shows composition but uses sync approach for inner
         var result = await outerComposite.ExecuteAsync(5);
 
-        Assert.Equal(60, result); // 10 + 50
+        ScenarioExpect.Equal(60, result); // 10 + 50
     }
 
+    [Scenario("AsyncComposite Empty Node Returns Seed")]
     [Fact]
     public async Task AsyncComposite_Empty_Node_Returns_Seed()
     {
@@ -95,9 +102,10 @@ public sealed class AsyncCompositeTests
 
         var result = await composite.ExecuteAsync(5);
 
-        Assert.Equal(42, result);
+        ScenarioExpect.Equal(42, result);
     }
 
+    [Scenario("AsyncComposite AddChildren Multiple")]
     [Fact]
     public async Task AsyncComposite_AddChildren_Multiple()
     {
@@ -112,9 +120,10 @@ public sealed class AsyncCompositeTests
 
         var result = await composite.ExecuteAsync(0);
 
-        Assert.Equal(24, result); // 1 * 2 * 3 * 4
+        ScenarioExpect.Equal(24, result); // 1 * 2 * 3 * 4
     }
 
+    [Scenario("AsyncComposite AddChild Ignored On Leaf")]
     [Fact]
     public async Task AsyncComposite_AddChild_Ignored_On_Leaf()
     {
@@ -124,13 +133,14 @@ public sealed class AsyncCompositeTests
 
         var result = await leaf.ExecuteAsync(5);
 
-        Assert.Equal(10, result); // Child is ignored
+        ScenarioExpect.Equal(10, result); // Child is ignored
     }
 
     #endregion
 
     #region ActionComposite<TIn> Tests
 
+    [Scenario("ActionComposite Leaf Executes")]
     [Fact]
     public void ActionComposite_Leaf_Executes()
     {
@@ -140,9 +150,10 @@ public sealed class AsyncCompositeTests
 
         leaf.Execute(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionComposite Node Executes All Children")]
     [Fact]
     public void ActionComposite_Node_Executes_All_Children()
     {
@@ -154,11 +165,12 @@ public sealed class AsyncCompositeTests
 
         composite.Execute(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("leaf1-5", log[0]);
-        Assert.Equal("leaf2-5", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("leaf1-5", log[0]);
+        ScenarioExpect.Equal("leaf2-5", log[1]);
     }
 
+    [Scenario("ActionComposite Node With Pre Post")]
     [Fact]
     public void ActionComposite_Node_With_Pre_Post()
     {
@@ -171,12 +183,13 @@ public sealed class AsyncCompositeTests
 
         composite.Execute(5);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("pre", log[0]);
-        Assert.Equal("child", log[1]);
-        Assert.Equal("post", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("pre", log[0]);
+        ScenarioExpect.Equal("child", log[1]);
+        ScenarioExpect.Equal("post", log[2]);
     }
 
+    [Scenario("ActionComposite Nested")]
     [Fact]
     public void ActionComposite_Nested()
     {
@@ -192,11 +205,12 @@ public sealed class AsyncCompositeTests
 
         outer.Execute(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("inner", log[0]);
-        Assert.Equal("outer", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("inner", log[0]);
+        ScenarioExpect.Equal("outer", log[1]);
     }
 
+    [Scenario("ActionComposite AddChildren Multiple")]
     [Fact]
     public void ActionComposite_AddChildren_Multiple()
     {
@@ -210,9 +224,10 @@ public sealed class AsyncCompositeTests
 
         composite.Execute(0);
 
-        Assert.Equal([1, 2, 3], log);
+        ScenarioExpect.Equal([1, 2, 3], log);
     }
 
+    [Scenario("ActionComposite Empty Node Executes")]
     [Fact]
     public void ActionComposite_Empty_Node_Executes()
     {
@@ -225,14 +240,15 @@ public sealed class AsyncCompositeTests
 
         composite.Execute(5);
 
-        Assert.True(preExecuted);
-        Assert.True(postExecuted);
+        ScenarioExpect.True(preExecuted);
+        ScenarioExpect.True(postExecuted);
     }
 
     #endregion
 
     #region AsyncActionComposite<TIn> Tests
 
+    [Scenario("AsyncActionComposite Leaf Executes")]
     [Fact]
     public async Task AsyncActionComposite_Leaf_Executes()
     {
@@ -246,9 +262,10 @@ public sealed class AsyncCompositeTests
 
         await composite.ExecuteAsync(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionComposite Leaf Sync Executes")]
     [Fact]
     public async Task AsyncActionComposite_Leaf_Sync_Executes()
     {
@@ -258,9 +275,10 @@ public sealed class AsyncCompositeTests
 
         await composite.ExecuteAsync(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionComposite Node Executes Children Sequentially")]
     [Fact]
     public async Task AsyncActionComposite_Node_Executes_Children_Sequentially()
     {
@@ -280,11 +298,12 @@ public sealed class AsyncCompositeTests
 
         await composite.ExecuteAsync(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("child1", log[0]);
-        Assert.Equal("child2", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("child1", log[0]);
+        ScenarioExpect.Equal("child2", log[1]);
     }
 
+    [Scenario("AsyncActionComposite ParallelNode Executes Children Concurrently")]
     [Fact]
     public async Task AsyncActionComposite_ParallelNode_Executes_Children_Concurrently()
     {
@@ -305,12 +324,13 @@ public sealed class AsyncCompositeTests
 
         await composite.ExecuteAsync(5);
 
-        Assert.Equal(2, log.Count);
+        ScenarioExpect.Equal(2, log.Count);
         // Fast should complete before slow because parallel execution
-        Assert.Equal("fast", log[0]);
-        Assert.Equal("slow", log[1]);
+        ScenarioExpect.Equal("fast", log[0]);
+        ScenarioExpect.Equal("slow", log[1]);
     }
 
+    [Scenario("AsyncActionComposite Node With PrePost Hooks")]
     [Fact]
     public async Task AsyncActionComposite_Node_With_PrePost_Hooks()
     {
@@ -323,12 +343,13 @@ public sealed class AsyncCompositeTests
 
         await composite.ExecuteAsync(5);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("pre", log[0]);
-        Assert.Equal("child", log[1]);
-        Assert.Equal("post", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("pre", log[0]);
+        ScenarioExpect.Equal("child", log[1]);
+        ScenarioExpect.Equal("post", log[2]);
     }
 
+    [Scenario("AsyncActionComposite AddChildren Multiple")]
     [Fact]
     public async Task AsyncActionComposite_AddChildren_Multiple()
     {
@@ -342,9 +363,10 @@ public sealed class AsyncCompositeTests
 
         await composite.ExecuteAsync(5);
 
-        Assert.Equal(3, count);
+        ScenarioExpect.Equal(3, count);
     }
 
+    [Scenario("AsyncActionComposite Nested Structure")]
     [Fact]
     public async Task AsyncActionComposite_Nested_Structure()
     {
@@ -358,12 +380,13 @@ public sealed class AsyncCompositeTests
 
         await composite.ExecuteAsync(5);
 
-        Assert.Equal(3, log.Count);
-        Assert.Equal("inner-pre", log[0]);
-        Assert.Equal("inner-leaf", log[1]);
-        Assert.Equal("outer-leaf", log[2]);
+        ScenarioExpect.Equal(3, log.Count);
+        ScenarioExpect.Equal("inner-pre", log[0]);
+        ScenarioExpect.Equal("inner-leaf", log[1]);
+        ScenarioExpect.Equal("outer-leaf", log[2]);
     }
 
+    [Scenario("AsyncActionComposite AddChild Ignored For Leaf")]
     [Fact]
     public void AsyncActionComposite_AddChild_Ignored_For_Leaf()
     {
@@ -373,13 +396,14 @@ public sealed class AsyncCompositeTests
 
         // Should still build successfully as a leaf
         var composite = builder.Build();
-        Assert.NotNull(composite);
+        ScenarioExpect.NotNull(composite);
     }
 
+    [Scenario("AsyncActionComposite Leaf Null Throws")]
     [Fact]
     public void AsyncActionComposite_Leaf_Null_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncActionComposite<int>.Leaf((AsyncActionComposite<int>.LeafAction)null!).Build());
     }
 
@@ -387,19 +411,21 @@ public sealed class AsyncCompositeTests
 
     #region Null Argument Tests
 
+    [Scenario("AsyncComposite Leaf Null Throws")]
     [Fact]
     public void AsyncComposite_Leaf_Null_Throws()
     {
         // Build() validates that leaf operation is set and throws InvalidOperationException
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncComposite<int, int>.Leaf((AsyncComposite<int, int>.LeafOp)null!).Build());
     }
 
+    [Scenario("ActionComposite Leaf Null Throws")]
     [Fact]
     public void ActionComposite_Leaf_Null_Throws()
     {
         // Build() validates that leaf operation is set and throws InvalidOperationException
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             ActionComposite<int>.Leaf(null!).Build());
     }
 

--- a/test/PatternKit.Tests/Structural/Composite/CompositeTests.cs
+++ b/test/PatternKit.Tests/Structural/Composite/CompositeTests.cs
@@ -72,7 +72,7 @@ public sealed class CompositeTests(ITestOutputHelper output) : TinyBddXunitBase(
     [Fact]
     public Task Build_Misuse_Throws()
         => Given("a builder-like misuse simulation", () => (Composite<int, int>.Builder?)null)
-            .When("calling Node with nulls is impossible at compile time; instead simulate by reflection? skip; assert leaf works", _ =>
+            .When("calling Node with nulls is impossible at compile time; instead simulate by reflection? skip; verify leaf works", _ =>
             {
                 var ex = Record.Exception(() => Composite<int, int>.Leaf(static (in x) => x).Build());
                 return ex;

--- a/test/PatternKit.Tests/Structural/Decorator/AsyncDecoratorTests.cs
+++ b/test/PatternKit.Tests/Structural/Decorator/AsyncDecoratorTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Structural.Decorator;
+using TinyBDD;
 
 namespace PatternKit.Tests.Structural.Decorator;
 
@@ -6,6 +7,7 @@ public sealed class AsyncDecoratorTests
 {
     #region AsyncDecorator<TIn, TOut> Tests
 
+    [Scenario("AsyncDecorator Core Executes")]
     [Fact]
     public async Task AsyncDecorator_Core_Executes()
     {
@@ -18,9 +20,10 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncDecorator Sync Core Executes")]
     [Fact]
     public async Task AsyncDecorator_Sync_Core_Executes()
     {
@@ -29,9 +32,10 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncDecorator Before Transforms Input")]
     [Fact]
     public async Task AsyncDecorator_Before_Transforms_Input()
     {
@@ -41,9 +45,10 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal(30, result); // (5+10) * 2
+        ScenarioExpect.Equal(30, result); // (5+10) * 2
     }
 
+    [Scenario("AsyncDecorator Before Async Transforms Input")]
     [Fact]
     public async Task AsyncDecorator_Before_Async_Transforms_Input()
     {
@@ -57,9 +62,10 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal(30, result); // (5+10) * 2
+        ScenarioExpect.Equal(30, result); // (5+10) * 2
     }
 
+    [Scenario("AsyncDecorator After Transforms Output")]
     [Fact]
     public async Task AsyncDecorator_After_Transforms_Output()
     {
@@ -69,9 +75,10 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal(11, result); // 5*2 + 1
+        ScenarioExpect.Equal(11, result); // 5*2 + 1
     }
 
+    [Scenario("AsyncDecorator After Async Transforms Output")]
     [Fact]
     public async Task AsyncDecorator_After_Async_Transforms_Output()
     {
@@ -85,9 +92,10 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal(15, result); // 5*2 + 5
+        ScenarioExpect.Equal(15, result); // 5*2 + 5
     }
 
+    [Scenario("AsyncDecorator Around Wraps Execution")]
     [Fact]
     public async Task AsyncDecorator_Around_Wraps_Execution()
     {
@@ -108,12 +116,13 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal("around-before", log[0]);
-        Assert.Equal("core", log[1]);
-        Assert.Equal("around-after", log[2]);
-        Assert.Equal(11, result); // 5*2 + 1
+        ScenarioExpect.Equal("around-before", log[0]);
+        ScenarioExpect.Equal("core", log[1]);
+        ScenarioExpect.Equal("around-after", log[2]);
+        ScenarioExpect.Equal(11, result); // 5*2 + 1
     }
 
+    [Scenario("AsyncDecorator Multiple Layers Execute In Order")]
     [Fact]
     public async Task AsyncDecorator_Multiple_Layers_Execute_In_Order()
     {
@@ -132,14 +141,15 @@ public sealed class AsyncDecoratorTests
         await decorator.ExecuteAsync(5);
 
         // Before hooks execute in order (FIFO)
-        Assert.Equal("before-1", log[0]);
-        Assert.Equal("before-2", log[1]);
-        Assert.Equal("core", log[2]);
+        ScenarioExpect.Equal("before-1", log[0]);
+        ScenarioExpect.Equal("before-2", log[1]);
+        ScenarioExpect.Equal("core", log[2]);
         // After hooks execute in reverse order (LIFO - like onion layers unwinding)
-        Assert.Equal("after-2", log[3]);
-        Assert.Equal("after-1", log[4]);
+        ScenarioExpect.Equal("after-2", log[3]);
+        ScenarioExpect.Equal("after-1", log[4]);
     }
 
+    [Scenario("AsyncDecorator No Layers Executes Core")]
     [Fact]
     public async Task AsyncDecorator_No_Layers_Executes_Core()
     {
@@ -148,13 +158,14 @@ public sealed class AsyncDecoratorTests
 
         var result = await decorator.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
     #endregion
 
     #region AsyncActionDecorator<TIn> Tests
 
+    [Scenario("AsyncActionDecorator Core Executes")]
     [Fact]
     public async Task AsyncActionDecorator_Core_Executes()
     {
@@ -168,9 +179,10 @@ public sealed class AsyncDecoratorTests
 
         await decorator.ExecuteAsync(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionDecorator Before Transforms Input")]
     [Fact]
     public async Task AsyncActionDecorator_Before_Transforms_Input()
     {
@@ -185,9 +197,10 @@ public sealed class AsyncDecoratorTests
 
         await decorator.ExecuteAsync(5);
 
-        Assert.Equal(15, capturedInput);
+        ScenarioExpect.Equal(15, capturedInput);
     }
 
+    [Scenario("AsyncActionDecorator Before Async Transforms Input")]
     [Fact]
     public async Task AsyncActionDecorator_Before_Async_Transforms_Input()
     {
@@ -206,9 +219,10 @@ public sealed class AsyncDecoratorTests
 
         await decorator.ExecuteAsync(5);
 
-        Assert.Equal(15, capturedInput);
+        ScenarioExpect.Equal(15, capturedInput);
     }
 
+    [Scenario("AsyncActionDecorator After Executes After Core")]
     [Fact]
     public async Task AsyncActionDecorator_After_Executes_After_Core()
     {
@@ -223,10 +237,11 @@ public sealed class AsyncDecoratorTests
 
         await decorator.ExecuteAsync(5);
 
-        Assert.Equal("core", log[0]);
-        Assert.Equal("after", log[1]);
+        ScenarioExpect.Equal("core", log[0]);
+        ScenarioExpect.Equal("after", log[1]);
     }
 
+    [Scenario("AsyncActionDecorator After Async Executes After Core")]
     [Fact]
     public async Task AsyncActionDecorator_After_Async_Executes_After_Core()
     {
@@ -245,10 +260,11 @@ public sealed class AsyncDecoratorTests
 
         await decorator.ExecuteAsync(5);
 
-        Assert.Equal("core", log[0]);
-        Assert.Equal("after", log[1]);
+        ScenarioExpect.Equal("core", log[0]);
+        ScenarioExpect.Equal("after", log[1]);
     }
 
+    [Scenario("AsyncActionDecorator Around Wraps Execution")]
     [Fact]
     public async Task AsyncActionDecorator_Around_Wraps_Execution()
     {
@@ -268,11 +284,12 @@ public sealed class AsyncDecoratorTests
 
         await decorator.ExecuteAsync(5);
 
-        Assert.Equal("around-before", log[0]);
-        Assert.Equal("core", log[1]);
-        Assert.Equal("around-after", log[2]);
+        ScenarioExpect.Equal("around-before", log[0]);
+        ScenarioExpect.Equal("core", log[1]);
+        ScenarioExpect.Equal("around-after", log[2]);
     }
 
+    [Scenario("AsyncActionDecorator Multiple Layers")]
     [Fact]
     public async Task AsyncActionDecorator_Multiple_Layers()
     {
@@ -288,15 +305,16 @@ public sealed class AsyncDecoratorTests
 
         await decorator.ExecuteAsync(5);
 
-        Assert.Equal("before", log[0]);
-        Assert.Equal("core", log[1]);
-        Assert.Equal("after", log[2]);
+        ScenarioExpect.Equal("before", log[0]);
+        ScenarioExpect.Equal("core", log[1]);
+        ScenarioExpect.Equal("after", log[2]);
     }
 
     #endregion
 
     #region ActionDecorator<TIn> Tests
 
+    [Scenario("ActionDecorator Core Executes")]
     [Fact]
     public void ActionDecorator_Core_Executes()
     {
@@ -305,9 +323,10 @@ public sealed class AsyncDecoratorTests
 
         decorator.Execute(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionDecorator Before Transforms Input")]
     [Fact]
     public void ActionDecorator_Before_Transforms_Input()
     {
@@ -318,9 +337,10 @@ public sealed class AsyncDecoratorTests
 
         decorator.Execute(5);
 
-        Assert.Equal(15, capturedInput);
+        ScenarioExpect.Equal(15, capturedInput);
     }
 
+    [Scenario("ActionDecorator After Executes After Core")]
     [Fact]
     public void ActionDecorator_After_Executes_After_Core()
     {
@@ -331,10 +351,11 @@ public sealed class AsyncDecoratorTests
 
         decorator.Execute(5);
 
-        Assert.Equal("core", log[0]);
-        Assert.Equal("after", log[1]);
+        ScenarioExpect.Equal("core", log[0]);
+        ScenarioExpect.Equal("after", log[1]);
     }
 
+    [Scenario("ActionDecorator Around Wraps Execution")]
     [Fact]
     public void ActionDecorator_Around_Wraps_Execution()
     {
@@ -350,11 +371,12 @@ public sealed class AsyncDecoratorTests
 
         decorator.Execute(5);
 
-        Assert.Equal("around-before", log[0]);
-        Assert.Equal("core", log[1]);
-        Assert.Equal("around-after", log[2]);
+        ScenarioExpect.Equal("around-before", log[0]);
+        ScenarioExpect.Equal("core", log[1]);
+        ScenarioExpect.Equal("around-after", log[2]);
     }
 
+    [Scenario("ActionDecorator Multiple Layers")]
     [Fact]
     public void ActionDecorator_Multiple_Layers()
     {
@@ -369,14 +391,15 @@ public sealed class AsyncDecoratorTests
         decorator.Execute(5);
 
         // Before hooks execute in order (FIFO)
-        Assert.Equal("before-1", log[0]);
-        Assert.Equal("before-2", log[1]);
-        Assert.Equal("core", log[2]);
+        ScenarioExpect.Equal("before-1", log[0]);
+        ScenarioExpect.Equal("before-2", log[1]);
+        ScenarioExpect.Equal("core", log[2]);
         // After hooks execute in reverse order (LIFO - like onion layers unwinding)
-        Assert.Equal("after-2", log[3]);
-        Assert.Equal("after-1", log[4]);
+        ScenarioExpect.Equal("after-2", log[3]);
+        ScenarioExpect.Equal("after-1", log[4]);
     }
 
+    [Scenario("ActionDecorator No Layers Executes Core")]
     [Fact]
     public void ActionDecorator_No_Layers_Executes_Core()
     {
@@ -385,9 +408,10 @@ public sealed class AsyncDecoratorTests
 
         decorator.Execute(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionDecorator Around Can Skip Core")]
     [Fact]
     public void ActionDecorator_Around_Can_Skip_Core()
     {
@@ -401,100 +425,112 @@ public sealed class AsyncDecoratorTests
 
         decorator.Execute(5);
 
-        Assert.False(coreExecuted);
+        ScenarioExpect.False(coreExecuted);
     }
 
     #endregion
 
     #region Null Argument Tests
 
+    [Scenario("AsyncDecorator Component Null Throws")]
     [Fact]
     public void AsyncDecorator_Component_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncDecorator<int, int>.Create(null!));
     }
 
+    [Scenario("AsyncDecorator Before Null Throws")]
     [Fact]
     public void AsyncDecorator_Before_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncDecorator<int, int>.Create((x, _) => new ValueTask<int>(x))
                 .Before((AsyncDecorator<int, int>.BeforeTransform)null!));
     }
 
+    [Scenario("AsyncDecorator After Null Throws")]
     [Fact]
     public void AsyncDecorator_After_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncDecorator<int, int>.Create((x, _) => new ValueTask<int>(x))
                 .After((AsyncDecorator<int, int>.AfterTransform)null!));
     }
 
+    [Scenario("AsyncDecorator Around Null Throws")]
     [Fact]
     public void AsyncDecorator_Around_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncDecorator<int, int>.Create((x, _) => new ValueTask<int>(x))
                 .Around(null!));
     }
 
+    [Scenario("AsyncActionDecorator Component Null Throws")]
     [Fact]
     public void AsyncActionDecorator_Component_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionDecorator<int>.Create(null!));
     }
 
+    [Scenario("AsyncActionDecorator Before Null Throws")]
     [Fact]
     public void AsyncActionDecorator_Before_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionDecorator<int>.Create((x, _) => default)
                 .Before((AsyncActionDecorator<int>.BeforeTransform)null!));
     }
 
+    [Scenario("AsyncActionDecorator After Null Throws")]
     [Fact]
     public void AsyncActionDecorator_After_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionDecorator<int>.Create((x, _) => default)
                 .After((AsyncActionDecorator<int>.AfterAction)null!));
     }
 
+    [Scenario("AsyncActionDecorator Around Null Throws")]
     [Fact]
     public void AsyncActionDecorator_Around_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionDecorator<int>.Create((x, _) => default)
                 .Around(null!));
     }
 
+    [Scenario("ActionDecorator Component Null Throws")]
     [Fact]
     public void ActionDecorator_Component_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionDecorator<int>.Create(null!));
     }
 
+    [Scenario("ActionDecorator Before Null Throws")]
     [Fact]
     public void ActionDecorator_Before_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionDecorator<int>.Create(x => { }).Before(null!));
     }
 
+    [Scenario("ActionDecorator After Null Throws")]
     [Fact]
     public void ActionDecorator_After_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionDecorator<int>.Create(x => { }).After(null!));
     }
 
+    [Scenario("ActionDecorator Around Null Throws")]
     [Fact]
     public void ActionDecorator_Around_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionDecorator<int>.Create(x => { }).Around(null!));
     }
 

--- a/test/PatternKit.Tests/Structural/Decorator/DecoratorTests.cs
+++ b/test/PatternKit.Tests/Structural/Decorator/DecoratorTests.cs
@@ -259,9 +259,9 @@ public sealed class DecoratorTests(ITestOutputHelper output) : TinyBddXunitBase(
         operation.Execute(5);
         operation.Execute(5);
 
-        // Assert
-        Assert.Equal(1, callCount); // Component called only once
-        Assert.Equal(25, cache[5]); // Cache contains result
+        // Then
+        ScenarioExpect.Equal(1, callCount); // Component called only once
+        ScenarioExpect.Equal(25, cache[5]); // Cache contains result
 
         return Task.CompletedTask;
     }

--- a/test/PatternKit.Tests/Structural/Facade/TypedFacadeTests.cs
+++ b/test/PatternKit.Tests/Structural/Facade/TypedFacadeTests.cs
@@ -328,6 +328,6 @@ public sealed class TypedFacadeTests(ITestOutputHelper output) : TinyBddXunitBas
     private static ArgumentException? InvokePrivateArgumentException(Action action)
     {
         var exception = Record.Exception(action);
-        return Assert.IsType<ArgumentException>(Assert.IsType<TargetInvocationException>(exception).InnerException);
+        return ScenarioExpect.IsType<ArgumentException>(ScenarioExpect.IsType<TargetInvocationException>(exception).InnerException);
     }
 }

--- a/test/PatternKit.Tests/Structural/Flyweight/FlyweightTests.cs
+++ b/test/PatternKit.Tests/Structural/Flyweight/FlyweightTests.cs
@@ -197,34 +197,39 @@ public sealed class FlyweightTests(ITestOutputHelper output) : TinyBddXunitBase(
 
 public sealed class FlyweightBuilderTests
 {
+    [Scenario("WithFactory Null Throws")]
     [Fact]
     public void WithFactory_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             Flyweight<int, string>.Create().WithFactory(null!));
     }
 
+    [Scenario("WithCapacity Negative Throws")]
     [Fact]
     public void WithCapacity_Negative_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        ScenarioExpect.Throws<ArgumentOutOfRangeException>(() =>
             Flyweight<int, string>.Create().WithCapacity(-1));
     }
 
+    [Scenario("WithComparer Null Throws")]
     [Fact]
     public void WithComparer_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             Flyweight<int, string>.Create().WithComparer(null!));
     }
 
+    [Scenario("Preload Batch Null Throws")]
     [Fact]
     public void Preload_Batch_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             Flyweight<int, string>.Create().Preload(null!));
     }
 
+    [Scenario("Preload Batch Empty Returns Builder")]
     [Fact]
     public void Preload_Batch_Empty_Returns_Builder()
     {
@@ -233,9 +238,10 @@ public sealed class FlyweightBuilderTests
             .Preload(Array.Empty<(int, string)>());
 
         var fw = builder.Build();
-        Assert.Equal(0, fw.Count);
+        ScenarioExpect.Equal(0, fw.Count);
     }
 
+    [Scenario("Preload Batch Works")]
     [Fact]
     public void Preload_Batch_Works()
     {
@@ -244,12 +250,13 @@ public sealed class FlyweightBuilderTests
             .Preload((1, "one"), (2, "two"), (3, "three"))
             .Build();
 
-        Assert.Equal(3, fw.Count);
-        Assert.Equal("one", fw.Get(1));
-        Assert.Equal("two", fw.Get(2));
-        Assert.Equal("three", fw.Get(3));
+        ScenarioExpect.Equal(3, fw.Count);
+        ScenarioExpect.Equal("one", fw.Get(1));
+        ScenarioExpect.Equal("two", fw.Get(2));
+        ScenarioExpect.Equal("three", fw.Get(3));
     }
 
+    [Scenario("WithCapacity Sets Initial Capacity")]
     [Fact]
     public void WithCapacity_Sets_Initial_Capacity()
     {
@@ -258,11 +265,12 @@ public sealed class FlyweightBuilderTests
             .WithCapacity(100)
             .Build();
 
-        Assert.Equal(0, fw.Count);
+        ScenarioExpect.Equal(0, fw.Count);
         fw.Get(1);
-        Assert.Equal(1, fw.Count);
+        ScenarioExpect.Equal(1, fw.Count);
     }
 
+    [Scenario("Preload Sets Capacity From Count")]
     [Fact]
     public void Preload_Sets_Capacity_From_Count()
     {
@@ -271,9 +279,10 @@ public sealed class FlyweightBuilderTests
             .Preload((1, "a"), (2, "b"))
             .Build();
 
-        Assert.Equal(2, fw.Count);
+        ScenarioExpect.Equal(2, fw.Count);
     }
 
+    [Scenario("TryGetExisting On Preloaded Key Returns True")]
     [Fact]
     public void TryGetExisting_On_Preloaded_Key_Returns_True()
     {
@@ -282,10 +291,11 @@ public sealed class FlyweightBuilderTests
             .Preload("key", "value")
             .Build();
 
-        Assert.True(fw.TryGetExisting("key", out var val));
-        Assert.Equal("value", val);
+        ScenarioExpect.True(fw.TryGetExisting("key", out var val));
+        ScenarioExpect.Equal("value", val);
     }
 
+    [Scenario("TryGetExisting On Missing Key Returns False")]
     [Fact]
     public void TryGetExisting_On_Missing_Key_Returns_False()
     {
@@ -293,9 +303,10 @@ public sealed class FlyweightBuilderTests
             .WithFactory(s => s)
             .Build();
 
-        Assert.False(fw.TryGetExisting("missing", out _));
+        ScenarioExpect.False(fw.TryGetExisting("missing", out _));
     }
 
+    [Scenario("Get With In Parameter Works")]
     [Fact]
     public void Get_With_In_Parameter_Works()
     {
@@ -306,9 +317,10 @@ public sealed class FlyweightBuilderTests
         var key = 42;
         var result = fw.Get(in key);
 
-        Assert.Equal("value:42", result);
+        ScenarioExpect.Equal("value:42", result);
     }
 
+    [Scenario("Concurrent Preload And Factory")]
     [Fact]
     public void Concurrent_Preload_And_Factory()
     {
@@ -324,13 +336,13 @@ public sealed class FlyweightBuilderTests
 
         // Preloaded key should not call factory
         var v1 = fw.Get(1);
-        Assert.Equal("preloaded:1", v1);
-        Assert.Equal(0, factoryCalls);
+        ScenarioExpect.Equal("preloaded:1", v1);
+        ScenarioExpect.Equal(0, factoryCalls);
 
         // New key should call factory
         var v2 = fw.Get(2);
-        Assert.Equal("created:2", v2);
-        Assert.Equal(1, factoryCalls);
+        ScenarioExpect.Equal("created:2", v2);
+        ScenarioExpect.Equal(1, factoryCalls);
     }
 }
 

--- a/test/PatternKit.Tests/Structural/Proxy/AsyncProxyTests.cs
+++ b/test/PatternKit.Tests/Structural/Proxy/AsyncProxyTests.cs
@@ -1,4 +1,5 @@
 using PatternKit.Structural.Proxy;
+using TinyBDD;
 
 namespace PatternKit.Tests.Structural.Proxy;
 
@@ -6,6 +7,7 @@ public sealed class AsyncProxyTests
 {
     #region AsyncProxy<TIn, TOut> Tests
 
+    [Scenario("AsyncProxy Direct Delegates To Subject")]
     [Fact]
     public async Task AsyncProxy_Direct_Delegates_To_Subject()
     {
@@ -17,9 +19,10 @@ public sealed class AsyncProxyTests
 
         var result = await proxy.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncProxy VirtualProxy Lazy Initialization")]
     [Fact]
     public async Task AsyncProxy_VirtualProxy_Lazy_Initialization()
     {
@@ -32,14 +35,15 @@ public sealed class AsyncProxyTests
             })
             .Build();
 
-        Assert.False(initialized);
+        ScenarioExpect.False(initialized);
 
         var result = await proxy.ExecuteAsync(5);
 
-        Assert.True(initialized);
-        Assert.Equal(10, result);
+        ScenarioExpect.True(initialized);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncProxy ProtectionProxy Allows Authorized")]
     [Fact]
     public async Task AsyncProxy_ProtectionProxy_Allows_Authorized()
     {
@@ -49,9 +53,10 @@ public sealed class AsyncProxyTests
 
         var result = await proxy.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
     }
 
+    [Scenario("AsyncProxy ProtectionProxy Denies Unauthorized")]
     [Fact]
     public async Task AsyncProxy_ProtectionProxy_Denies_Unauthorized()
     {
@@ -59,10 +64,11 @@ public sealed class AsyncProxyTests
             .ProtectionProxy(async (x, ct) => x > 0)
             .Build();
 
-        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+        await ScenarioExpect.ThrowsAsync<UnauthorizedAccessException>(() =>
             proxy.ExecuteAsync(-5).AsTask());
     }
 
+    [Scenario("AsyncProxy Before Intercepts")]
     [Fact]
     public async Task AsyncProxy_Before_Intercepts()
     {
@@ -75,10 +81,11 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.Equal("before-5", log[0]);
-        Assert.Equal("subject", log[1]);
+        ScenarioExpect.Equal("before-5", log[0]);
+        ScenarioExpect.Equal("subject", log[1]);
     }
 
+    [Scenario("AsyncProxy After Intercepts")]
     [Fact]
     public async Task AsyncProxy_After_Intercepts()
     {
@@ -91,10 +98,11 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.Equal("subject", log[0]);
-        Assert.Contains("after-5->10", log[1]);
+        ScenarioExpect.Equal("subject", log[0]);
+        ScenarioExpect.Contains("after-5->10", log[1]);
     }
 
+    [Scenario("AsyncProxy Intercept Modifies Behavior")]
     [Fact]
     public async Task AsyncProxy_Intercept_Modifies_Behavior()
     {
@@ -104,13 +112,14 @@ public sealed class AsyncProxyTests
 
         var result = await proxy.ExecuteAsync(-5);
 
-        Assert.Equal(0, result);
+        ScenarioExpect.Equal(0, result);
     }
 
+    [Scenario("AsyncProxy Build Throws Without Subject")]
     [Fact]
     public void AsyncProxy_Build_Throws_Without_Subject()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncProxy<int, int>.Create().Build());
     }
 
@@ -118,6 +127,7 @@ public sealed class AsyncProxyTests
 
     #region AsyncActionProxy<TIn> Tests
 
+    [Scenario("AsyncActionProxy Executes")]
     [Fact]
     public async Task AsyncActionProxy_Executes()
     {
@@ -130,9 +140,10 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionProxy VirtualProxy Lazy")]
     [Fact]
     public async Task AsyncActionProxy_VirtualProxy_Lazy()
     {
@@ -146,14 +157,15 @@ public sealed class AsyncProxyTests
             })
             .Build();
 
-        Assert.False(initialized);
+        ScenarioExpect.False(initialized);
 
         await proxy.ExecuteAsync(5);
 
-        Assert.True(initialized);
-        Assert.True(executed);
+        ScenarioExpect.True(initialized);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionProxy ProtectionProxy Allows")]
     [Fact]
     public async Task AsyncActionProxy_ProtectionProxy_Allows()
     {
@@ -164,9 +176,10 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionProxy ProtectionProxy Denies")]
     [Fact]
     public async Task AsyncActionProxy_ProtectionProxy_Denies()
     {
@@ -174,10 +187,11 @@ public sealed class AsyncProxyTests
             .ProtectionProxy(async (x, ct) => x > 0)
             .Build();
 
-        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+        await ScenarioExpect.ThrowsAsync<UnauthorizedAccessException>(() =>
             proxy.ExecuteAsync(-5).AsTask());
     }
 
+    [Scenario("AsyncActionProxy Before Intercepts")]
     [Fact]
     public async Task AsyncActionProxy_Before_Intercepts()
     {
@@ -188,10 +202,11 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.Equal("before-5", log[0]);
-        Assert.Equal("subject", log[1]);
+        ScenarioExpect.Equal("before-5", log[0]);
+        ScenarioExpect.Equal("subject", log[1]);
     }
 
+    [Scenario("AsyncActionProxy After Intercepts")]
     [Fact]
     public async Task AsyncActionProxy_After_Intercepts()
     {
@@ -202,10 +217,11 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.Equal("subject", log[0]);
-        Assert.Contains("after-5", log[1]);
+        ScenarioExpect.Equal("subject", log[0]);
+        ScenarioExpect.Contains("after-5", log[1]);
     }
 
+    [Scenario("AsyncActionProxy Intercept Can Skip")]
     [Fact]
     public async Task AsyncActionProxy_Intercept_Can_Skip()
     {
@@ -220,13 +236,14 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(-5);
 
-        Assert.False(executed);
+        ScenarioExpect.False(executed);
     }
 
+    [Scenario("AsyncActionProxy Build Throws Without Subject")]
     [Fact]
     public void AsyncActionProxy_Build_Throws_Without_Subject()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncActionProxy<int>.Create().Build());
     }
 
@@ -234,6 +251,7 @@ public sealed class AsyncProxyTests
 
     #region ActionProxy<TIn> Tests
 
+    [Scenario("ActionProxy Executes")]
     [Fact]
     public void ActionProxy_Executes()
     {
@@ -242,9 +260,10 @@ public sealed class AsyncProxyTests
 
         proxy.Execute(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionProxy VirtualProxy Lazy")]
     [Fact]
     public void ActionProxy_VirtualProxy_Lazy()
     {
@@ -258,14 +277,15 @@ public sealed class AsyncProxyTests
             })
             .Build();
 
-        Assert.False(initialized);
+        ScenarioExpect.False(initialized);
 
         proxy.Execute(5);
 
-        Assert.True(initialized);
-        Assert.True(executed);
+        ScenarioExpect.True(initialized);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionProxy ProtectionProxy Allows")]
     [Fact]
     public void ActionProxy_ProtectionProxy_Allows()
     {
@@ -276,9 +296,10 @@ public sealed class AsyncProxyTests
 
         proxy.Execute(5);
 
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("ActionProxy ProtectionProxy Denies")]
     [Fact]
     public void ActionProxy_ProtectionProxy_Denies()
     {
@@ -286,9 +307,10 @@ public sealed class AsyncProxyTests
             .ProtectionProxy(x => x > 0)
             .Build();
 
-        Assert.Throws<UnauthorizedAccessException>(() => proxy.Execute(-5));
+        ScenarioExpect.Throws<UnauthorizedAccessException>(() => proxy.Execute(-5));
     }
 
+    [Scenario("ActionProxy Before Intercepts")]
     [Fact]
     public void ActionProxy_Before_Intercepts()
     {
@@ -299,10 +321,11 @@ public sealed class AsyncProxyTests
 
         proxy.Execute(5);
 
-        Assert.Equal("before-5", log[0]);
-        Assert.Equal("subject", log[1]);
+        ScenarioExpect.Equal("before-5", log[0]);
+        ScenarioExpect.Equal("subject", log[1]);
     }
 
+    [Scenario("ActionProxy After Intercepts")]
     [Fact]
     public void ActionProxy_After_Intercepts()
     {
@@ -313,10 +336,11 @@ public sealed class AsyncProxyTests
 
         proxy.Execute(5);
 
-        Assert.Equal("subject", log[0]);
-        Assert.Contains("after-5", log[1]);
+        ScenarioExpect.Equal("subject", log[0]);
+        ScenarioExpect.Contains("after-5", log[1]);
     }
 
+    [Scenario("ActionProxy Intercept Can Skip")]
     [Fact]
     public void ActionProxy_Intercept_Can_Skip()
     {
@@ -331,16 +355,18 @@ public sealed class AsyncProxyTests
 
         proxy.Execute(-5);
 
-        Assert.False(executed);
+        ScenarioExpect.False(executed);
     }
 
+    [Scenario("ActionProxy Build Throws Without Subject")]
     [Fact]
     public void ActionProxy_Build_Throws_Without_Subject()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             ActionProxy<int>.Create().Build());
     }
 
+    [Scenario("ActionProxy VirtualProxy Thread Safe")]
     [Fact]
     public void ActionProxy_VirtualProxy_Thread_Safe()
     {
@@ -356,80 +382,90 @@ public sealed class AsyncProxyTests
 
         Parallel.For(0, 10, _ => proxy.Execute(5));
 
-        Assert.Equal(1, initCount);
+        ScenarioExpect.Equal(1, initCount);
     }
 
     #endregion
 
     #region Null Argument Tests
 
+    [Scenario("AsyncProxy VirtualProxy Null Throws")]
     [Fact]
     public void AsyncProxy_VirtualProxy_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncProxy<int, int>.Create().VirtualProxy((AsyncProxy<int, int>.SubjectFactory)null!));
     }
 
+    [Scenario("AsyncProxy ProtectionProxy Null Throws")]
     [Fact]
     public void AsyncProxy_ProtectionProxy_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncProxy<int, int>.Create(async (x, ct) => x).ProtectionProxy((AsyncProxy<int, int>.AccessValidator)null!));
     }
 
+    [Scenario("AsyncProxy Before Null Throws")]
     [Fact]
     public void AsyncProxy_Before_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncProxy<int, int>.Create(async (x, ct) => x).Before(null!));
     }
 
+    [Scenario("AsyncProxy After Null Throws")]
     [Fact]
     public void AsyncProxy_After_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncProxy<int, int>.Create(async (x, ct) => x).After(null!));
     }
 
+    [Scenario("AsyncProxy Intercept Null Throws")]
     [Fact]
     public void AsyncProxy_Intercept_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncProxy<int, int>.Create(async (x, ct) => x).Intercept(null!));
     }
 
+    [Scenario("ActionProxy VirtualProxy Null Throws")]
     [Fact]
     public void ActionProxy_VirtualProxy_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionProxy<int>.Create().VirtualProxy(null!));
     }
 
+    [Scenario("ActionProxy ProtectionProxy Null Throws")]
     [Fact]
     public void ActionProxy_ProtectionProxy_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionProxy<int>.Create(x => { }).ProtectionProxy(null!));
     }
 
+    [Scenario("ActionProxy Before Null Throws")]
     [Fact]
     public void ActionProxy_Before_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionProxy<int>.Create(x => { }).Before(null!));
     }
 
+    [Scenario("ActionProxy After Null Throws")]
     [Fact]
     public void ActionProxy_After_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionProxy<int>.Create(x => { }).After(null!));
     }
 
+    [Scenario("ActionProxy Intercept Null Throws")]
     [Fact]
     public void ActionProxy_Intercept_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             ActionProxy<int>.Create(x => { }).Intercept(null!));
     }
 
@@ -437,6 +473,7 @@ public sealed class AsyncProxyTests
 
     #region Additional AsyncProxy Tests
 
+    [Scenario("AsyncProxy VirtualProxy Caches Subject")]
     [Fact]
     public async Task AsyncProxy_VirtualProxy_Caches_Subject()
     {
@@ -453,9 +490,10 @@ public sealed class AsyncProxyTests
         await proxy.ExecuteAsync(2);
         await proxy.ExecuteAsync(3);
 
-        Assert.Equal(1, initCount);
+        ScenarioExpect.Equal(1, initCount);
     }
 
+    [Scenario("AsyncProxy VirtualProxy Sync Factory")]
     [Fact]
     public async Task AsyncProxy_VirtualProxy_Sync_Factory()
     {
@@ -470,10 +508,11 @@ public sealed class AsyncProxyTests
 
         var result = await proxy.ExecuteAsync(10);
 
-        Assert.True(initialized);
-        Assert.Equal(30, result);
+        ScenarioExpect.True(initialized);
+        ScenarioExpect.Equal(30, result);
     }
 
+    [Scenario("AsyncProxy ProtectionProxy Sync Validator")]
     [Fact]
     public async Task AsyncProxy_ProtectionProxy_Sync_Validator()
     {
@@ -482,12 +521,13 @@ public sealed class AsyncProxyTests
             .Build();
 
         var result = await proxy.ExecuteAsync(5);
-        Assert.Equal(10, result);
+        ScenarioExpect.Equal(10, result);
 
-        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+        await ScenarioExpect.ThrowsAsync<UnauthorizedAccessException>(() =>
             proxy.ExecuteAsync(-1).AsTask());
     }
 
+    [Scenario("AsyncProxy Before Sync Action")]
     [Fact]
     public async Task AsyncProxy_Before_Sync_Action()
     {
@@ -498,10 +538,11 @@ public sealed class AsyncProxyTests
 
         var result = await proxy.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
-        Assert.Contains("before:5", log);
+        ScenarioExpect.Equal(10, result);
+        ScenarioExpect.Contains("before:5", log);
     }
 
+    [Scenario("AsyncProxy After Sync Action")]
     [Fact]
     public async Task AsyncProxy_After_Sync_Action()
     {
@@ -512,10 +553,11 @@ public sealed class AsyncProxyTests
 
         var result = await proxy.ExecuteAsync(5);
 
-        Assert.Equal(10, result);
-        Assert.Contains("after:5=10", log);
+        ScenarioExpect.Equal(10, result);
+        ScenarioExpect.Contains("after:5=10", log);
     }
 
+    [Scenario("AsyncProxy VirtualProxy Thread Safe")]
     [Fact]
     public async Task AsyncProxy_VirtualProxy_Thread_Safe()
     {
@@ -535,42 +577,47 @@ public sealed class AsyncProxyTests
 
         await Task.WhenAll(tasks);
 
-        Assert.Equal(1, initCount);
-        Assert.All(tasks, t => Assert.Equal(10, t.Result));
+        ScenarioExpect.Equal(1, initCount);
+        ScenarioExpect.All(tasks, t => ScenarioExpect.Equal(10, t.Result));
     }
 
+    [Scenario("AsyncProxy Intercept NoSubject Throws")]
     [Fact]
     public void AsyncProxy_Intercept_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncProxy<int, int>.Create()
                 .Intercept(async (x, ct, next) => x));
     }
 
+    [Scenario("AsyncProxy Before NoSubject Throws")]
     [Fact]
     public void AsyncProxy_Before_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncProxy<int, int>.Create()
                 .Before(async (x, ct) => { }));
     }
 
+    [Scenario("AsyncProxy After NoSubject Throws")]
     [Fact]
     public void AsyncProxy_After_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncProxy<int, int>.Create()
                 .After(async (x, r, ct) => { }));
     }
 
+    [Scenario("AsyncProxy ProtectionProxy NoSubject Throws")]
     [Fact]
     public void AsyncProxy_ProtectionProxy_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncProxy<int, int>.Create()
                 .ProtectionProxy(async (x, ct) => true));
     }
 
+    [Scenario("AsyncActionProxy VirtualProxy Sync Factory")]
     [Fact]
     public async Task AsyncActionProxy_VirtualProxy_Sync_Factory()
     {
@@ -586,10 +633,11 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.True(initialized);
-        Assert.True(executed);
+        ScenarioExpect.True(initialized);
+        ScenarioExpect.True(executed);
     }
 
+    [Scenario("AsyncActionProxy ProtectionProxy Sync Validator")]
     [Fact]
     public async Task AsyncActionProxy_ProtectionProxy_Sync_Validator()
     {
@@ -599,14 +647,15 @@ public sealed class AsyncProxyTests
             .Build();
 
         await proxy.ExecuteAsync(5);
-        Assert.True(executed);
+        ScenarioExpect.True(executed);
 
         executed = false;
-        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+        await ScenarioExpect.ThrowsAsync<UnauthorizedAccessException>(() =>
             proxy.ExecuteAsync(-1).AsTask());
-        Assert.False(executed);
+        ScenarioExpect.False(executed);
     }
 
+    [Scenario("AsyncActionProxy Before Sync")]
     [Fact]
     public async Task AsyncActionProxy_Before_Sync()
     {
@@ -617,11 +666,12 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("before:5", log[0]);
-        Assert.Equal("subject", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("before:5", log[0]);
+        ScenarioExpect.Equal("subject", log[1]);
     }
 
+    [Scenario("AsyncActionProxy After Sync")]
     [Fact]
     public async Task AsyncActionProxy_After_Sync()
     {
@@ -632,43 +682,48 @@ public sealed class AsyncProxyTests
 
         await proxy.ExecuteAsync(5);
 
-        Assert.Equal(2, log.Count);
-        Assert.Equal("subject", log[0]);
-        Assert.Equal("after:5", log[1]);
+        ScenarioExpect.Equal(2, log.Count);
+        ScenarioExpect.Equal("subject", log[0]);
+        ScenarioExpect.Equal("after:5", log[1]);
     }
 
+    [Scenario("AsyncActionProxy Intercept NoSubject Throws")]
     [Fact]
     public void AsyncActionProxy_Intercept_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncActionProxy<int>.Create()
                 .Intercept(async (x, ct, next) => { }));
     }
 
+    [Scenario("AsyncActionProxy Before NoSubject Throws")]
     [Fact]
     public void AsyncActionProxy_Before_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncActionProxy<int>.Create()
                 .Before(async (x, ct) => { }));
     }
 
+    [Scenario("AsyncActionProxy After NoSubject Throws")]
     [Fact]
     public void AsyncActionProxy_After_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncActionProxy<int>.Create()
                 .After(async (x, ct) => { }));
     }
 
+    [Scenario("AsyncActionProxy ProtectionProxy NoSubject Throws")]
     [Fact]
     public void AsyncActionProxy_ProtectionProxy_NoSubject_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        ScenarioExpect.Throws<InvalidOperationException>(() =>
             AsyncActionProxy<int>.Create()
                 .ProtectionProxy(async (x, ct) => true));
     }
 
+    [Scenario("AsyncActionProxy VirtualProxy Caches Subject")]
     [Fact]
     public async Task AsyncActionProxy_VirtualProxy_Caches_Subject()
     {
@@ -685,9 +740,10 @@ public sealed class AsyncProxyTests
         await proxy.ExecuteAsync(2);
         await proxy.ExecuteAsync(3);
 
-        Assert.Equal(1, initCount);
+        ScenarioExpect.Equal(1, initCount);
     }
 
+    [Scenario("AsyncActionProxy VirtualProxy Thread Safe")]
     [Fact]
     public async Task AsyncActionProxy_VirtualProxy_Thread_Safe()
     {
@@ -708,46 +764,51 @@ public sealed class AsyncProxyTests
 
         await Task.WhenAll(tasks);
 
-        Assert.Equal(1, initCount);
-        Assert.Equal(10, execCount);
+        ScenarioExpect.Equal(1, initCount);
+        ScenarioExpect.Equal(10, execCount);
     }
 
+    [Scenario("AsyncActionProxy Null VirtualProxy Throws")]
     [Fact]
     public async Task AsyncActionProxy_Null_VirtualProxy_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionProxy<int>.Create()
                 .VirtualProxy((AsyncActionProxy<int>.SubjectFactory)null!));
     }
 
+    [Scenario("AsyncActionProxy Null ProtectionProxy Throws")]
     [Fact]
     public async Task AsyncActionProxy_Null_ProtectionProxy_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionProxy<int>.Create(async (x, ct) => { })
                 .ProtectionProxy((AsyncActionProxy<int>.AccessValidator)null!));
     }
 
+    [Scenario("AsyncActionProxy Null Before Throws")]
     [Fact]
     public async Task AsyncActionProxy_Null_Before_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionProxy<int>.Create(async (x, ct) => { })
                 .Before((AsyncActionProxy<int>.ActionHook)null!));
     }
 
+    [Scenario("AsyncActionProxy Null After Throws")]
     [Fact]
     public async Task AsyncActionProxy_Null_After_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionProxy<int>.Create(async (x, ct) => { })
                 .After((AsyncActionProxy<int>.ActionHook)null!));
     }
 
+    [Scenario("AsyncActionProxy Null Intercept Throws")]
     [Fact]
     public async Task AsyncActionProxy_Null_Intercept_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        ScenarioExpect.Throws<ArgumentNullException>(() =>
             AsyncActionProxy<int>.Create(async (x, ct) => { })
                 .Intercept(null!));
     }

--- a/test/ScenarioExpect.cs
+++ b/test/ScenarioExpect.cs
@@ -1,0 +1,317 @@
+using System.Collections;
+using System.Text.RegularExpressions;
+using TinyBDD.Assertions;
+
+public static class ScenarioExpect
+{
+    public static void True(bool condition, string? message = null)
+    {
+        if (!condition)
+            Fail(message ?? "expected condition to be true");
+    }
+
+    public static void True(bool? condition, string? message = null)
+    {
+        if (condition != true)
+            Fail(message ?? $"expected condition to be true, but was {Format(condition)}");
+    }
+
+    public static void False(bool condition, string? message = null)
+    {
+        if (condition)
+            Fail(message ?? "expected condition to be false");
+    }
+
+    public static void False(bool? condition, string? message = null)
+    {
+        if (condition != false)
+            Fail(message ?? $"expected condition to be false, but was {Format(condition)}");
+    }
+
+    public static void Equal<T>(T expected, T actual)
+    {
+        if (BothEnumerable(expected, actual, out var expectedItems, out var actualItems))
+        {
+            EqualSequences(expectedItems, actualItems);
+            return;
+        }
+
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            Throw("value", expected, actual);
+    }
+
+    public static void Equal<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+        => EqualSequences(expected.Cast<object?>(), actual.Cast<object?>());
+
+    public static void NotEqual<T>(T notExpected, T actual)
+    {
+        if (EqualityComparer<T>.Default.Equals(notExpected, actual))
+            Fail($"expected value to not equal {Format(notExpected)}, but it did");
+    }
+
+    public static void Null(object? value)
+        => Expect.That(value, "value").ToBeNull().EvaluateAsync().GetAwaiter().GetResult();
+
+    public static T NotNull<T>(T? value)
+    {
+        Expect.That(value, "value").ToNotBeNull().EvaluateAsync().GetAwaiter().GetResult();
+        return value!;
+    }
+
+    public static void Empty(IEnumerable collection)
+    {
+        if (collection.Cast<object?>().Any())
+            Fail("expected collection to be empty");
+    }
+
+    public static void NotEmpty(IEnumerable collection)
+    {
+        if (!collection.Cast<object?>().Any())
+            Fail("expected collection to not be empty");
+    }
+
+    public static T Single<T>(IEnumerable<T> collection)
+    {
+        var items = collection.Take(2).ToArray();
+        if (items.Length != 1)
+            Fail($"expected collection to contain exactly one item, but it contained {collection.Count()}");
+        return items[0];
+    }
+
+    public static T Single<T>(IEnumerable<T> collection, Func<T, bool> predicate)
+    {
+        var matches = collection.Where(predicate).Take(2).ToArray();
+        if (matches.Length != 1)
+            Fail($"expected collection to contain exactly one matching item, but it contained {collection.Count(predicate)}");
+        return matches[0];
+    }
+
+    public static void All<T>(IEnumerable<T> collection, Action<T> assertion)
+    {
+        var index = 0;
+        foreach (var item in collection)
+        {
+            try
+            {
+                assertion(item);
+            }
+            catch (Exception ex) when (ex is not TinyBddAssertionException)
+            {
+                throw new TinyBddAssertionException($"expected all items to pass assertion, but item {index} threw {ex.GetType().Name}: {ex.Message}", ex);
+            }
+
+            index++;
+        }
+    }
+
+    public static void Contains(string expectedSubstring, string actualString)
+        => Contains(expectedSubstring, actualString, StringComparison.Ordinal);
+
+    public static void Contains(string expectedSubstring, string actualString, StringComparison comparison)
+    {
+        if (actualString.IndexOf(expectedSubstring, comparison) < 0)
+            Fail($"expected string to contain {Format(expectedSubstring)}, but was {Format(actualString)}");
+    }
+
+    public static void Contains<T>(T expected, IEnumerable<T> collection)
+    {
+        if (!collection.Contains(expected))
+            Fail($"expected collection to contain {Format(expected)}");
+    }
+
+    public static T Contains<T>(IEnumerable<T> collection, Func<T, bool> predicate)
+    {
+        foreach (var item in collection)
+        {
+            if (predicate(item))
+                return item;
+        }
+
+        Fail("expected collection to contain a matching item");
+        return default!;
+    }
+
+    public static void DoesNotContain(string expectedSubstring, string actualString)
+    {
+        if (actualString.Contains(expectedSubstring, StringComparison.Ordinal))
+            Fail($"expected string to not contain {Format(expectedSubstring)}, but was {Format(actualString)}");
+    }
+
+    public static void DoesNotContain<T>(T expected, IEnumerable<T> collection)
+    {
+        if (collection.Contains(expected))
+            Fail($"expected collection to not contain {Format(expected)}");
+    }
+
+    public static void DoesNotContain<T>(IEnumerable<T> collection, Func<T, bool> predicate)
+    {
+        if (collection.Any(predicate))
+            Fail("expected collection to not contain a matching item");
+    }
+
+    public static void StartsWith(string expectedStart, string actualString)
+        => StartsWith(expectedStart, actualString, StringComparison.Ordinal);
+
+    public static void StartsWith(string expectedStart, string actualString, StringComparison comparison)
+    {
+        if (!actualString.StartsWith(expectedStart, comparison))
+            Fail($"expected string to start with {Format(expectedStart)}, but was {Format(actualString)}");
+    }
+
+    public static void Matches(string expectedRegexPattern, string actualString)
+    {
+        if (!Regex.IsMatch(actualString, expectedRegexPattern))
+            Fail($"expected string to match /{expectedRegexPattern}/, but was {Format(actualString)}");
+    }
+
+    public static void Same(object? expected, object? actual)
+    {
+        if (!ReferenceEquals(expected, actual))
+            Fail("expected references to be the same instance");
+    }
+
+    public static void NotSame(object? notExpected, object? actual)
+    {
+        if (ReferenceEquals(notExpected, actual))
+            Fail("expected references to be different instances");
+    }
+
+    public static void InRange<T>(T actual, T low, T high) where T : IComparable<T>
+    {
+        if (actual.CompareTo(low) < 0 || actual.CompareTo(high) > 0)
+            Fail($"expected {Format(actual)} to be in range {Format(low)}..{Format(high)}");
+    }
+
+    public static TExpected IsType<TExpected>(object? value)
+    {
+        if (value is not null && value.GetType() == typeof(TExpected))
+            return (TExpected)value;
+
+        if (value is null)
+            Fail($"expected value to be of type {typeof(TExpected).Name}, but was null");
+        else
+            Fail($"expected value to be of type {typeof(TExpected).Name}, but was {value?.GetType().Name ?? "null"}");
+
+        return default!;
+    }
+
+    public static TExpected IsAssignableFrom<TExpected>(object? value)
+    {
+        if (value is TExpected typed)
+            return typed;
+
+        if (value is null)
+            Fail($"expected value to be assignable to {typeof(TExpected).Name}, but was null");
+        else
+            Fail($"expected value to be assignable to {typeof(TExpected).Name}, but was {value?.GetType().Name ?? "null"}");
+
+        return default!;
+    }
+
+    public static TException Throws<TException>(Action action) where TException : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (TException ex)
+        {
+            return ex;
+        }
+        catch (Exception ex)
+        {
+            Fail($"expected {typeof(TException).Name}, but threw {ex.GetType().Name}: {ex.Message}");
+        }
+
+        Fail($"expected {typeof(TException).Name}, but no exception was thrown");
+        return null!;
+    }
+
+    public static TException Throws<TException, TResult>(Func<TResult> action) where TException : Exception
+        => Throws<TException>(() => _ = action());
+
+    public static async Task<TException> ThrowsAsync<TException>(Func<Task> action) where TException : Exception
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (TException ex)
+        {
+            return ex;
+        }
+        catch (Exception ex)
+        {
+            Fail($"expected {typeof(TException).Name}, but threw {ex.GetType().Name}: {ex.Message}");
+        }
+
+        Fail($"expected {typeof(TException).Name}, but no exception was thrown");
+        return null!;
+    }
+
+    public static async Task<TException> ThrowsAnyAsync<TException>(Func<Task> action) where TException : Exception
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (TException ex)
+        {
+            return ex;
+        }
+        catch (Exception ex)
+        {
+            Fail($"expected {typeof(TException).Name} or derived type, but threw {ex.GetType().Name}: {ex.Message}");
+        }
+
+        Fail($"expected {typeof(TException).Name} or derived type, but no exception was thrown");
+        return null!;
+    }
+
+    public static void Fail(string? message = null)
+        => throw new TinyBddAssertionException(message ?? "assertion failed");
+
+    private static void EqualSequences(IEnumerable<object?> expected, IEnumerable<object?> actual)
+    {
+        var expectedArray = expected.ToArray();
+        var actualArray = actual.ToArray();
+        if (expectedArray.Length != actualArray.Length)
+            Fail($"expected collection count {expectedArray.Length}, but was {actualArray.Length}");
+
+        for (var i = 0; i < expectedArray.Length; i++)
+        {
+            if (!Equals(expectedArray[i], actualArray[i]))
+                Fail($"expected collection item {i} to be {Format(expectedArray[i])}, but was {Format(actualArray[i])}");
+        }
+    }
+
+    private static bool BothEnumerable<T>(T expected, T actual, out IEnumerable<object?> expectedItems, out IEnumerable<object?> actualItems)
+    {
+        if (expected is IEnumerable expectedEnumerable && actual is IEnumerable actualEnumerable && expected is not string && actual is not string)
+        {
+            expectedItems = expectedEnumerable.Cast<object?>();
+            actualItems = actualEnumerable.Cast<object?>();
+            return true;
+        }
+
+        expectedItems = [];
+        actualItems = [];
+        return false;
+    }
+
+    private static void Throw(string subject, object? expected, object? actual)
+        => throw new TinyBddAssertionException($"expected {subject} to be {Format(expected)}, but was {Format(actual)}")
+        {
+            Expected = expected,
+            Actual = actual,
+            Subject = subject
+        };
+
+    private static string Format(object? value)
+        => value switch
+        {
+            null => "null",
+            string text => $"\"{text}\"",
+            _ => value.ToString() ?? string.Empty
+        };
+}


### PR DESCRIPTION
## Summary
- Convert remaining PatternKit tests to TinyBDD scenarios
- Replace direct xUnit assertions with TinyBDD-backed scenario expectations
- Link shared ScenarioExpect helper into test projects

## Verification
- dotnet test test\\PatternKit.Tests\\PatternKit.Tests.csproj --no-restore
- dotnet test test\\PatternKit.Generators.Tests\\PatternKit.Generators.Tests.csproj --no-restore
- dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --no-restore
- scenario/assertion audits: 0 missing scenarios, 0 direct Assert.* calls