### PR TITLE
perf: add application service benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
+| Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
+| Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -488,10 +490,14 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
+| Service Layer | Construction | 56.33 ns | 496 B | 41.36 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Table Data Gateway | Execution | 90.51 ns | 600 B | 96.35 ns | 600 B | Same allocation; fluent was slightly faster for the insert-update-query workflow. |
+| Transaction Script | Construction | 20.634 ns | 240 B | 5.839 ns | 40 B | Generated materially reduced construction time and allocation in this microbenchmark. |
+| Transaction Script | Execution | 184.93 ns | 1,136 B | 98.28 ns | 600 B | Generated reduced execution time and allocation for the submit-order workflow. |
 | Unit Of Work | Construction | 49.50 ns | 304 B | 46.91 ns | 304 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
 

--- a/benchmarks/PatternKit.Benchmarks/Application/DomainEventBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/DomainEventBenchmarks.cs
@@ -1,0 +1,29 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.DomainEvents;
+using PatternKit.Examples.DomainEventDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "DomainEvent")]
+public class DomainEventBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create domain event dispatcher")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public DomainEventDispatcher<OrderDomainEvent> Fluent_CreateDispatcher()
+        => OrderDomainEventPolicies.CreateFluentDispatcher(new OrderEventProjection(), new List<string>());
+
+    [Benchmark(Description = "Generated: create domain event dispatcher")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IDomainEventDispatcher<OrderDomainEvent> Generated_CreateDispatcher()
+        => GeneratedOrderDomainEvents.CreateDispatcher();
+
+    [Benchmark(Description = "Fluent: dispatch order placed")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<OrderDomainEventSummary> Fluent_DispatchOrderPlaced()
+        => OrderDomainEventDemo.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: dispatch order placed")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<OrderDomainEventSummary> Generated_DispatchOrderPlaced()
+        => OrderDomainEventDemo.RunGeneratedAsync();
+}

--- a/benchmarks/PatternKit.Benchmarks/Application/ServiceLayerBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/ServiceLayerBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.Repository;
+using PatternKit.Application.ServiceLayer;
+using PatternKit.Examples.ServiceLayerDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "ServiceLayer")]
+public class ServiceLayerBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create service layer operation")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public ServiceLayerOperation<RegisterCustomerRequest, CustomerRegistrationReceipt> Fluent_CreateOperation()
+        => CustomerServiceLayerPolicies.CreateFluentOperation(
+            InMemoryRepository<RegisteredCustomer, string>.Create(static customer => customer.CustomerId).Build());
+
+    [Benchmark(Description = "Generated: create service layer operation")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IServiceOperation<RegisterCustomerRequest, CustomerRegistrationReceipt> Generated_CreateOperation()
+        => GeneratedCustomerServiceLayer.CreateOperation();
+
+    [Benchmark(Description = "Fluent: register customer")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<CustomerServiceLayerSummary> Fluent_RegisterCustomer()
+        => CustomerServiceLayerDemo.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: register customer")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<CustomerServiceLayerSummary> Generated_RegisterCustomer()
+        => CustomerServiceLayerDemo.RunGeneratedAsync();
+}

--- a/benchmarks/PatternKit.Benchmarks/Application/TransactionScriptBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/TransactionScriptBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.Repository;
+using PatternKit.Application.TransactionScript;
+using PatternKit.Examples.TransactionScriptDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "TransactionScript")]
+public class TransactionScriptBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create transaction script")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public TransactionScript<SubmitOrderRequest, SubmitOrderReceipt> Fluent_CreateScript()
+        => OrderTransactionScriptPolicies.CreateFluentScript(
+            InMemoryRepository<SubmittedOrder, string>.Create(static order => order.OrderId).Build());
+
+    [Benchmark(Description = "Generated: create transaction script")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public ITransactionScript<SubmitOrderRequest, SubmitOrderReceipt> Generated_CreateScript()
+        => GeneratedSubmitOrderScript.CreateScript();
+
+    [Benchmark(Description = "Fluent: submit order")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<OrderTransactionScriptSummary> Fluent_SubmitOrder()
+        => OrderTransactionScriptDemo.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: submit order")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<OrderTransactionScriptSummary> Generated_SubmitOrder()
+        => OrderTransactionScriptDemo.RunGeneratedAsync();
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -17,6 +17,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
+| Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
+| Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -35,10 +37,14 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
+| Service Layer | Construction | 56.33 ns | 496 B | 41.36 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Table Data Gateway | Execution | 90.51 ns | 600 B | 96.35 ns | 600 B | Same allocation; fluent was slightly faster for the insert-update-query workflow. |
+| Transaction Script | Construction | 20.634 ns | 240 B | 5.839 ns | 40 B | Generated materially reduced construction time and allocation in this microbenchmark. |
+| Transaction Script | Execution | 184.93 ns | 1,136 B | 98.28 ns | 600 B | Generated reduced execution time and allocation for the submit-order workflow. |
 | Unit Of Work | Construction | 49.50 ns | 304 B | 46.91 ns | 304 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
 

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -34,6 +34,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
+| Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
+| Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -52,10 +54,14 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
+| Service Layer | Construction | 56.33 ns | 496 B | 41.36 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Table Data Gateway | Execution | 90.51 ns | 600 B | 96.35 ns | 600 B | Same allocation; fluent was slightly faster for the insert-update-query workflow. |
+| Transaction Script | Construction | 20.634 ns | 240 B | 5.839 ns | 40 B | Generated materially reduced construction time and allocation in this microbenchmark. |
+| Transaction Script | Execution | 184.93 ns | 1,136 B | 98.28 ns | 600 B | Generated reduced execution time and allocation for the submit-order workflow. |
 | Unit Of Work | Construction | 49.50 ns | 304 B | 46.91 ns | 304 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
 


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet scenario benchmarks for Domain Event, Service Layer, and Transaction Script
- publish fluent vs generated construction and execution results in README and benchmark guides
- continue benchmark coverage tracking for #330

## Validation
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- git diff --check
- dotnet test PatternKit.slnx --configuration Release --no-restore

Closes part of #330