### PR TITLE
fix: isolate POS DI singleton from demo counters

### DIFF
--- a/src/PatternKit.Examples/DependencyInjection/PatternKitExampleServiceCollectionExtensions.cs
+++ b/src/PatternKit.Examples/DependencyInjection/PatternKitExampleServiceCollectionExtensions.cs
@@ -267,7 +267,16 @@ public static class PatternKitExampleServiceCollectionExtensions
 
     public static IServiceCollection AddPosAppStateSingletonExample(this IServiceCollection services)
     {
-        services.AddSingleton(_ => PosAppStateDemo.BuildLazy());
+        services.AddSingleton(_ => Singleton<PosAppState>
+            .Create(static () => new PosAppState
+            {
+                Config = StoreConfig.Load(),
+                Pricing = new PricingCache(),
+                Devices = new DeviceRegistry()
+            })
+            .Init(static state => state.Pricing.Prewarm(["SKU-1", "SKU-2", "SKU-3"]))
+            .Init(static state => state.Devices.ConnectAll())
+            .Build());
         services.AddSingleton<PosAppStateSingletonExample>(sp => new(sp.GetRequiredService<Singleton<PosAppState>>()));
         return services.RegisterExample<PosAppStateSingletonExample>("POS App State Singleton", ExampleIntegrationSurface.LibraryOnly | ExampleIntegrationSurface.DependencyInjection);
     }


### PR DESCRIPTION
The example DI registration for POS app state previously reused PosAppStateDemo.BuildLazy(), which mutates the demo's static FactoryCalls counter. In main release CI, that can race with the POS singleton TinyBDD scenario under parallel test execution. This change keeps the DI example production-style and counter-free by registering an equivalent local singleton factory and init hooks.