### PR TITLE
feat: add production-ready examples catalog

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -17,6 +17,7 @@ Welcome! This section collects small, focused demos that show **how to compose b
 * **Source-generated application wiring** for builders, factories, facades, proxies, observers, visitors, state machines, strategies, mementos, template methods, and messaging factories.
 * **Enterprise messaging workflows** for envelopes, routers, recipient lists, splitters, aggregators, routing slips, sagas, mailboxes, idempotent receivers, inboxes, and outboxes.
 * **Messaging backplane facade** for host-style setup, typed request/reply, and publish/subscribe over an application-owned transport boundary.
+* **Production-readiness catalog** for DI, generic host, and ASP.NET Core diagnostics that maps every documented example to its source, TinyBDD tests, docs page, integration surfaces, and production checks.
 
 ## Demos in this section
 
@@ -71,6 +72,9 @@ Welcome! This section collects small, focused demos that show **how to compose b
 * **Messaging Backplane Facade**
   Demonstrates how PatternKit can sit behind a MassTransit- or MediatR-style host builder and typed client while RabbitMQ, Azure Service Bus, Postgres, MQTT, or another adapter remains infrastructure-owned. See [Messaging Backplane Facade](messaging-backplane-facade.md).
 
+* **Production-Ready Example Integrations**
+  Importable catalog and validation tooling for every documented example. Register it through `IServiceCollection`, validate it during generic host startup, or expose it through ASP.NET Core minimal API endpoints. See [Production-Ready Example Integrations](production-ready-integrations.md).
+
 ## How to run
 
 From the repo root:
@@ -117,6 +121,7 @@ dotnet test PatternKit.slnx -c Release
 * **Resilient Checkout:** `ResilientCheckoutDemo` (+ `ResilientCheckoutDemoTests`) — fallback checkout routes with compensation.
 * **Collaborating Mailboxes:** `ServiceCollaborationMailboxDemo` (+ `ServiceCollaborationMailboxDemoTests`) — inventory, payment, shipping, and notification services collaborating through serialized mailboxes.
 * **Messaging Backplane Facade:** `BackplaneFacadeDemo` (+ `BackplaneFacadeDemoTests`) — host setup, request/reply, pub/sub, outbox, idempotency, and mailbox-backed transport subscribers.
+* **Production-Ready Example Catalog:** `PatternKitExampleCatalog` (+ `PatternKitExampleCatalogTests`) — DI registration, generic host validation, ASP.NET Core endpoint mapping, and source/test/docs manifest checks.
 * **Tests:** `PatternKit.Examples.Tests/*` use TinyBDD scenarios that read like specs.
 
 ## Why these demos exist

