### PR TITLE
ci: allow expanded test suite to complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   pr-checks:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write
@@ -50,7 +50,7 @@ jobs:
           docfx build docs/docfx.json
 
       - name: Test with coverage
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           dotnet test PatternKit.slnx \
             --configuration Release \
@@ -106,7 +106,7 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: write
       packages: write
@@ -162,7 +162,7 @@ jobs:
           /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 
       - name: Test with coverage (Release)
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           dotnet test PatternKit.slnx \
             --configuration Release \
@@ -170,7 +170,7 @@ jobs:
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[PatternKit*]*" \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests]*" \
-            -- RunConfiguration.TestSessionTimeout=900000
+            -- RunConfiguration.TestSessionTimeout=1800000
 
 
       - name: Pack (all packable projects)


### PR DESCRIPTION
## Summary
- increase CI job and coverage test timeouts for the expanded PatternKit suite
- raise the release VSTest session timeout from 15 to 30 minutes

## Validation
- git diff --check