### PR TITLE
feat: add enterprise feature slice DI demo

### DIFF
--- a/docs/examples/enterprise-feature-slices.md
+++ b/docs/examples/enterprise-feature-slices.md
@@ -1,0 +1,112 @@
+# Enterprise Feature Slices with .NET DI
+
+This demo shows PatternKit artifacts registered through the standard
+`Microsoft.Extensions.DependencyInjection` container and consumed by a
+task-focused application facade.
+
+Source: `src/PatternKit.Examples/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemo.cs`
+
+Tests: `test/PatternKit.Examples.Tests/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemoTests.cs`
+
+## Scenario
+
+A checkout feature slice owns the business workflow for placing and estimating
+orders. The composition root registers small immutable PatternKit artifacts as
+singletons, then exposes `IEnterpriseCheckout` through a typed facade.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Examples.EnterpriseFeatureSlices;
+
+using var provider = EnterpriseFeatureSlicesDemo.BuildServiceProvider();
+
+var checkout = provider.GetRequiredService<EnterpriseFeatureSlicesDemo.IEnterpriseCheckout>();
+var result = checkout.Place(EnterpriseFeatureSlicesDemo.CreateRetailRequest());
+```
+
+## Composition Root
+
+`AddEnterpriseFeatureSlices` is the important part of the demo. It wires the
+feature through the normal .NET container:
+
+```csharp
+services.AddSingleton(CreateCatalog());
+services.AddSingleton(CreateFulfillmentFactory());
+services.AddSingleton(CreateCheckoutPrototype());
+services.AddSingleton(CreateDiscountStrategy());
+services.AddSingleton(CreateValidationChain());
+services.AddSingleton(CreateFulfillmentRenderer());
+services.AddSingleton(CreateCheckoutStateMachine());
+services.AddSingleton(CreateCheckoutHistory());
+services.AddSingleton<Observer<CheckoutEvent>>(sp =>
+    CreateCheckoutObserver(sp.GetRequiredService<AuditLog>()));
+services.AddSingleton<AbstractFactory<Region>>(sp =>
+    CreateRegionalFactory(sp.GetRequiredService<AuditLog>()));
+services.AddSingleton<Proxy<PaymentCharge, PaymentReceipt>>(sp =>
+    CreatePaymentProxy(
+        sp.GetRequiredService<AbstractFactory<Region>>(),
+        sp.GetRequiredService<AuditLog>()));
+```
+
+The final registration maps the internal service behind a typed facade:
+
+```csharp
+services.AddSingleton<IEnterpriseCheckout>(sp =>
+{
+    var service = new EnterpriseCheckoutService(...);
+
+    return TypedFacade<IEnterpriseCheckout>.Create()
+        .Map<CheckoutRequest, CheckoutResult>(x => x.Place, request => service.Place(request))
+        .Map<CheckoutRequest, CheckoutResult>(x => x.Estimate, request => service.Estimate(request))
+        .Build();
+});
+```
+
+## Pattern Map
+
+| Pattern | Role |
+| --- | --- |
+| Flyweight | Catalog metadata is shared by SKU and lazily creates special-order items. |
+| Factory | Fulfillment instructions are created from product kind and line context. |
+| Prototype | Checkout contexts are cloned from a configured template. |
+| ResultChain | Validation rules short-circuit invalid orders. |
+| Strategy | Customer tier and order size select discount policy. |
+| Decorator | Pricing layers subtotal, shipping, regional tax, and discount. |
+| Abstract Factory | Each region supplies compatible tax, payment, and risk services. |
+| Proxy | Payment calls are audited and risk-gated before reaching the gateway. |
+| TypeDispatcher | Fulfillment instructions render by concrete work-item type. |
+| State Machine | Checkout lifecycle moves through received, priced, paid, queued, or rejected. |
+| Memento | Checkout snapshots capture received, priced, queued, and rejected milestones. |
+| Observer | Domain events feed audit and fulfillment notification subscribers. |
+| Iterator/Flow | Fulfillment work is filtered and rendered lazily before queueing. |
+| Typed Facade | Application consumers see a narrow `IEnterpriseCheckout` contract. |
+
+## Why This Shape
+
+This is intentionally close to a production feature slice:
+
+* The feature has one public contract: `IEnterpriseCheckout`.
+* PatternKit objects are immutable after build and safe to share as singletons.
+* Regional policies are grouped with `AbstractFactory`, so tax, payment, and risk
+  stay compatible.
+* Cross-cutting concerns stay at the edge: the payment `Proxy` records audit data
+  and handles manual-review gating.
+* Tests resolve the feature through `ServiceProvider`, not by manually newing each
+  dependency.
+
+## Covered Scenarios
+
+The TinyBDD tests validate:
+
+* the standard DI container can resolve the facade and PatternKit artifacts;
+* a mixed physical, digital, and subscription order reaches fulfillment;
+* estimate mode prices without charging or queueing work;
+* electronic fulfillment rejects physical goods before payment;
+* high-value payments require manager override through the payment proxy.
+
+## See Also
+
+* [Enterprise Order Processing Demo](enterprise-order.md)
+* [Configuration-Driven Transaction Pipeline](config-driven-transaction-pipeline.md)
+* [Source Generator Application Suite](source-generator-application-suite.md)
+* [Messaging Backplane Facade](messaging-backplane-facade.md)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,6 +9,7 @@ Welcome! This section collects small, focused demos that show **how to compose b
 * **Fluent decorators** for layering functionality (tax, discounts, rounding, logging) without inheritance.
 * **Pipelines** built declaratively and tested end-to-end.
 * **Config-driven composition** (DI + `IOptions`) so ops can re-order rules without redeploys.
+* **Enterprise feature slices** wired through the standard .NET DI container with PatternKit artifacts registered as singletons.
 * **Strategy-based coercion** for turning "whatever came in" into the types you actually want.
 * **Ultra-minimal HTTP routing** to illustrate middleware vs. routes vs. negotiation.
 * **Flyweight identity sharing** to eliminate duplicate immutable objects (glyphs, styles, tokens).
@@ -33,6 +34,9 @@ Welcome! This section collects small, focused demos that show **how to compose b
 
 * **Configuration-Driven Transaction Pipeline**
   Same business shape as above, but wired via DI + `IOptions<PipelineOptions>`. Discounts/rounding/tenders are discovered and **ordered from config**, making the pipeline operationally tunable.
+
+* **Enterprise Feature Slices with .NET DI**
+  A checkout feature slice registered with `Microsoft.Extensions.DependencyInjection`, exposing a typed `IEnterpriseCheckout` facade while the container owns Flyweight, Factory, Prototype, Chain, Strategy, Decorator, Abstract Factory, Proxy, TypeDispatcher, State Machine, Memento, Observer, and Flow artifacts. See [Enterprise Feature Slices with .NET DI](enterprise-feature-slices.md).
 
 * **Minimal Web Request Router**
   A tiny "API gateway" that separates **first-match middleware** (side effects/logging/auth) from **first-match routes** and **content negotiation**. A crisp example of Strategy patterns in an HTTP-ish setting.
@@ -101,6 +105,7 @@ dotnet test PatternKit.slnx -c Release
 * **Mini Router:** `MiniRouter` + `Demo.Run` — middleware/auth/negotiation in console output.
 * **Mediated Pipeline:** `TransactionPipelineBuilder` + `MediatedTransactionPipelineDemo.Run`.
 * **Config-Driven Pipeline:** `ConfigDrivenPipelineDemo.AddPaymentPipeline` + `PipelineOptions`.
+* **Enterprise Feature Slices:** `EnterpriseFeatureSlicesDemo.AddEnterpriseFeatureSlices` (+ `EnterpriseFeatureSlicesDemoTests`) — standard .NET DI owns PatternKit artifacts behind a typed checkout facade.
 * **Payment Processor Decorators:** `PaymentProcessor*` + related tests.
 * **Flyweight Glyph Cache:** `FlyweightDemo` (+ `FlyweightDemoTests`) — glyph width layout & style sharing.
 * **Flyweight Structural Tests:** `Structural/Flyweight/FlyweightTests.cs` — preload, concurrency, comparer, guards.

--- a/docs/examples/toc.yml
+++ b/docs/examples/toc.yml
@@ -16,6 +16,9 @@
 - name: Configuration-Driven Transaction Pipeline
   href: config-driven-transaction-pipeline.md
 
+- name: Enterprise Feature Slices with .NET DI
+  href: enterprise-feature-slices.md
+
 - name: Minimal Web Request Router
   href: mini-router.md
 

--- a/src/PatternKit.Examples/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemo.cs
+++ b/src/PatternKit.Examples/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemo.cs
@@ -1,0 +1,496 @@
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Behavioral.Chain;
+using PatternKit.Behavioral.Iterator;
+using PatternKit.Behavioral.Memento;
+using PatternKit.Behavioral.Observer;
+using PatternKit.Behavioral.State;
+using PatternKit.Behavioral.Strategy;
+using PatternKit.Behavioral.TypeDispatcher;
+using PatternKit.Creational.AbstractFactory;
+using PatternKit.Creational.Factory;
+using PatternKit.Creational.Prototype;
+using PatternKit.Structural.Decorator;
+using PatternKit.Structural.Facade;
+using PatternKit.Structural.Flyweight;
+using PatternKit.Structural.Proxy;
+
+namespace PatternKit.Examples.EnterpriseFeatureSlices;
+
+/// <summary>
+/// Enterprise feature-slice demo that wires PatternKit artifacts through the standard
+/// Microsoft.Extensions.DependencyInjection container.
+/// </summary>
+public static class EnterpriseFeatureSlicesDemo
+{
+    public enum ProductKind { Physical, Digital, Subscription }
+    public enum CustomerTier { Standard, Gold, Enterprise }
+    public enum Region { NorthAmerica, Europe, AsiaPacific }
+    public enum FulfillmentMode { Standard, Express, Electronic }
+    public enum CheckoutStage { Received, Validating, Priced, Paid, FulfillmentQueued, Rejected }
+    public enum CheckoutEventKind { Validate, Price, Pay, QueueFulfillment, Reject }
+
+    public sealed record CatalogItem(string Sku, ProductKind Kind, string Name, decimal ListPrice, double WeightKg);
+    public sealed record CheckoutLine(string Sku, ProductKind Kind, int Quantity);
+    public sealed record CheckoutRequest(
+        string OrderId,
+        string CustomerId,
+        CustomerTier Tier,
+        Region Region,
+        FulfillmentMode Mode,
+        IReadOnlyList<CheckoutLine> Lines,
+        bool ManagerOverride = false);
+
+    public sealed record FulfillmentDraft(string OrderId, CheckoutLine Line, CatalogItem CatalogItem);
+
+    public abstract record FulfillmentInstruction(string OrderId, string Sku, int Quantity);
+    public sealed record ShipPhysical(string OrderId, string Sku, int Quantity, double WeightKg)
+        : FulfillmentInstruction(OrderId, Sku, Quantity);
+    public sealed record SendDownload(string OrderId, string Sku, int Quantity)
+        : FulfillmentInstruction(OrderId, Sku, Quantity);
+    public sealed record ActivateSubscription(string OrderId, string Sku, int Quantity, int Months)
+        : FulfillmentInstruction(OrderId, Sku, Quantity);
+
+    public sealed record CheckoutEvent(string OrderId, CheckoutEventKind Kind, string Detail);
+    public sealed record CheckoutSnapshot(string OrderId, CheckoutStage Stage, decimal Total, string Note);
+    public sealed record ValidationOutcome(bool Accepted, string Message);
+    public sealed record PaymentCharge(string OrderId, Region Region, decimal Amount, bool ManagerOverride);
+    public sealed record PaymentReceipt(bool Approved, string Provider, string AuthorizationCode);
+    public sealed record CheckoutResult(
+        bool Accepted,
+        string Message,
+        CheckoutStage Stage,
+        decimal Total,
+        IReadOnlyList<string> WorkItems,
+        IReadOnlyList<string> Audit,
+        int SnapshotVersion);
+
+    public interface IEnterpriseCheckout
+    {
+        CheckoutResult Place(CheckoutRequest request);
+        CheckoutResult Estimate(CheckoutRequest request);
+    }
+
+    public interface IRegionalTaxPolicy
+    {
+        decimal Apply(decimal taxableAmount);
+    }
+
+    public interface IRegionalPaymentGateway
+    {
+        string Name { get; }
+        PaymentReceipt Charge(PaymentCharge charge);
+    }
+
+    public interface IRegionalRiskPolicy
+    {
+        bool Allows(PaymentCharge charge);
+    }
+
+    public sealed class AuditLog
+    {
+        private readonly List<string> _entries = [];
+
+        public IReadOnlyList<string> Entries => _entries.ToArray();
+
+        public void Add(string entry) => _entries.Add(entry);
+
+        public void Clear() => _entries.Clear();
+    }
+
+    public sealed class EnterpriseCheckoutContext
+    {
+        public required CheckoutRequest Request { get; set; }
+        public required IReadOnlyList<CatalogItem> CatalogItems { get; set; }
+        public required IReadOnlyList<FulfillmentInstruction> Instructions { get; set; }
+        public decimal Subtotal { get; set; }
+        public decimal Shipping { get; set; }
+        public decimal Discount { get; set; }
+        public decimal Tax { get; set; }
+        public decimal Total { get; set; }
+        public CheckoutStage Stage { get; set; } = CheckoutStage.Received;
+        public List<string> WorkItems { get; } = [];
+        public List<string> Audit { get; } = [];
+    }
+
+    public static IServiceCollection AddEnterpriseFeatureSlices(this IServiceCollection services)
+    {
+        services.AddSingleton<AuditLog>();
+        services.AddSingleton(CreateCatalog());
+        services.AddSingleton(CreateFulfillmentFactory());
+        services.AddSingleton(CreateCheckoutPrototype());
+        services.AddSingleton(CreateDiscountStrategy());
+        services.AddSingleton(CreateValidationChain());
+        services.AddSingleton(CreateFulfillmentRenderer());
+        services.AddSingleton(CreateCheckoutStateMachine());
+        services.AddSingleton(CreateCheckoutHistory());
+        services.AddSingleton<Observer<CheckoutEvent>>(sp => CreateCheckoutObserver(sp.GetRequiredService<AuditLog>()));
+        services.AddSingleton<AbstractFactory<Region>>(sp => CreateRegionalFactory(sp.GetRequiredService<AuditLog>()));
+        services.AddSingleton<Decorator<EnterpriseCheckoutContext, decimal>>(sp =>
+            CreatePriceCalculator(sp.GetRequiredService<AbstractFactory<Region>>()));
+        services.AddSingleton<Proxy<PaymentCharge, PaymentReceipt>>(sp =>
+            CreatePaymentProxy(sp.GetRequiredService<AbstractFactory<Region>>(), sp.GetRequiredService<AuditLog>()));
+        services.AddSingleton<IEnterpriseCheckout>(sp =>
+        {
+            var service = new EnterpriseCheckoutService(
+                sp.GetRequiredService<Flyweight<string, CatalogItem>>(),
+                sp.GetRequiredService<Factory<ProductKind, FulfillmentDraft, FulfillmentInstruction>>(),
+                sp.GetRequiredService<Prototype<string, EnterpriseCheckoutContext>>(),
+                sp.GetRequiredService<ResultChain<EnterpriseCheckoutContext, ValidationOutcome>>(),
+                sp.GetRequiredService<Strategy<EnterpriseCheckoutContext, decimal>>(),
+                sp.GetRequiredService<Decorator<EnterpriseCheckoutContext, decimal>>(),
+                sp.GetRequiredService<Proxy<PaymentCharge, PaymentReceipt>>(),
+                sp.GetRequiredService<TypeDispatcher<FulfillmentInstruction, string>>(),
+                sp.GetRequiredService<StateMachine<CheckoutStage, CheckoutEvent>>(),
+                sp.GetRequiredService<Memento<CheckoutSnapshot>>(),
+                sp.GetRequiredService<Observer<CheckoutEvent>>(),
+                sp.GetRequiredService<AuditLog>());
+
+            return TypedFacade<IEnterpriseCheckout>.Create()
+                .Map<CheckoutRequest, CheckoutResult>(x => x.Place, request => service.Place(request))
+                .Map<CheckoutRequest, CheckoutResult>(x => x.Estimate, request => service.Estimate(request))
+                .Build();
+        });
+
+        return services;
+    }
+
+    public static ServiceProvider BuildServiceProvider()
+        => new ServiceCollection()
+            .AddEnterpriseFeatureSlices()
+            .BuildServiceProvider(validateScopes: true);
+
+    public static CheckoutRequest CreateRetailRequest(string orderId = "SO-1001")
+        => new(
+            orderId,
+            "CUST-GOLD",
+            CustomerTier.Gold,
+            Region.NorthAmerica,
+            FulfillmentMode.Express,
+            [
+                new CheckoutLine("KB-001", ProductKind.Physical, 1),
+                new CheckoutLine("APP-365", ProductKind.Subscription, 1),
+                new CheckoutLine("EBOOK-42", ProductKind.Digital, 1)
+            ]);
+
+    private static Flyweight<string, CatalogItem> CreateCatalog()
+        => Flyweight<string, CatalogItem>.Create()
+            .WithComparer(StringComparer.OrdinalIgnoreCase)
+            .Preload("KB-001", new CatalogItem("KB-001", ProductKind.Physical, "Mechanical Keyboard", 129.99m, 1.2))
+            .Preload("APP-365", new CatalogItem("APP-365", ProductKind.Subscription, "Productivity Suite", 199.00m, 0))
+            .Preload("EBOOK-42", new CatalogItem("EBOOK-42", ProductKind.Digital, "Architecture Playbook", 39.00m, 0))
+            .WithFactory(sku => new CatalogItem(sku, ProductKind.Physical, $"Special order {sku}", 59.00m, 0.5))
+            .Build();
+
+    private static Factory<ProductKind, FulfillmentDraft, FulfillmentInstruction> CreateFulfillmentFactory()
+        => Factory<ProductKind, FulfillmentDraft, FulfillmentInstruction>.Create()
+            .Map(ProductKind.Physical, static (in FulfillmentDraft draft) =>
+                new ShipPhysical(draft.OrderId, draft.Line.Sku, draft.Line.Quantity, draft.CatalogItem.WeightKg))
+            .Map(ProductKind.Digital, static (in FulfillmentDraft draft) =>
+                new SendDownload(draft.OrderId, draft.Line.Sku, draft.Line.Quantity))
+            .Map(ProductKind.Subscription, static (in FulfillmentDraft draft) =>
+                new ActivateSubscription(draft.OrderId, draft.Line.Sku, draft.Line.Quantity, 12))
+            .Build();
+
+    private static Prototype<string, EnterpriseCheckoutContext> CreateCheckoutPrototype()
+    {
+        var seed = new EnterpriseCheckoutContext
+        {
+            Request = new CheckoutRequest("", "", CustomerTier.Standard, Region.NorthAmerica, FulfillmentMode.Standard, []),
+            CatalogItems = [],
+            Instructions = []
+        };
+
+        return Prototype<string, EnterpriseCheckoutContext>.Create()
+            .Map("checkout", seed, static (in EnterpriseCheckoutContext context) => new EnterpriseCheckoutContext
+            {
+                Request = context.Request,
+                CatalogItems = context.CatalogItems,
+                Instructions = context.Instructions,
+                Subtotal = context.Subtotal,
+                Shipping = context.Shipping,
+                Discount = context.Discount,
+                Tax = context.Tax,
+                Total = context.Total,
+                Stage = context.Stage
+            })
+            .Default(seed, static (in EnterpriseCheckoutContext context) => new EnterpriseCheckoutContext
+            {
+                Request = context.Request,
+                CatalogItems = context.CatalogItems,
+                Instructions = context.Instructions,
+                Subtotal = context.Subtotal,
+                Shipping = context.Shipping,
+                Discount = context.Discount,
+                Tax = context.Tax,
+                Total = context.Total,
+                Stage = context.Stage
+            })
+            .Build();
+    }
+
+    private static Strategy<EnterpriseCheckoutContext, decimal> CreateDiscountStrategy()
+        => Strategy<EnterpriseCheckoutContext, decimal>.Create()
+            .When(static (in EnterpriseCheckoutContext ctx) => ctx.Request.Tier == CustomerTier.Enterprise)
+                .Then(static (in EnterpriseCheckoutContext ctx) => Math.Round(ctx.Subtotal * 0.12m, 2))
+            .When(static (in EnterpriseCheckoutContext ctx) => ctx.Request.Tier == CustomerTier.Gold)
+                .Then(static (in EnterpriseCheckoutContext ctx) => Math.Round(ctx.Subtotal * 0.08m, 2))
+            .When(static (in EnterpriseCheckoutContext ctx) => ctx.Subtotal >= 500m)
+                .Then(static (in EnterpriseCheckoutContext _) => 25m)
+            .Default(static (in EnterpriseCheckoutContext _) => 0m)
+            .Build();
+
+    private static ResultChain<EnterpriseCheckoutContext, ValidationOutcome> CreateValidationChain()
+        => ResultChain<EnterpriseCheckoutContext, ValidationOutcome>.Create()
+            .When(static (in EnterpriseCheckoutContext ctx) => string.IsNullOrWhiteSpace(ctx.Request.OrderId))
+                .Then(static _ => new ValidationOutcome(false, "Order id is required"))
+            .When(static (in EnterpriseCheckoutContext ctx) => ctx.Request.Lines.Count == 0)
+                .Then(static _ => new ValidationOutcome(false, "At least one checkout line is required"))
+            .When(static (in EnterpriseCheckoutContext ctx) => ctx.Request.Lines.Any(line => line.Quantity <= 0))
+                .Then(static _ => new ValidationOutcome(false, "Line quantities must be positive"))
+            .When(static (in EnterpriseCheckoutContext ctx) =>
+                ctx.Request.Mode == FulfillmentMode.Electronic
+                && ctx.Instructions.OfType<ShipPhysical>().Any())
+                .Then(static _ => new ValidationOutcome(false, "Electronic fulfillment cannot contain physical goods"))
+            .Finally(static (in EnterpriseCheckoutContext _, out ValidationOutcome? result, ResultChain<EnterpriseCheckoutContext, ValidationOutcome>.Next _) =>
+            {
+                result = new ValidationOutcome(true, "Accepted");
+                return true;
+            })
+            .Build();
+
+    private static AbstractFactory<Region> CreateRegionalFactory(AuditLog audit)
+        => AbstractFactory<Region>.Create()
+            .Family(Region.NorthAmerica)
+                .Product<IRegionalTaxPolicy>(() => new FlatTaxPolicy(0.0825m))
+                .Product<IRegionalPaymentGateway>(() => new RegionalPaymentGateway("Stripe", audit))
+                .Product<IRegionalRiskPolicy>(() => new ThresholdRiskPolicy(5000m))
+            .Family(Region.Europe)
+                .Product<IRegionalTaxPolicy>(() => new FlatTaxPolicy(0.20m))
+                .Product<IRegionalPaymentGateway>(() => new RegionalPaymentGateway("Adyen", audit))
+                .Product<IRegionalRiskPolicy>(() => new ThresholdRiskPolicy(4000m))
+            .Family(Region.AsiaPacific)
+                .Product<IRegionalTaxPolicy>(() => new FlatTaxPolicy(0.10m))
+                .Product<IRegionalPaymentGateway>(() => new RegionalPaymentGateway("Alipay", audit))
+                .Product<IRegionalRiskPolicy>(() => new ThresholdRiskPolicy(4500m))
+            .Build();
+
+    private static Decorator<EnterpriseCheckoutContext, decimal> CreatePriceCalculator(AbstractFactory<Region> regionalFactory)
+        => Decorator<EnterpriseCheckoutContext, decimal>.Create(static ctx => ctx.Subtotal)
+            .After(static (ctx, price) => price + ctx.Shipping)
+            .After((ctx, price) =>
+            {
+                var policy = regionalFactory.GetFamily(ctx.Request.Region).Create<IRegionalTaxPolicy>();
+                ctx.Tax = policy.Apply(price) - price;
+                return policy.Apply(price);
+            })
+            .After(static (ctx, price) => price - ctx.Discount)
+            .Build();
+
+    private static Proxy<PaymentCharge, PaymentReceipt> CreatePaymentProxy(
+        AbstractFactory<Region> regionalFactory,
+        AuditLog audit)
+        => Proxy<PaymentCharge, PaymentReceipt>.Create(charge =>
+            {
+                var family = regionalFactory.GetFamily(charge.Region);
+                var risk = family.Create<IRegionalRiskPolicy>();
+                if (!risk.Allows(charge) && !charge.ManagerOverride)
+                    return new PaymentReceipt(false, "risk", "manual-review");
+
+                return family.Create<IRegionalPaymentGateway>().Charge(charge);
+            })
+            .Intercept((charge, next) =>
+            {
+                audit.Add($"payment:request:{charge.OrderId}:{charge.Amount:F2}");
+                var receipt = next(charge);
+                audit.Add($"payment:{receipt.Provider}:{receipt.AuthorizationCode}");
+                return receipt;
+            })
+            .Build();
+
+    private static TypeDispatcher<FulfillmentInstruction, string> CreateFulfillmentRenderer()
+        => TypeDispatcher<FulfillmentInstruction, string>.Create()
+            .On<ShipPhysical>(static item => $"ship:{item.Sku}:{item.Quantity}:{item.WeightKg:F1}kg")
+            .On<SendDownload>(static item => $"download:{item.Sku}:{item.Quantity}")
+            .On<ActivateSubscription>(static item => $"subscription:{item.Sku}:{item.Quantity}:{item.Months}mo")
+            .Default(static item => $"manual:{item.Sku}:{item.Quantity}")
+            .Build();
+
+    private static StateMachine<CheckoutStage, CheckoutEvent> CreateCheckoutStateMachine()
+        => StateMachine<CheckoutStage, CheckoutEvent>.Create()
+            .InState(CheckoutStage.Received, state => state
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.Validate).Permit(CheckoutStage.Validating).End()
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.Reject).Permit(CheckoutStage.Rejected).End())
+            .InState(CheckoutStage.Validating, state => state
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.Price).Permit(CheckoutStage.Priced).End()
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.Reject).Permit(CheckoutStage.Rejected).End())
+            .InState(CheckoutStage.Priced, state => state
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.Pay).Permit(CheckoutStage.Paid).End()
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.Reject).Permit(CheckoutStage.Rejected).End())
+            .InState(CheckoutStage.Paid, state => state
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.QueueFulfillment).Permit(CheckoutStage.FulfillmentQueued).End()
+                .When(static (in CheckoutEvent e) => e.Kind == CheckoutEventKind.Reject).Permit(CheckoutStage.Rejected).End())
+            .InState(CheckoutStage.FulfillmentQueued, state => state
+                .Otherwise().Stay().AsDefault())
+            .InState(CheckoutStage.Rejected, state => state
+                .Otherwise().Stay().AsDefault())
+            .Build();
+
+    private static Memento<CheckoutSnapshot> CreateCheckoutHistory()
+        => Memento<CheckoutSnapshot>.Create()
+            .Capacity(32)
+            .Build();
+
+    private static Observer<CheckoutEvent> CreateCheckoutObserver(AuditLog audit)
+    {
+        var observer = Observer<CheckoutEvent>.Create().Build();
+        observer.Subscribe((in CheckoutEvent e) => audit.Add($"event:{e.OrderId}:{e.Kind}:{e.Detail}"));
+        observer.Subscribe(
+            (in CheckoutEvent e) => e.Kind == CheckoutEventKind.QueueFulfillment,
+            (in CheckoutEvent e) => audit.Add($"notify:fulfillment:{e.OrderId}"));
+        return observer;
+    }
+
+    private sealed class EnterpriseCheckoutService(
+        Flyweight<string, CatalogItem> catalog,
+        Factory<ProductKind, FulfillmentDraft, FulfillmentInstruction> fulfillmentFactory,
+        Prototype<string, EnterpriseCheckoutContext> contextPrototype,
+        ResultChain<EnterpriseCheckoutContext, ValidationOutcome> validation,
+        Strategy<EnterpriseCheckoutContext, decimal> discounts,
+        Decorator<EnterpriseCheckoutContext, decimal> prices,
+        Proxy<PaymentCharge, PaymentReceipt> payments,
+        TypeDispatcher<FulfillmentInstruction, string> renderer,
+        StateMachine<CheckoutStage, CheckoutEvent> stages,
+        Memento<CheckoutSnapshot> history,
+        Observer<CheckoutEvent> events,
+        AuditLog audit)
+    {
+        public CheckoutResult Estimate(CheckoutRequest request)
+            => Execute(request, chargePayment: false);
+
+        public CheckoutResult Place(CheckoutRequest request)
+            => Execute(request, chargePayment: true);
+
+        private CheckoutResult Execute(CheckoutRequest request, bool chargePayment)
+        {
+            var ctx = BuildContext(request);
+            Save(ctx, "received");
+
+            Move(ctx, CheckoutEventKind.Validate, "start validation");
+            validation.Execute(ctx, out var outcome);
+            if (outcome is not { Accepted: true })
+                return Reject(ctx, outcome?.Message ?? "Rejected");
+
+            ctx.Subtotal = ctx.CatalogItems.Zip(request.Lines, static (item, line) => item.ListPrice * line.Quantity).Sum();
+            ctx.Shipping = CalculateShipping(ctx);
+            ctx.Discount = discounts.Execute(ctx);
+
+            Move(ctx, CheckoutEventKind.Price, "priced");
+            ctx.Total = prices.Execute(ctx);
+            Save(ctx, "priced");
+
+            if (!chargePayment)
+                return Complete(ctx, "Estimated", accepted: true);
+
+            Move(ctx, CheckoutEventKind.Pay, "payment requested");
+            var receipt = payments.Execute(new PaymentCharge(request.OrderId, request.Region, ctx.Total, request.ManagerOverride));
+            if (!receipt.Approved)
+                return Reject(ctx, "Payment requires manual review");
+
+            Move(ctx, CheckoutEventKind.QueueFulfillment, "fulfillment queued");
+            var instructions = Flow<FulfillmentInstruction>.From(ctx.Instructions)
+                .Filter(static item => item.Quantity > 0)
+                .Map<string>(item => renderer.Dispatch(item))
+                .ToList();
+            ctx.WorkItems.AddRange(instructions);
+            Save(ctx, "queued");
+
+            return Complete(ctx, "Order accepted", accepted: true);
+        }
+
+        private EnterpriseCheckoutContext BuildContext(CheckoutRequest request)
+        {
+            var catalogItems = request.Lines
+                .Select(line => catalog.Get(line.Sku))
+                .ToList();
+
+            var instructions = request.Lines.Zip(catalogItems, (line, item) =>
+                fulfillmentFactory.Create(line.Kind, new FulfillmentDraft(request.OrderId, line, item)))
+                .ToList();
+
+            return contextPrototype.Create("checkout", ctx =>
+            {
+                ctx.Request = request;
+                ctx.CatalogItems = catalogItems;
+                ctx.Instructions = instructions;
+                ctx.Stage = CheckoutStage.Received;
+                ctx.Subtotal = 0m;
+                ctx.Shipping = 0m;
+                ctx.Discount = 0m;
+                ctx.Tax = 0m;
+                ctx.Total = 0m;
+            });
+        }
+
+        private static decimal CalculateShipping(EnterpriseCheckoutContext ctx)
+        {
+            if (ctx.Request.Mode == FulfillmentMode.Electronic)
+                return 0m;
+
+            var weight = ctx.Instructions.OfType<ShipPhysical>().Sum(item => item.WeightKg * item.Quantity);
+            var baseRate = ctx.Request.Mode == FulfillmentMode.Express ? 18m : 7m;
+            var perKg = ctx.Request.Mode == FulfillmentMode.Express ? 6m : 3m;
+            return Math.Round(baseRate + (decimal)weight * perKg, 2);
+        }
+
+        private CheckoutResult Reject(EnterpriseCheckoutContext ctx, string message)
+        {
+            Move(ctx, CheckoutEventKind.Reject, message);
+            Save(ctx, "rejected");
+            return Complete(ctx, message, accepted: false);
+        }
+
+        private CheckoutResult Complete(EnterpriseCheckoutContext ctx, string message, bool accepted)
+            => new(
+                accepted,
+                message,
+                ctx.Stage,
+                ctx.Total,
+                ctx.WorkItems.ToArray(),
+                ctx.Audit.Concat(audit.Entries).ToArray(),
+                history.CurrentVersion);
+
+        private void Move(EnterpriseCheckoutContext ctx, CheckoutEventKind kind, string detail)
+        {
+            var evt = new CheckoutEvent(ctx.Request.OrderId, kind, detail);
+            var stage = ctx.Stage;
+            stages.Transition(ref stage, evt);
+            ctx.Stage = stage;
+            events.Publish(evt);
+            ctx.Audit.Add($"stage:{ctx.Stage}");
+        }
+
+        private void Save(EnterpriseCheckoutContext ctx, string note)
+            => history.Save(new CheckoutSnapshot(ctx.Request.OrderId, ctx.Stage, ctx.Total, note), note);
+    }
+
+    private sealed class FlatTaxPolicy(decimal rate) : IRegionalTaxPolicy
+    {
+        public decimal Apply(decimal taxableAmount) => Math.Round(taxableAmount * (1m + rate), 2);
+    }
+
+    private sealed class ThresholdRiskPolicy(decimal threshold) : IRegionalRiskPolicy
+    {
+        public bool Allows(PaymentCharge charge) => charge.Amount <= threshold;
+    }
+
+    private sealed class RegionalPaymentGateway(string name, AuditLog audit) : IRegionalPaymentGateway
+    {
+        public string Name => name;
+
+        public PaymentReceipt Charge(PaymentCharge charge)
+        {
+            audit.Add($"gateway:{Name}:{charge.OrderId}");
+            return new PaymentReceipt(true, Name, $"{Name[..Math.Min(3, Name.Length)].ToUpperInvariant()}-{charge.OrderId}");
+        }
+    }
+}

--- a/test/PatternKit.Examples.Tests/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemoTests.cs
+++ b/test/PatternKit.Examples.Tests/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemoTests.cs
@@ -1,0 +1,355 @@
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Behavioral.Chain;
+using PatternKit.Behavioral.Memento;
+using PatternKit.Behavioral.Observer;
+using PatternKit.Behavioral.State;
+using PatternKit.Behavioral.Strategy;
+using PatternKit.Behavioral.TypeDispatcher;
+using PatternKit.Creational.AbstractFactory;
+using PatternKit.Creational.Factory;
+using PatternKit.Creational.Prototype;
+using PatternKit.Examples.EnterpriseFeatureSlices;
+using PatternKit.Structural.Decorator;
+using PatternKit.Structural.Flyweight;
+using PatternKit.Structural.Proxy;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
+using static PatternKit.Examples.EnterpriseFeatureSlices.EnterpriseFeatureSlicesDemo;
+
+namespace PatternKit.Examples.Tests.EnterpriseFeatureSlices;
+
+[Feature("Enterprise feature slices with standard .NET dependency injection")]
+public sealed class EnterpriseFeatureSlicesDemoTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    [Scenario("ServiceCollection resolves the feature facade and PatternKit artifacts")]
+    [Fact]
+    public Task ServiceCollection_Resolves_Feature_Facade_And_PatternKit_Artifacts()
+        => Given("a provider built from the enterprise feature-slice registration", BuildServiceProvider)
+            .When("resolving registered services", provider => new
+            {
+                Checkout = provider.GetService<IEnterpriseCheckout>(),
+                Catalog = provider.GetService<Flyweight<string, CatalogItem>>(),
+                FulfillmentFactory = provider.GetService<Factory<ProductKind, FulfillmentDraft, FulfillmentInstruction>>(),
+                Prototype = provider.GetService<Prototype<string, EnterpriseCheckoutContext>>(),
+                Validation = provider.GetService<ResultChain<EnterpriseCheckoutContext, ValidationOutcome>>(),
+                Discounts = provider.GetService<Strategy<EnterpriseCheckoutContext, decimal>>(),
+                Prices = provider.GetService<Decorator<EnterpriseCheckoutContext, decimal>>(),
+                Payments = provider.GetService<Proxy<PaymentCharge, PaymentReceipt>>(),
+                Stages = provider.GetService<StateMachine<CheckoutStage, CheckoutEvent>>(),
+                History = provider.GetService<Memento<CheckoutSnapshot>>(),
+                Events = provider.GetService<Observer<CheckoutEvent>>(),
+                RegionalFactory = provider.GetService<AbstractFactory<Region>>()
+            })
+            .Then("the feature facade is available", services => services.Checkout is not null)
+            .And("the pattern artifacts are container-owned singletons", services =>
+                services.Catalog is not null
+                && services.FulfillmentFactory is not null
+                && services.Prototype is not null
+                && services.Validation is not null
+                && services.Discounts is not null
+                && services.Prices is not null
+                && services.Payments is not null
+                && services.Stages is not null
+                && services.History is not null
+                && services.Events is not null
+                && services.RegionalFactory is not null)
+            .AssertPassed();
+
+    [Scenario("Place accepts a real retail checkout and queues fulfillment work")]
+    [Fact]
+    public Task Place_Accepts_Real_Retail_Checkout_And_Queues_Fulfillment()
+        => Given("a feature facade and a mixed physical digital subscription order", () =>
+            {
+                var provider = BuildServiceProvider();
+                return new
+                {
+                    Provider = provider,
+                    Checkout = provider.GetRequiredService<IEnterpriseCheckout>(),
+                    Request = CreateRetailRequest()
+                };
+            })
+            .When("placing the order", ctx => ctx.Checkout.Place(ctx.Request))
+            .Then("the order is accepted", result =>
+                result.Accepted && result.Stage == CheckoutStage.FulfillmentQueued)
+            .And("fulfillment work items are typed by item kind", result =>
+                result.WorkItems.Any(item => item.StartsWith("ship:KB-001", StringComparison.Ordinal))
+                && result.WorkItems.Any(item => item.StartsWith("subscription:APP-365", StringComparison.Ordinal))
+                && result.WorkItems.Any(item => item.StartsWith("download:EBOOK-42", StringComparison.Ordinal)))
+            .And("the audit shows DI-wired observers and payment proxy activity", result =>
+                result.Audit.Any(item => item.Contains("event:SO-1001:Validate", StringComparison.Ordinal))
+                && result.Audit.Any(item => item.Contains("payment:request:SO-1001", StringComparison.Ordinal))
+                && result.Audit.Any(item => item.Contains("gateway:Stripe:SO-1001", StringComparison.Ordinal))
+                && result.SnapshotVersion >= 3)
+            .AssertPassed();
+
+    [Scenario("Estimate computes pricing without charging payment or queueing work")]
+    [Fact]
+    public Task Estimate_Computes_Pricing_Without_Charging_Or_Queueing()
+        => Given("a feature facade and a retail order", () =>
+            {
+                var provider = BuildServiceProvider();
+                return new
+                {
+                    Checkout = provider.GetRequiredService<IEnterpriseCheckout>(),
+                    Request = CreateRetailRequest("SO-EST")
+                };
+            })
+            .When("estimating the order", ctx => ctx.Checkout.Estimate(ctx.Request))
+            .Then("the estimate is accepted at priced stage", result =>
+                result.Accepted && result.Stage == CheckoutStage.Priced && result.Total > 0)
+            .And("no payment or fulfillment side effects occurred", result =>
+                result.WorkItems.Count == 0
+                && result.Audit.All(item => !item.Contains("payment:request", StringComparison.Ordinal))
+                && result.Audit.All(item => !item.Contains("notify:fulfillment", StringComparison.Ordinal)))
+            .AssertPassed();
+
+    [Scenario("Validation rejects incompatible electronic fulfillment for physical goods")]
+    [Fact]
+    public Task Validation_Rejects_Electronic_Mode_For_Physical_Goods()
+        => Given("a feature facade and an electronic order containing physical goods", () =>
+            {
+                var provider = BuildServiceProvider();
+                var request = CreateRetailRequest("SO-BAD") with { Mode = FulfillmentMode.Electronic };
+                return new
+                {
+                    Checkout = provider.GetRequiredService<IEnterpriseCheckout>(),
+                    Request = request
+                };
+            })
+            .When("placing the order", ctx => ctx.Checkout.Place(ctx.Request))
+            .Then("the order is rejected before payment", result =>
+                !result.Accepted && result.Stage == CheckoutStage.Rejected)
+            .And("the message identifies the fulfillment issue", result =>
+                result.Message.Contains("Electronic fulfillment", StringComparison.Ordinal))
+            .And("the payment proxy was not called", result =>
+                result.Audit.All(item => !item.Contains("payment:request", StringComparison.Ordinal)))
+            .AssertPassed();
+
+    [Scenario("Risk proxy sends high value orders to manual review unless manager override is present")]
+    [Fact]
+    public async Task Risk_Proxy_Requires_Manager_Override_For_High_Value_Orders()
+    {
+        await Given("two high-value requests, one without override and one with override", () =>
+            {
+                var deniedProvider = BuildServiceProvider();
+                var approvedProvider = BuildServiceProvider();
+                var lines = new[] { new CheckoutLine("KB-001", ProductKind.Physical, 50) };
+
+                return new
+                {
+                    Denied = deniedProvider.GetRequiredService<IEnterpriseCheckout>(),
+                    Approved = approvedProvider.GetRequiredService<IEnterpriseCheckout>(),
+                    DeniedRequest = new CheckoutRequest(
+                        "SO-RISK-1",
+                        "CUST-001",
+                        CustomerTier.Standard,
+                        Region.NorthAmerica,
+                        FulfillmentMode.Standard,
+                        lines),
+                    ApprovedRequest = new CheckoutRequest(
+                        "SO-RISK-2",
+                        "CUST-001",
+                        CustomerTier.Standard,
+                        Region.NorthAmerica,
+                        FulfillmentMode.Standard,
+                        lines,
+                        ManagerOverride: true)
+                };
+            })
+            .When("placing both orders", ctx => new
+            {
+                Denied = ctx.Denied.Place(ctx.DeniedRequest),
+                Approved = ctx.Approved.Place(ctx.ApprovedRequest)
+            })
+            .Then("the unapproved high-value order goes to manual review", result =>
+                !result.Denied.Accepted
+                && result.Denied.Message.Contains("manual review", StringComparison.Ordinal))
+            .And("the manager override order is accepted", result =>
+                result.Approved.Accepted
+                && result.Approved.Stage == CheckoutStage.FulfillmentQueued)
+            .And("the accepted path still goes through the regional payment gateway", result =>
+                result.Approved.Audit.Any(item => item.Contains("gateway:Stripe:SO-RISK-2", StringComparison.Ordinal)))
+            .AssertPassed();
+    }
+
+    [Scenario("Validation chain rejects malformed checkout requests before payment")]
+    [Fact]
+    public Task Validation_Rejects_Malformed_Checkout_Requests()
+        => Given("a feature facade and malformed checkout requests", () =>
+            {
+                var provider = BuildServiceProvider();
+                var checkout = provider.GetRequiredService<IEnterpriseCheckout>();
+
+                return new
+                {
+                    Checkout = checkout,
+                    MissingOrder = CreateRetailRequest("") with { CustomerId = "CUST-MISSING" },
+                    EmptyLines = CreateRetailRequest("SO-EMPTY") with { Lines = [] },
+                    BadQuantity = CreateRetailRequest("SO-QTY") with
+                    {
+                        Lines = [new CheckoutLine("EBOOK-42", ProductKind.Digital, 0)]
+                    }
+                };
+            })
+            .When("placing each malformed request", ctx => new
+            {
+                ctx.MissingOrder.CustomerId,
+                MissingOrder = ctx.Checkout.Place(ctx.MissingOrder),
+                EmptyLines = ctx.Checkout.Place(ctx.EmptyLines),
+                BadQuantity = ctx.Checkout.Place(ctx.BadQuantity)
+            })
+            .Then("the order-id rule reports the missing identifier", result =>
+                result.CustomerId == "CUST-MISSING"
+                && !result.MissingOrder.Accepted
+                && result.MissingOrder.Message.Contains("Order id", StringComparison.Ordinal))
+            .And("the line-count rule reports empty orders", result =>
+                !result.EmptyLines.Accepted
+                && result.EmptyLines.Message.Contains("At least one checkout line", StringComparison.Ordinal))
+            .And("the quantity rule reports invalid quantities", result =>
+                !result.BadQuantity.Accepted
+                && result.BadQuantity.Message.Contains("positive", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Discount strategy covers enterprise, volume, and default pricing tiers")]
+    [Fact]
+    public Task Discount_Strategy_Covers_Enterprise_Volume_And_Default_Tiers()
+        => Given("a feature facade and representative pricing requests", () =>
+            {
+                var provider = BuildServiceProvider();
+                var checkout = provider.GetRequiredService<IEnterpriseCheckout>();
+
+                return new
+                {
+                    Checkout = checkout,
+                    Enterprise = CreateRetailRequest("SO-ENT") with { Tier = CustomerTier.Enterprise },
+                    Volume = new CheckoutRequest(
+                        "SO-VOL",
+                        "CUST-STANDARD",
+                        CustomerTier.Standard,
+                        Region.NorthAmerica,
+                        FulfillmentMode.Standard,
+                        [new CheckoutLine("APP-365", ProductKind.Subscription, 3)]),
+                    Default = new CheckoutRequest(
+                        "SO-BASE",
+                        "CUST-STANDARD",
+                        CustomerTier.Standard,
+                        Region.NorthAmerica,
+                        FulfillmentMode.Electronic,
+                        [new CheckoutLine("EBOOK-42", ProductKind.Digital, 1)])
+                };
+            })
+            .When("estimating all pricing tiers", ctx => new
+            {
+                Enterprise = ctx.Checkout.Estimate(ctx.Enterprise),
+                Volume = ctx.Checkout.Estimate(ctx.Volume),
+                Default = ctx.Checkout.Estimate(ctx.Default)
+            })
+            .Then("the enterprise tier receives the largest configured discount", result =>
+                result.Enterprise.Accepted
+                && result.Enterprise.Total < result.Volume.Total)
+            .And("the volume tier receives its fixed discount", result =>
+                result.Volume.Accepted
+                && result.Volume.Total > 0m)
+            .And("the default tier remains a valid digital-only electronic estimate", result =>
+                result.Default.Accepted
+                && result.Default.Stage == CheckoutStage.Priced
+                && result.Default.Total > 0m)
+            .AssertPassed();
+
+    [Scenario("Regional abstract factory routes payments through Europe and Asia Pacific providers")]
+    [Fact]
+    public Task Regional_Factory_Routes_Europe_And_Asia_Pacific_Payments()
+        => Given("separate regional providers and digital checkout requests", () =>
+            {
+                var europeProvider = BuildServiceProvider();
+                var asiaProvider = BuildServiceProvider();
+
+                return new
+                {
+                    Europe = europeProvider.GetRequiredService<IEnterpriseCheckout>(),
+                    Asia = asiaProvider.GetRequiredService<IEnterpriseCheckout>(),
+                    EuropeRequest = new CheckoutRequest(
+                        "SO-EU",
+                        "CUST-EU",
+                        CustomerTier.Standard,
+                        Region.Europe,
+                        FulfillmentMode.Electronic,
+                        [new CheckoutLine("EBOOK-42", ProductKind.Digital, 1)]),
+                    AsiaRequest = new CheckoutRequest(
+                        "SO-APAC",
+                        "CUST-APAC",
+                        CustomerTier.Standard,
+                        Region.AsiaPacific,
+                        FulfillmentMode.Electronic,
+                        [new CheckoutLine("EBOOK-42", ProductKind.Digital, 1)])
+                };
+            })
+            .When("placing regional orders", ctx => new
+            {
+                Europe = ctx.Europe.Place(ctx.EuropeRequest),
+                Asia = ctx.Asia.Place(ctx.AsiaRequest)
+            })
+            .Then("Europe uses the Adyen payment family", result =>
+                result.Europe.Accepted
+                && result.Europe.Audit.Any(item => item.Contains("gateway:Adyen:SO-EU", StringComparison.Ordinal)))
+            .And("Asia Pacific uses the Alipay payment family", result =>
+                result.Asia.Accepted
+                && result.Asia.Audit.Any(item => item.Contains("gateway:Alipay:SO-APAC", StringComparison.Ordinal)))
+            .AssertPassed();
+
+    [Scenario("Fallback artifacts handle catalog misses, prototype defaults, and manual fulfillment")]
+    [Fact]
+    public Task Fallback_Artifacts_Handle_Catalog_Prototype_And_Dispatcher_Defaults()
+        => Given("a provider with fallback-capable PatternKit artifacts", () =>
+            {
+                var provider = BuildServiceProvider();
+                var audit = provider.GetRequiredService<AuditLog>();
+                audit.Add("seed");
+
+                return new
+                {
+                    Checkout = provider.GetRequiredService<IEnterpriseCheckout>(),
+                    Prototype = provider.GetRequiredService<Prototype<string, EnterpriseCheckoutContext>>(),
+                    Dispatcher = provider.GetRequiredService<TypeDispatcher<FulfillmentInstruction, string>>(),
+                    Audit = audit,
+                    SpecialOrder = new CheckoutRequest(
+                        "SO-SPECIAL",
+                        "CUST-SPECIAL",
+                        CustomerTier.Standard,
+                        Region.NorthAmerica,
+                        FulfillmentMode.Standard,
+                        [new CheckoutLine("SPECIAL-9", ProductKind.Physical, 1)])
+                };
+            })
+            .When("using each fallback path", ctx =>
+            {
+                var defaultContext = ctx.Prototype.Create("quote");
+                var manualWork = ctx.Dispatcher.Dispatch(new ManualInstruction("SO-MANUAL", "MAN-1", 2));
+                ctx.Audit.Clear();
+                var auditWasCleared = ctx.Audit.Entries.Count == 0;
+
+                return new
+                {
+                    SpecialOrder = ctx.Checkout.Place(ctx.SpecialOrder),
+                    DefaultContext = defaultContext,
+                    ManualWork = manualWork,
+                    AuditWasCleared = auditWasCleared
+                };
+            })
+            .Then("the catalog flyweight creates a special-order product", result =>
+                result.SpecialOrder.Accepted
+                && result.SpecialOrder.WorkItems.Any(item => item.Contains("SPECIAL-9", StringComparison.Ordinal)))
+            .And("the prototype default returns a fresh checkout context", result =>
+                result.DefaultContext.Request.OrderId == ""
+                && result.DefaultContext.Request.CustomerId == ""
+                && result.DefaultContext.CatalogItems.Count == 0
+                && result.DefaultContext.Stage == CheckoutStage.Received)
+            .And("the dispatcher default renders manual fulfillment work", result =>
+                result.ManualWork == "manual:MAN-1:2"
+                && result.AuditWasCleared)
+            .AssertPassed();
+
+    private sealed record ManualInstruction(string ManualOrderId, string ManualSku, int ManualQuantity)
+        : FulfillmentInstruction(ManualOrderId, ManualSku, ManualQuantity);
+}


### PR DESCRIPTION
## Summary
- add an enterprise checkout feature-slice demo wired through Microsoft.Extensions.DependencyInjection
- register PatternKit artifacts as DI-owned singletons behind a typed IEnterpriseCheckout facade
- cover accepted, estimate-only, validation rejection, and high-value risk proxy scenarios with TinyBDD
- document the new demo and link it into the examples index/ToC

## Verification
- dotnet test PatternKit.slnx --no-restore
- docfx metadata docs\\docfx.json; docfx build docs\\docfx.json
- git diff --check