--- a/docs/examples/production-ready-integrations.md
+++ b/docs/examples/production-ready-integrations.md
@@ -1,0 +1,103 @@
+# Production-Ready Example Integrations
+
+PatternKit examples are meant to be importable building blocks, not throwaway snippets. The examples package now exposes a production-readiness catalog that applications, tests, documentation tooling, and ASP.NET Core diagnostics can use to discover which examples exist, where their source/tests/docs live, and which integration surfaces they exercise.
+
+## Register the catalog
+
+Use the standard .NET dependency injection container:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Examples.ProductionReadiness;
+
+var services = new ServiceCollection()
+    .AddLogging()
+    .AddPatternKitExampleCatalog();
+
+using var provider = services.BuildServiceProvider(validateScopes: true);
+var catalog = provider.GetRequiredService<IPatternKitExampleCatalog>();
+```
+
+Each `PatternKitExampleDescriptor` includes:
+
+| Field | Purpose |
+| --- | --- |
+| `Name` | Human-readable example name. |
+| `SourcePath` | Repository source file or entry point. |
+| `TestPath` | TinyBDD scenario coverage for the example. |
+| `DocumentationPath` | DocFX page for the example. |
+| `Integration` | Tooling surfaces covered: DI, options, generic host, ASP.NET Core, source generators, messaging, or external infrastructure. |
+| `Patterns` | PatternKit primitives demonstrated by the example. |
+| `ProductionChecks` | The behaviors that make the example production-shaped and regression-testable. |
+
+## Validate in a generic host
+
+Applications can fail fast during startup when catalog metadata is malformed or when source/docs/tests are missing from a repository checkout:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using PatternKit.Examples.ProductionReadiness;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddPatternKitExampleHostedValidation(options =>
+{
+    options.RepositoryRoot = "/work/PatternKit";
+    options.FailOnInvalid = true;
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+
+When `RepositoryRoot` is unset, validation still checks descriptor quality: names, paths, integration surfaces, listed patterns, and production checks. Supplying a repository root also verifies that the referenced source, test, and documentation files exist.
+
+## Expose diagnostics in ASP.NET Core
+
+ASP.NET Core apps can map a tiny diagnostics endpoint for internal documentation portals or build verification:
+
+```csharp
+using PatternKit.Examples.ProductionReadiness;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddPatternKitExampleCatalog();
+
+var app = builder.Build();
+app.MapPatternKitExampleCatalog();
+
+await app.RunAsync();
+```
+
+This maps:
+
+| Route | Result |
+| --- | --- |
+| `/patternkit/examples` | The catalog descriptors. |
+| `/patternkit/examples/validation` | A validation report, with HTTP 500 when validation fails. |
+
+## Readiness Contract
+
+Every documented example should satisfy the same baseline contract:
+
+| Requirement | How it is enforced |
+| --- | --- |
+| Documented in DocFX | `docs/examples/toc.yml` links to the page and documentation tests validate hrefs. |
+| Covered by TinyBDD scenarios | The catalog points to a test file and catalog tests verify it exists. |
+| Importable from the examples package | The catalog is part of `PatternKit.Examples` and is registered through `IServiceCollection`/`IHostApplicationBuilder`. |
+| Host/tooling friendly where applicable | Integration flags identify examples that demonstrate `IOptions`, DI, generic host, ASP.NET Core, source generators, messaging, or external infrastructure. |
+| Production-shaped behavior called out | `ProductionChecks` records the behaviors each example must keep validating. |
+
+## Current Catalog Scope
+
+The catalog covers every page in the examples ToC, including:
+
+| Area | Examples |
+| --- | --- |
+| Request and pipeline composition | Auth/logging chain, minimal web router, mediated transaction pipeline, configuration-driven pipeline. |
+| Host and DI composition | Enterprise feature slices, source-generator application suite, messaging backplane facade. |
+| Messaging | Enterprise messaging workflow suite, resilient checkout, collaborating mailboxes, message router visitor. |
+| POS and pricing | Payment processor decorator, pricing calculator, POS app state, tender visitor. |
+| Behavioral workflows | Async state machine, reactive ViewModel, reactive transaction, template method sync/async, event processing visitor. |
+| Structural and creational patterns | Flyweight glyph cache, proxy demos, prototype registry, text editor memento, observer hub. |
+
+The catalog is intentionally small and static. It is easy to audit in code review, cheap to resolve at runtime, and suitable for use in build checks, docs portals, sample applications, or internal architecture dashboards.

--- a/docs/examples/toc.yml
+++ b/docs/examples/toc.yml
@@ -1,6 +1,9 @@
 - name: Examples & Demos
   href: index.md
 
+- name: Production-Ready Example Integrations
+  href: production-ready-integrations.md
+
 - name: Auth & Logging with `ActionChain<HttpRequest>`
   href: auth-logging-chain.md
 

--- a/src/PatternKit.Examples/PatternKit.Examples.csproj
+++ b/src/PatternKit.Examples/PatternKit.Examples.csproj
@@ -29,4 +29,8 @@
       <Folder Include="Strategies\" />
     </ItemGroup>
 
+    <ItemGroup>
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
 </Project>

--- a/src/PatternKit.Examples/ProductionReadiness/PatternKitExampleCatalog.cs
+++ b/src/PatternKit.Examples/ProductionReadiness/PatternKitExampleCatalog.cs
@@ -1,0 +1,492 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace PatternKit.Examples.ProductionReadiness;
+
+/// <summary>
+/// Integration surfaces demonstrated by an example entry.
+/// </summary>
+[Flags]
+public enum ExampleIntegrationSurface
+{
+    None = 0,
+    LibraryOnly = 1,
+    DependencyInjection = 2,
+    Options = 4,
+    GenericHost = 8,
+    AspNetCore = 16,
+    SourceGenerator = 32,
+    Messaging = 64,
+    ExternalInfrastructure = 128
+}
+
+/// <summary>
+/// Describes a production-shaped PatternKit example, its tests, and its documentation.
+/// </summary>
+public sealed record PatternKitExampleDescriptor(
+    string Name,
+    string SourcePath,
+    string TestPath,
+    string DocumentationPath,
+    ExampleIntegrationSurface Integration,
+    IReadOnlyList<string> Patterns,
+    IReadOnlyList<string> ProductionChecks);
+
+/// <summary>
+/// A validation issue found while auditing example metadata and optional repository files.
+/// </summary>
+public sealed record PatternKitExampleValidationIssue(
+    string ExampleName,
+    string Field,
+    string Message);
+
+/// <summary>
+/// Validation report for the example catalog.
+/// </summary>
+public sealed record PatternKitExampleValidationReport(
+    IReadOnlyList<PatternKitExampleDescriptor> Entries,
+    IReadOnlyList<PatternKitExampleValidationIssue> Issues)
+{
+    public bool IsValid => Issues.Count == 0;
+}
+
+/// <summary>
+/// Runtime validation options for the examples catalog.
+/// </summary>
+public sealed class PatternKitExampleCatalogOptions
+{
+    /// <summary>
+    /// Optional repository root. When supplied, validation checks that source, test, and documentation paths exist.
+    /// </summary>
+    public string? RepositoryRoot { get; set; }
+
+    /// <summary>
+    /// Throws during hosted startup when validation fails.
+    /// </summary>
+    public bool FailOnInvalid { get; set; } = true;
+}
+
+/// <summary>
+/// Read-only manifest of production-shaped PatternKit examples.
+/// </summary>
+public interface IPatternKitExampleCatalog
+{
+    IReadOnlyList<PatternKitExampleDescriptor> Entries { get; }
+
+    PatternKitExampleValidationReport Validate(string? repositoryRoot = null);
+}
+
+/// <summary>
+/// Default example catalog used by docs, tests, hosts, and ASP.NET Core endpoints.
+/// </summary>
+public sealed class PatternKitExampleCatalog : IPatternKitExampleCatalog
+{
+    private static readonly IReadOnlyList<PatternKitExampleDescriptor> Items =
+    [
+        Descriptor(
+            "Production-Ready Example Integrations",
+            "src/PatternKit.Examples/ProductionReadiness/PatternKitExampleCatalog.cs",
+            "test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitExampleCatalogTests.cs",
+            "docs/examples/production-ready-integrations.md",
+            ExampleIntegrationSurface.DependencyInjection | ExampleIntegrationSurface.GenericHost | ExampleIntegrationSurface.AspNetCore,
+            ["Catalog", "Facade"],
+            ["source/test/docs manifest", "host startup validation", "minimal API diagnostics"]),
+        Descriptor(
+            "Auth & Logging Chain",
+            "src/PatternKit.Examples/Chain/AuthLoggingDemo.cs",
+            "test/PatternKit.Examples.Tests/Chain/AuthLoggingDemoTests.cs",
+            "docs/examples/auth-logging-chain.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["ActionChain"],
+            ["request logging", "authorization short-circuit", "strict stop semantics"]),
+        Descriptor(
+            "Strategy-Based Data Coercion",
+            "src/PatternKit.Examples/Strategies/Coercion/Coercer.cs",
+            "test/PatternKit.Examples.Tests/Strategies/Coercion/CoercerTests.cs",
+            "docs/examples/coercer.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["TryStrategy", "Strategy"],
+            ["culture-safe conversions", "JSON and primitive coercion", "invalid input handling"]),
+        Descriptor(
+            "Composed Notification Strategy",
+            "src/PatternKit.Examples/Strategies/Composed/ComposedStrategies.cs",
+            "test/PatternKit.Examples.Tests/Strategies/Composed/ComposedStrategiesTests.cs",
+            "docs/examples/composed-notification-strategy.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["AsyncStrategy", "Strategy"],
+            ["preference ordering", "fallback channels", "rate and identity gates"]),
+        Descriptor(
+            "Mediated Transaction Pipeline",
+            "src/PatternKit.Examples/Chain/MediatedTransactionPipelineDemo.cs",
+            "test/PatternKit.Examples.Tests/Chain/MediatedTransactionPipelineDemoTests.cs",
+            "docs/examples/mediated-transaction-pipeline.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["ActionChain", "Strategy", "TryStrategy"],
+            ["pre-authorization", "discounting", "tender handling"]),
+        Descriptor(
+            "Configuration-Driven Transaction Pipeline",
+            "src/PatternKit.Examples/Chain/ConfigDriven/TransactionPipelineDemo.cs",
+            "test/PatternKit.Examples.Tests/Chain/TransactionPipelineDemoTests.cs",
+            "docs/examples/config-driven-transaction-pipeline.md",
+            ExampleIntegrationSurface.DependencyInjection | ExampleIntegrationSurface.Options,
+            ["ActionChain", "BranchBuilder", "Strategy"],
+            ["IOptions validation", "configurable rule order", "DI composition"]),
+        Descriptor(
+            "Enterprise Feature Slices with .NET DI",
+            "src/PatternKit.Examples/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemo.cs",
+            "test/PatternKit.Examples.Tests/EnterpriseFeatureSlices/EnterpriseFeatureSlicesDemoTests.cs",
+            "docs/examples/enterprise-feature-slices.md",
+            ExampleIntegrationSurface.DependencyInjection,
+            ["Flyweight", "Factory", "Prototype", "ResultChain", "Strategy", "Decorator", "Proxy", "Facade"],
+            ["container-owned artifacts", "typed facade", "payment and fulfillment validation"]),
+        Descriptor(
+            "Minimal Web Request Router",
+            "src/PatternKit.Examples/ApiGateway/MiniRouter.cs",
+            "test/PatternKit.Examples.Tests/ApiGateway/ApiGatewayTests.cs",
+            "docs/examples/mini-router.md",
+            ExampleIntegrationSurface.AspNetCore,
+            ["Strategy", "ActionChain"],
+            ["middleware ordering", "content negotiation", "route matching"]),
+        Descriptor(
+            "Payment Processor Decorator",
+            "src/PatternKit.Examples/PointOfSale/PaymentProcessorDemo.cs",
+            "test/PatternKit.Examples.Tests/PointOfSale/PaymentProcessorTests.cs",
+            "docs/examples/payment-processor-decorator.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Decorator"],
+            ["input validation", "discount layering", "receipt audit trail"]),
+        Descriptor(
+            "POS App State Singleton",
+            "src/PatternKit.Examples/Singleton/PosAppStateDemo.cs",
+            "test/PatternKit.Examples.Tests/Singleton/PosAppStateDemoTests.cs",
+            "docs/examples/pos-app-state-singleton.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Singleton"],
+            ["state reset", "session identity", "cache reuse"]),
+        Descriptor(
+            "Pricing Calculator",
+            "src/PatternKit.Examples/Pricing/Demo.cs",
+            "test/PatternKit.Examples.Tests/Pricing/PricingDemoTests.cs",
+            "docs/examples/pricing-calculator.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["AsyncStrategy", "ResultChain"],
+            ["async source fallback", "loyalty pricing", "rounding rules"]),
+        Descriptor(
+            "POS Tender Visitor",
+            "src/PatternKit.Examples/VisitorDemo/VisitorDemo.cs",
+            "test/PatternKit.Examples.Tests/VisitorDemo/VisitorDemoTests.cs",
+            "docs/examples/pos-visitor-routing.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Visitor", "TypeDispatcher"],
+            ["receipt rendering", "unknown tender fallback", "routing counters"]),
+        Descriptor(
+            "API Exception Mapping Visitor",
+            "src/PatternKit.Examples/Generators/Visitors/DocumentProcessingDemo.cs",
+            "test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs",
+            "docs/examples/api-exception-mapping-visitor.md",
+            ExampleIntegrationSurface.AspNetCore,
+            ["Visitor"],
+            ["ProblemDetails mapping", "middleware boundary", "default error shape"]),
+        Descriptor(
+            "Event Processing Visitor",
+            "src/PatternKit.Examples/Generators/Visitors/DocumentProcessingDemo.cs",
+            "test/PatternKit.Examples.Tests/Generators/VisitorGeneratorExamplesTests.cs",
+            "docs/examples/event-processor-visitor.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["AsyncVisitor", "Visitor"],
+            ["domain event routing", "orchestration", "projection fallback"]),
+        Descriptor(
+            "Message Router Visitor",
+            "src/PatternKit.Examples/Messaging/MessageRoutingExample.cs",
+            "test/PatternKit.Examples.Tests/Messaging/MessageRoutingExampleTests.cs",
+            "docs/examples/message-router-visitor.md",
+            ExampleIntegrationSurface.Messaging,
+            ["Visitor", "ContentRouter"],
+            ["message dispatch", "route fallback", "typed handlers"]),
+        Descriptor(
+            "Patterns Showcase",
+            "src/PatternKit.Examples/PatternShowcase/PatternShowcase.cs",
+            "test/PatternKit.Examples.Tests/PatternShowcase/PatternShowcaseTests.cs",
+            "docs/examples/patterns-showcase.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Strategy", "Factory", "Decorator", "Observer", "StateMachine"],
+            ["integrated order flow", "audit events", "state transitions"]),
+        Descriptor(
+            "Source Generator Application Suite",
+            "src/PatternKit.Examples/Generators/Builders/CorporateApplicationBuilderDemo/CorporateApplication.cs",
+            "test/PatternKit.Examples.Tests/Generators/CorporateApplicationBuilderDemoTests.cs",
+            "docs/examples/source-generator-application-suite.md",
+            ExampleIntegrationSurface.SourceGenerator | ExampleIntegrationSurface.DependencyInjection | ExampleIntegrationSurface.GenericHost,
+            ["Builder", "Factory", "Facade", "Proxy", "Observer", "Memento", "StateMachine", "Strategy", "Visitor"],
+            ["host composition", "module ordering", "generated API shape"]),
+        Descriptor(
+            "Enterprise Messaging Workflow Suite",
+            "src/PatternKit.Examples/Messaging/MessageEnvelopeExample.cs",
+            "test/PatternKit.Examples.Tests/Messaging/MessageEnvelopeExampleTests.cs",
+            "docs/examples/enterprise-messaging-workflows.md",
+            ExampleIntegrationSurface.Messaging | ExampleIntegrationSurface.SourceGenerator,
+            ["ContentRouter", "RecipientList", "Splitter", "Aggregator", "RoutingSlip", "Saga", "Mailbox"],
+            ["idempotency", "inbox/outbox", "generated dispatcher"]),
+        Descriptor(
+            "Resilient Checkout and Collaborating Mailboxes",
+            "src/PatternKit.Examples/Messaging/ResilientCheckoutDemo.cs",
+            "test/PatternKit.Examples.Tests/Messaging/ResilientCheckoutDemoTests.cs",
+            "docs/examples/resilient-checkout-and-mailboxes.md",
+            ExampleIntegrationSurface.Messaging,
+            ["RoutingSlip", "Saga", "Mailbox", "Command"],
+            ["compensation", "fallback routing", "correlated messages"]),
+        Descriptor(
+            "Messaging Backplane Facade",
+            "src/PatternKit.Examples/Messaging/BackplaneFacadeDemo.cs",
+            "test/PatternKit.Examples.Tests/Messaging/BackplaneFacadeDemoTests.cs",
+            "docs/examples/messaging-backplane-facade.md",
+            ExampleIntegrationSurface.GenericHost | ExampleIntegrationSurface.Messaging | ExampleIntegrationSurface.ExternalInfrastructure,
+            ["Facade", "Mailbox", "Outbox", "IdempotentReceiver"],
+            ["host setup", "request/reply", "pub/sub", "transport boundary"]),
+        Descriptor(
+            "Prototype Game Character Factory",
+            "src/PatternKit.Examples/PrototypeDemo/PrototypeDemo.cs",
+            "test/PatternKit.Examples.Tests/PrototypeDemo/PrototypeDemoTests.cs",
+            "docs/examples/prototype-demo.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Prototype"],
+            ["clone registry", "per-call mutation", "default family"]),
+        Descriptor(
+            "Proxy Pattern Demonstrations",
+            "src/PatternKit.Examples/ProxyDemo/ProxyDemo.cs",
+            "test/PatternKit.Examples.Tests/ProxyDemo/ProxyDemoTests.cs",
+            "docs/examples/proxy-demo.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Proxy"],
+            ["virtual proxy", "protection proxy", "caching proxy", "remote proxy"]),
+        Descriptor(
+            "Flyweight Glyph Cache",
+            "src/PatternKit.Examples/FlyweightDemo/FlyweightDemo.cs",
+            "test/PatternKit.Examples.Tests/FlyweightDemos/FlyweightDemoTests.cs",
+            "docs/examples/flyweight-glyph-cache.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Flyweight"],
+            ["identity sharing", "case-insensitive styles", "layout reuse"]),
+        Descriptor(
+            "Text Editor Memento",
+            "src/PatternKit.Examples/MementoDemo/MementoDemo.cs",
+            "test/PatternKit.Examples.Tests/MementoDemo/MementoDemoTests.cs",
+            "docs/examples/text-editor-memento.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Memento"],
+            ["undo", "redo", "jump-to-version"]),
+        Descriptor(
+            "Observer Event Hub",
+            "src/PatternKit.Examples/ObserverDemo/SimpleEventHub.cs",
+            "test/PatternKit.Examples.Tests/ObserverDemo/EventHubTests.cs",
+            "docs/examples/observer-demo.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Observer"],
+            ["subscription routing", "error handling", "event fan-out"]),
+        Descriptor(
+            "Reactive ViewModel",
+            "src/PatternKit.Examples/ObserverDemo/ReactivePrimitives.cs",
+            "test/PatternKit.Examples.Tests/ObserverDemo/ReactiveViewModelTests.cs",
+            "docs/examples/reactive-viewmodel.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Observer"],
+            ["dependent properties", "command enablement", "event ordering"]),
+        Descriptor(
+            "Reactive Transaction",
+            "src/PatternKit.Examples/ObserverDemo/ReactiveTransaction.cs",
+            "test/PatternKit.Examples.Tests/ObserverDemo/ReactiveTransactionTests.cs",
+            "docs/examples/reactive-transaction.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["Observer", "Strategy"],
+            ["dynamic discounts", "tax recomputation", "total projection"]),
+        Descriptor(
+            "Async Connection State Machine",
+            "src/PatternKit.Examples/AsyncStateDemo/AsyncStateDemo.cs",
+            "test/PatternKit.Examples.Tests/AsyncStateDemo/AsyncStateDemoTests.cs",
+            "docs/examples/async-state-machine.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["AsyncStateMachine"],
+            ["cancellation", "async effects", "transition ordering"]),
+        Descriptor(
+            "Template Method Subclassing",
+            "src/PatternKit.Examples/TemplateDemo/TemplateDemo.cs",
+            "test/PatternKit.Examples.Tests/TemplateDemo/TemplateDemoTests.cs",
+            "docs/examples/template-method-demo.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["TemplateMethod"],
+            ["hooks", "validation", "workflow reuse"]),
+        Descriptor(
+            "Template Method Async",
+            "src/PatternKit.Examples/TemplateDemo/TemplateAsyncDemo.cs",
+            "test/PatternKit.Examples.Tests/TemplateDemo/TemplateDemoTests.cs",
+            "docs/examples/template-method-async-demo.md",
+            ExampleIntegrationSurface.LibraryOnly,
+            ["AsyncTemplate", "AsyncTemplateMethod"],
+            ["cancellation", "async storage", "error observation"])
+    ];
+
+    public IReadOnlyList<PatternKitExampleDescriptor> Entries => Items;
+
+    public PatternKitExampleValidationReport Validate(string? repositoryRoot = null)
+    {
+        var issues = new List<PatternKitExampleValidationIssue>();
+
+        foreach (var entry in Entries)
+        {
+            CheckRequired(entry, entry.Name, nameof(entry.Name), issues);
+            CheckRequired(entry, entry.SourcePath, nameof(entry.SourcePath), issues);
+            CheckRequired(entry, entry.TestPath, nameof(entry.TestPath), issues);
+            CheckRequired(entry, entry.DocumentationPath, nameof(entry.DocumentationPath), issues);
+
+            if (entry.Patterns.Count == 0)
+                issues.Add(new(entry.Name, nameof(entry.Patterns), "At least one PatternKit pattern must be listed."));
+
+            if (entry.ProductionChecks.Count == 0)
+                issues.Add(new(entry.Name, nameof(entry.ProductionChecks), "At least one production check must be listed."));
+
+            if (entry.Integration == ExampleIntegrationSurface.None)
+                issues.Add(new(entry.Name, nameof(entry.Integration), "At least one integration surface must be listed."));
+
+            if (!string.IsNullOrWhiteSpace(repositoryRoot))
+            {
+                CheckFile(repositoryRoot, entry, nameof(entry.SourcePath), entry.SourcePath, issues);
+                CheckFile(repositoryRoot, entry, nameof(entry.TestPath), entry.TestPath, issues);
+                CheckFile(repositoryRoot, entry, nameof(entry.DocumentationPath), entry.DocumentationPath, issues);
+            }
+        }
+
+        return new PatternKitExampleValidationReport(Entries, issues);
+    }
+
+    private static PatternKitExampleDescriptor Descriptor(
+        string name,
+        string sourcePath,
+        string testPath,
+        string documentationPath,
+        ExampleIntegrationSurface integration,
+        IReadOnlyList<string> patterns,
+        IReadOnlyList<string> productionChecks)
+        => new(name, sourcePath, testPath, documentationPath, integration, patterns, productionChecks);
+
+    private static void CheckRequired(
+        PatternKitExampleDescriptor entry,
+        string value,
+        string field,
+        ICollection<PatternKitExampleValidationIssue> issues)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            issues.Add(new(entry.Name, field, "Value is required."));
+    }
+
+    private static void CheckFile(
+        string repositoryRoot,
+        PatternKitExampleDescriptor entry,
+        string field,
+        string relativePath,
+        ICollection<PatternKitExampleValidationIssue> issues)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(repositoryRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(fullPath))
+            issues.Add(new(entry.Name, field, $"File does not exist: {relativePath}"));
+    }
+}
+
+/// <summary>
+/// Service registration helpers for importing the examples catalog into standard .NET hosts.
+/// </summary>
+public static class PatternKitExampleCatalogServiceCollectionExtensions
+{
+    public static IServiceCollection AddPatternKitExampleCatalog(
+        this IServiceCollection services,
+        Action<PatternKitExampleCatalogOptions>? configure = null)
+    {
+        services.AddOptions<PatternKitExampleCatalogOptions>();
+        if (configure is not null)
+            services.Configure(configure);
+
+        services.AddSingleton<IPatternKitExampleCatalog, PatternKitExampleCatalog>();
+        return services;
+    }
+
+    public static IHostApplicationBuilder AddPatternKitExampleCatalog(
+        this IHostApplicationBuilder builder,
+        Action<PatternKitExampleCatalogOptions>? configure = null)
+    {
+        builder.Services.AddPatternKitExampleCatalog(configure);
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddPatternKitExampleHostedValidation(
+        this IHostApplicationBuilder builder,
+        Action<PatternKitExampleCatalogOptions>? configure = null)
+    {
+        builder.Services.AddPatternKitExampleCatalog(configure);
+        builder.Services.AddHostedService<PatternKitExampleCatalogHostedValidator>();
+        return builder;
+    }
+}
+
+/// <summary>
+/// Hosted startup validator for production hosts that want example metadata failures to fail fast.
+/// </summary>
+public sealed class PatternKitExampleCatalogHostedValidator(
+    IPatternKitExampleCatalog catalog,
+    IOptions<PatternKitExampleCatalogOptions> options,
+    ILogger<PatternKitExampleCatalogHostedValidator> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var report = catalog.Validate(options.Value.RepositoryRoot);
+
+        if (report.IsValid)
+        {
+            logger.LogInformation("PatternKit example catalog validated {Count} entries.", report.Entries.Count);
+            return Task.CompletedTask;
+        }
+
+        foreach (var issue in report.Issues)
+            logger.LogError("PatternKit example catalog issue in {Example} ({Field}): {Message}", issue.ExampleName, issue.Field, issue.Message);
+
+        if (options.Value.FailOnInvalid)
+            throw new InvalidOperationException($"PatternKit example catalog validation failed with {report.Issues.Count} issue(s).");
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Minimal API integration for exposing the example catalog in ASP.NET Core applications.
+/// </summary>
+public static class PatternKitExampleCatalogEndpointRouteBuilderExtensions
+{
+    public static IEndpointRouteBuilder MapPatternKitExampleCatalog(
+        this IEndpointRouteBuilder endpoints,
+        string pattern = "/patternkit/examples")
+    {
+        endpoints.MapGet(pattern, (IPatternKitExampleCatalog catalog) => Results.Ok(catalog.Entries))
+            .WithName("PatternKitExampleCatalog");
+
+        endpoints.MapGet($"{pattern}/validation", ValidateCatalog)
+            .WithName("PatternKitExampleCatalogValidation");
+
+        return endpoints;
+    }
+
+    private static IResult ValidateCatalog(
+        IPatternKitExampleCatalog catalog,
+        IOptions<PatternKitExampleCatalogOptions> options)
+    {
+        var report = catalog.Validate(options.Value.RepositoryRoot);
+        return report.IsValid ? Results.Ok(report) : Results.Problem(
+            title: "PatternKit example catalog validation failed",
+            detail: $"{report.Issues.Count} issue(s) found.",
+            statusCode: StatusCodes.Status500InternalServerError);
+    }
+}

--- a/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
+++ b/test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj
@@ -54,4 +54,8 @@
         <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
 </Project>

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitExampleCatalogTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitExampleCatalogTests.cs
@@ -1,0 +1,187 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using PatternKit.Examples.ProductionReadiness;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
+
+namespace PatternKit.Examples.Tests.ProductionReadiness;
+
+[Feature("Production-ready example catalog integrations")]
+public sealed class PatternKitExampleCatalogTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    [Scenario("Catalog entries map documented examples to source, tests, and production checks")]
+    [Fact]
+    public Task Catalog_Entries_Map_Documented_Examples_To_Source_Tests_And_Production_Checks()
+        => Given("an examples catalog and the repository root", () => new
+            {
+                Catalog = new PatternKitExampleCatalog(),
+                RepositoryRoot = FindRepoRoot()
+            })
+            .When("validating the catalog against repository files", ctx => new
+            {
+                ctx.Catalog.Entries,
+                Report = ctx.Catalog.Validate(ctx.RepositoryRoot)
+            })
+            .Then("every catalog entry is valid", result => result.Report.IsValid)
+            .And("the catalog covers every docs example toc page", result =>
+                ExampleTocHrefs()
+                    .Where(href => !string.Equals(href, "index.md", StringComparison.OrdinalIgnoreCase))
+                    .All(href => result.Entries.Any(entry => string.Equals(
+                        entry.DocumentationPath,
+                        $"docs/examples/{href}",
+                        StringComparison.OrdinalIgnoreCase))))
+            .And("all entries describe integration surfaces and production checks", result =>
+                result.Entries.All(entry =>
+                    entry.Integration != ExampleIntegrationSurface.None
+                    && entry.Patterns.Count > 0
+                    && entry.ProductionChecks.Count > 0))
+            .AssertPassed();
+
+    [Scenario("ServiceCollection exposes the examples catalog to consumers")]
+    [Fact]
+    public Task ServiceCollection_Exposes_Examples_Catalog_To_Consumers()
+        => Given("a service collection configured with the catalog", () =>
+            {
+                var services = new ServiceCollection();
+                services.AddLogging();
+                services.AddPatternKitExampleCatalog(options => options.RepositoryRoot = FindRepoRoot());
+                return services.BuildServiceProvider(validateScopes: true);
+            })
+            .When("resolving and validating the catalog", provider =>
+            {
+                var catalog = provider.GetRequiredService<IPatternKitExampleCatalog>();
+                var options = provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<PatternKitExampleCatalogOptions>>();
+
+                return new
+                {
+                    Catalog = catalog,
+                    Report = catalog.Validate(options.Value.RepositoryRoot)
+                };
+            })
+            .Then("the catalog resolves from DI", result => result.Catalog.Entries.Count >= ExampleTocHrefs().Count - 1)
+            .And("the configured repository validation succeeds", result => result.Report.IsValid)
+            .AssertPassed();
+
+    [Scenario("Generic host validates example metadata on startup")]
+    [Fact]
+    public Task Generic_Host_Validates_Example_Metadata_On_Startup()
+        => Given("a generic host with hosted catalog validation", () =>
+            {
+                var builder = Host.CreateApplicationBuilder();
+                builder.AddPatternKitExampleHostedValidation(options => options.RepositoryRoot = FindRepoRoot());
+                return builder.Build();
+            })
+            .When("starting the host", host =>
+            {
+                host.StartAsync().GetAwaiter().GetResult();
+                host.StopAsync().GetAwaiter().GetResult();
+                host.Dispose();
+                return true;
+            })
+            .Then("startup validation succeeds", started => started)
+            .AssertPassed();
+
+    [Scenario("Generic host fails fast when example metadata is invalid")]
+    [Fact]
+    public Task Generic_Host_Fails_Fast_When_Example_Metadata_Is_Invalid()
+        => Given("a generic host with hosted catalog validation and a missing repository root", () =>
+            {
+                var builder = Host.CreateApplicationBuilder();
+                builder.AddPatternKitExampleHostedValidation(options =>
+                {
+                    options.RepositoryRoot = Path.Combine(Path.GetTempPath(), $"patternkit-missing-examples-root-{Guid.NewGuid():N}");
+                    options.FailOnInvalid = true;
+                });
+                return builder.Build();
+            })
+            .When("starting the host", host =>
+            {
+                try
+                {
+                    host.StartAsync().GetAwaiter().GetResult();
+                    return null;
+                }
+                catch (InvalidOperationException ex)
+                {
+                    return ex;
+                }
+                finally
+                {
+                    host.Dispose();
+                }
+            })
+            .Then("startup fails with a catalog validation error", exception =>
+                exception is not null
+                && exception.Message.Contains("PatternKit example catalog validation failed", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("ASP.NET Core endpoint exposes the examples catalog")]
+    [Fact]
+    public Task AspNetCore_Endpoint_Exposes_Examples_Catalog()
+        => Given("an ASP.NET Core app mapped with PatternKit example catalog endpoints", () =>
+            {
+                var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+                {
+                    EnvironmentName = Environments.Development
+                });
+
+                builder.Services.AddPatternKitExampleCatalog(options => options.RepositoryRoot = FindRepoRoot());
+
+                var app = builder.Build();
+                app.MapPatternKitExampleCatalog();
+                return app;
+            })
+            .When("inspecting mapped endpoints and resolving the catalog", app =>
+            {
+                var endpoints = ((IEndpointRouteBuilder)app).DataSources
+                    .SelectMany(source => source.Endpoints)
+                    .ToArray();
+                var catalog = app.Services.GetRequiredService<IPatternKitExampleCatalog>();
+                var report = catalog.Validate(FindRepoRoot());
+                app.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+                return new
+                {
+                    EndpointNames = endpoints
+                        .Select(endpoint => endpoint.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName)
+                        .OfType<string>()
+                        .ToArray(),
+                    report.IsValid
+                };
+            })
+            .Then("the catalog endpoint is mapped", result =>
+                result.EndpointNames.Contains("PatternKitExampleCatalog", StringComparer.Ordinal))
+            .And("the validation endpoint is mapped and the report is valid", result =>
+                result.EndpointNames.Contains("PatternKitExampleCatalogValidation", StringComparer.Ordinal)
+                && result.IsValid)
+            .AssertPassed();
+
+    private static IReadOnlyList<string> ExampleTocHrefs()
+    {
+        var tocPath = Path.Combine(FindRepoRoot(), "docs", "examples", "toc.yml");
+        return File.ReadAllLines(tocPath)
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith("href: ", StringComparison.Ordinal))
+            .Select(line => line["href: ".Length..])
+            .Where(href => href.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PatternKit.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find PatternKit repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- add a production-readiness catalog for documented examples with source/test/docs metadata
- expose the catalog through IServiceCollection, IHostApplicationBuilder hosted validation, and ASP.NET Core minimal APIs
- document the integration contract and cover it with TinyBDD scenarios

## Validation
- git diff --check
- catalog path audit validated 87 source/test/docs paths
- dotnet test test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj --framework net8.0 --no-restore -p:DOCFX=true *(blocked locally by existing generated-symbol failures when source generator output is unavailable)*