### PR TITLE
test: harden async scatter gather timeout scenario

### DIFF
--- a/test/PatternKit.Tests/Messaging/Routing/AsyncScatterGatherTests.cs
+++ b/test/PatternKit.Tests/Messaging/Routing/AsyncScatterGatherTests.cs
@@ -48,7 +48,7 @@ public sealed class AsyncScatterGatherTests
     public async Task DispatchAsync_TimeoutStrategy_PartialResults()
     {
         var sg = AsyncScatterGather<string, int, int>.Create()
-            .Recipient("fast", async (m, _, _) => { await Task.Delay(5); return 1; })
+            .Recipient("fast", (m, _, _) => ValueTask.FromResult(1))
             .Recipient("slow", async (m, _, ct) => { await Task.Delay(5000, ct); return 2; })
             .CompleteWith(CompletionStrategy.Timeout(TimeSpan.FromMilliseconds(200)))
             .WithAggregator((envelopes, _, _) => envelopes.Where(e => e.Succeeded).Sum(e => e.Response))


### PR DESCRIPTION
## Summary
- make the timeout partial-results scenario deterministic by completing the fast recipient synchronously
- keeps the slow recipient cancellable so the timeout strategy is still exercised

## Validation
- dotnet test test\PatternKit.Tests\PatternKit.Tests.csproj --configuration Release --framework net10.0 --filter FullyQualifiedName~AsyncScatterGatherTests.DispatchAsync_TimeoutStrategy_PartialResults --no-restore
- dotnet test PatternKit.slnx --configuration Release --no-restore

Fixes the main CI release failure after #343.