### PR TITLE
perf: add messaging scenario benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,10 +470,18 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
+| Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
+| Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
+| Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
+| Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
+| Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
+| Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
 
 Run the benchmarks on target hardware before making final route decisions:
 

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MessageRoutingBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MessageRoutingBenchmarks.cs
@@ -1,0 +1,47 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "MessageRouting")]
+public class MessageRoutingBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create routing flow")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public object Fluent_CreateRoutingFlow()
+    {
+        var splitter = Splitter<RoutedOrder, RoutedLine>.Create()
+            .Use(static (message, _) => message.Payload.Lines)
+            .Build();
+
+        var aggregator = Aggregator<string, RoutedLine, decimal>.Create()
+            .KeyBy(static (message, _) => message.Headers.CorrelationId ?? message.Payload.Sku)
+            .CompleteWhen(static (_, messages, _) => messages.Count == 2)
+            .Project(static (_, messages, _) => messages.Sum(message => message.Payload.Amount))
+            .Build();
+
+        return new RoutingFlow(splitter, aggregator);
+    }
+
+    [Benchmark(Description = "Generated: create routing flow")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public object Generated_CreateRoutingFlow()
+        => new RoutingFlow(
+            GeneratedOrderLineSplitter.CreateLineSplitter(),
+            GeneratedOrderLineAggregator.CreateLineTotalAggregator());
+
+    [Benchmark(Description = "Fluent: route split aggregate")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public RoutingSummary Fluent_RunRoutingFlow()
+        => MessageRoutingExample.RunFluent();
+
+    [Benchmark(Description = "Generated: route split aggregate")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public RoutingSummary Generated_RunRoutingFlow()
+        => MessageRoutingExample.RunGenerated();
+
+    private sealed record RoutingFlow(
+        Splitter<RoutedOrder, RoutedLine> Splitter,
+        Aggregator<string, RoutedLine, decimal> Aggregator);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MessageTranslatorBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MessageTranslatorBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Transformation;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "MessageTranslator")]
+public class MessageTranslatorBenchmarks
+{
+    private static readonly PartnerOrderAccepted PartnerOrder = new("partner-a", "EXT-100", 125m, "USD");
+    private readonly MessageTranslator<PartnerOrderAccepted, CommerceOrderAccepted> _fluent =
+        PartnerOrderTranslatorPolicies.CreateFluentTranslator();
+    private readonly MessageTranslator<PartnerOrderAccepted, CommerceOrderAccepted> _generated =
+        GeneratedPartnerOrderTranslator.Create();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create translator")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public MessageTranslator<PartnerOrderAccepted, CommerceOrderAccepted> Fluent_CreateTranslator()
+        => PartnerOrderTranslatorPolicies.CreateFluentTranslator();
+
+    [Benchmark(Description = "Generated: create translator")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public MessageTranslator<PartnerOrderAccepted, CommerceOrderAccepted> Generated_CreateTranslator()
+        => GeneratedPartnerOrderTranslator.Create();
+
+    [Benchmark(Description = "Fluent: translate partner order")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public PartnerOrderImportSummary Fluent_TranslatePartnerOrder()
+        => PartnerOrderImportSummary.From("fluent", _fluent.Translate(CreateMessage()));
+
+    [Benchmark(Description = "Generated: translate partner order")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public PartnerOrderImportSummary Generated_TranslatePartnerOrder()
+        => PartnerOrderImportSummary.From("source-generated", _generated.Translate(CreateMessage()));
+
+    private static PatternKit.Messaging.Message<PartnerOrderAccepted> CreateMessage()
+        => PatternKit.Messaging.Message<PartnerOrderAccepted>
+            .Create(PartnerOrder)
+            .WithMessageId("partner:EXT-100")
+            .WithCorrelationId("EXT-100")
+            .WithHeader("partner-id", "partner-a")
+            .WithHeader("raw-signature", "demo-signature");
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/ReliabilityPipelineBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/ReliabilityPipelineBenchmarks.cs
@@ -1,0 +1,65 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Mailboxes;
+using PatternKit.Messaging.Reliability;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "ReliabilityPipeline")]
+public class ReliabilityPipelineBenchmarks
+{
+    private static readonly Message<AcceptOrder> Command = Message<AcceptOrder>
+        .Create(new AcceptOrder("order-42"))
+        .WithIdempotencyKey("accept-order-42");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create receiver and outbox")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public object Fluent_CreateReceiverAndOutbox()
+    {
+        var store = new InMemoryIdempotencyStore();
+        var outbox = new InMemoryOutbox<ReliabilityOrderAccepted>();
+        var receiver = IdempotentReceiver<AcceptOrder, string>.Create(
+                store,
+                async (message, _, cancellationToken) =>
+                {
+                    await outbox.EnqueueAsync(
+                        Message<ReliabilityOrderAccepted>.Create(new ReliabilityOrderAccepted(message.Payload.OrderId)),
+                        id: $"accepted-{message.Payload.OrderId}",
+                        cancellationToken: cancellationToken);
+                    return message.Payload.OrderId;
+                })
+            .OnDuplicate(DuplicateMessagePolicy.ReplayCompleted)
+            .Build();
+
+        return new FluentReliabilityFlow(receiver, outbox);
+    }
+
+    [Benchmark(Description = "Generated: create inbox and outbox")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public object Generated_CreateInboxAndOutbox()
+    {
+        var store = new InMemoryIdempotencyStore();
+        return new GeneratedReliabilityFlow(
+            GeneratedReliabilityOrderPipeline.CreateInbox(store),
+            GeneratedReliabilityOrderPipeline.CreateOutbox());
+    }
+
+    [Benchmark(Description = "Fluent: duplicate inbox then dispatch")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<IReadOnlyList<string>> Fluent_ProcessDuplicateThenDispatch()
+        => ReliabilityExample.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: duplicate inbox then dispatch")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<IReadOnlyList<string>> Generated_ProcessDuplicateThenDispatch()
+        => ReliabilityExample.RunGeneratedAsync();
+
+    private sealed record FluentReliabilityFlow(
+        IdempotentReceiver<AcceptOrder, string> Receiver,
+        InMemoryOutbox<ReliabilityOrderAccepted> Outbox);
+
+    private sealed record GeneratedReliabilityFlow(
+        InboxProcessor<AcceptOrder, string> Inbox,
+        InMemoryOutbox<ReliabilityOrderAccepted> Outbox);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/ServiceActivatorBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/ServiceActivatorBenchmarks.cs
@@ -1,0 +1,33 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Activation;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "ServiceActivator")]
+public class ServiceActivatorBenchmarks
+{
+    private static readonly InventoryReservationRequest Request = new("SKU-42", 12);
+    private readonly InventoryServiceActivatorService _fluentService = new(InventoryServiceActivators.Create());
+    private readonly InventoryServiceActivatorService _generatedService = new(GeneratedInventoryServiceActivator.Create());
+
+    [Benchmark(Baseline = true, Description = "Fluent: create service activator")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public ServiceActivator<InventoryReservationRequest, InventoryReservationResult> Fluent_CreateActivator()
+        => InventoryServiceActivators.Create();
+
+    [Benchmark(Description = "Generated: create service activator")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public ServiceActivator<InventoryReservationRequest, InventoryReservationResult> Generated_CreateActivator()
+        => GeneratedInventoryServiceActivator.Create();
+
+    [Benchmark(Description = "Fluent: reserve inventory")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public InventoryServiceActivatorSummary Fluent_ReserveInventory()
+        => _fluentService.Reserve(Request);
+
+    [Benchmark(Description = "Generated: reserve inventory")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public InventoryServiceActivatorSummary Generated_ReserveInventory()
+        => _generatedService.Reserve(Request);
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -17,10 +17,18 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
+| Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
+| Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
+| Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
+| Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
+| Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
+| Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
 
 ## Coverage Matrix Summary
 

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -34,10 +34,18 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
+| Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
+| Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
+| Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
+| Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
+| Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
+| Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
 
 The coverage matrix is separate from the scenario timings. Matrix benchmarks prove every catalog pattern and every generator source file has a reportable BenchmarkDotNet route; pattern-specific scenario benchmarks provide the fluent-vs-generated construction and execution numbers shown above. See [Benchmark Results](benchmark-results.md) for the full pattern and generator matrix.
 


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet scenario classes for Message Routing, Message Translator, Service Activator, and Reliability Pipeline
- publish current-TFM fluent-vs-generated construction and execution results in README and benchmark docs
- extend issue #331 with measured routing, transformation, activation, and inbox/outbox reliability results

## Validation
- dotnet run -c Release --framework net10.0 --project benchmarks/PatternKit.Benchmarks -- --filter *MessageRouting* --artifacts artifacts/benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks/PatternKit.Benchmarks -- --filter *MessageTranslator* --artifacts artifacts/benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks/PatternKit.Benchmarks -- --filter *ServiceActivatorBenchmarks* --artifacts artifacts/benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks/PatternKit.Benchmarks -- --filter *ReliabilityPipeline* --artifacts artifacts/benchmarks --join --job short
- dotnet build benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet test test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore
- dotnet test PatternKit.slnx --configuration Release --no-restore
- git diff --check

Refs #331