### PR TITLE
perf: add messaging scenario benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,8 +484,12 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
+| Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |
+| Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
+| Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -500,6 +504,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Transaction Script | Execution | 184.93 ns | 1,136 B | 98.28 ns | 600 B | Generated reduced execution time and allocation for the submit-order workflow. |
 | Unit Of Work | Construction | 49.50 ns | 304 B | 46.91 ns | 304 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
+| Wire Tap | Construction | 47.13 ns | 496 B | 40.99 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Wire Tap | Execution | 214.72 ns | 1,232 B | 191.45 ns | 1,064 B | Generated reduced execution time and allocation for the order observability workflow. |
 
 Run the benchmarks on target hardware before making final route decisions:
 

--- a/benchmarks/PatternKit.Benchmarks/Messaging/ResequencerBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/ResequencerBenchmarks.cs
@@ -1,0 +1,39 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "Resequencer")]
+public class ResequencerBenchmarks
+{
+    private static readonly ShipmentEvent[] Events =
+    [
+        new(2, "ship-100", "packed"),
+        new(1, "ship-100", "received"),
+        new(3, "ship-100", "shipped")
+    ];
+
+    [Benchmark(Baseline = true, Description = "Fluent: create resequencer")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Resequencer<ShipmentEvent> Fluent_CreateResequencer()
+        => ShipmentResequencers.Create();
+
+    [Benchmark(Description = "Generated: create resequencer")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Resequencer<ShipmentEvent> Generated_CreateResequencer()
+        => GeneratedShipmentResequencer.Create();
+
+    [Benchmark(Description = "Fluent: resequence shipment events")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public IReadOnlyList<ShipmentResequencerSummary> Fluent_ResequenceShipmentEvents()
+        => ShipmentResequencerExampleRunner.RunFluent(Events);
+
+    [Benchmark(Description = "Generated: resequence shipment events")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public IReadOnlyList<ShipmentResequencerSummary> Generated_ResequenceShipmentEvents()
+    {
+        var service = new ShipmentResequencerService(GeneratedShipmentResequencer.Create());
+        return Events.Select(service.Record).ToArray();
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/ScatterGatherBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/ScatterGatherBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "ScatterGather")]
+public class ScatterGatherBenchmarks
+{
+    private static readonly SupplierQuoteRequest Request = new("SKU-100", 120, true);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create scatter-gather")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public ScatterGather<SupplierQuoteRequest, SupplierQuote, SupplierQuoteSummary> Fluent_CreateScatterGather()
+        => SupplierQuoteScatterGathers.Create();
+
+    [Benchmark(Description = "Generated: create scatter-gather")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public ScatterGather<SupplierQuoteRequest, SupplierQuote, SupplierQuoteSummary> Generated_CreateScatterGather()
+        => GeneratedSupplierQuoteScatterGather.Create();
+
+    [Benchmark(Description = "Fluent: request supplier quotes")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public SupplierQuoteSummary Fluent_RequestQuotes()
+        => SupplierQuoteScatterGatherExampleRunner.RunFluent(Request);
+
+    [Benchmark(Description = "Generated: request supplier quotes")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public SupplierQuoteSummary Generated_RequestQuotes()
+        => new SupplierQuoteService(GeneratedSupplierQuoteScatterGather.Create()).RequestQuotes(Request);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/WireTapBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/WireTapBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "WireTap")]
+public class WireTapBenchmarks
+{
+    private static readonly OrderWireTapEvent Event = new("order-100", "tenant-a", 149.95m);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create wire tap")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public WireTap<OrderWireTapEvent> Fluent_CreateWireTap()
+        => OrderWireTaps.Create(new OrderWireTapAuditSink(), new OrderWireTapMetricsSink());
+
+    [Benchmark(Description = "Generated: create wire tap")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public WireTap<OrderWireTapEvent> Generated_CreateWireTap()
+    {
+        OrderWireTapSinkRegistry.Audit = new OrderWireTapAuditSink();
+        OrderWireTapSinkRegistry.Metrics = new OrderWireTapMetricsSink();
+        return GeneratedOrderWireTap.Create();
+    }
+
+    [Benchmark(Description = "Fluent: publish order event")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderWireTapSummary Fluent_PublishOrderEvent()
+        => OrderWireTapExampleRunner.RunFluent(Event);
+
+    [Benchmark(Description = "Generated: publish order event")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderWireTapSummary Generated_PublishOrderEvent()
+    {
+        var audit = new OrderWireTapAuditSink();
+        var metrics = new OrderWireTapMetricsSink();
+        OrderWireTapSinkRegistry.Audit = audit;
+        OrderWireTapSinkRegistry.Metrics = metrics;
+
+        var service = new OrderWireTapService(GeneratedOrderWireTap.Create(), audit, metrics);
+        return service.Publish(Event);
+    }
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -31,8 +31,12 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
+| Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |
+| Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
+| Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -47,6 +51,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Transaction Script | Execution | 184.93 ns | 1,136 B | 98.28 ns | 600 B | Generated reduced execution time and allocation for the submit-order workflow. |
 | Unit Of Work | Construction | 49.50 ns | 304 B | 46.91 ns | 304 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
+| Wire Tap | Construction | 47.13 ns | 496 B | 40.99 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Wire Tap | Execution | 214.72 ns | 1,232 B | 191.45 ns | 1,064 B | Generated reduced execution time and allocation for the order observability workflow. |
 
 ## Coverage Matrix Summary
 

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -48,8 +48,12 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
+| Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |
+| Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
+| Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -64,6 +68,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Transaction Script | Execution | 184.93 ns | 1,136 B | 98.28 ns | 600 B | Generated reduced execution time and allocation for the submit-order workflow. |
 | Unit Of Work | Construction | 49.50 ns | 304 B | 46.91 ns | 304 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
+| Wire Tap | Construction | 47.13 ns | 496 B | 40.99 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Wire Tap | Execution | 214.72 ns | 1,232 B | 191.45 ns | 1,064 B | Generated reduced execution time and allocation for the order observability workflow. |
 
 The coverage matrix is separate from the scenario timings. Matrix benchmarks prove every catalog pattern and every generator source file has a reportable BenchmarkDotNet route; pattern-specific scenario benchmarks provide the fluent-vs-generated construction and execution numbers shown above. See [Benchmark Results](benchmark-results.md) for the full pattern and generator matrix.
 


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet scenario benchmarks for Scatter Gather, Resequencer, and Wire Tap
- publish fluent vs generated construction and execution results in README and benchmark guides
- continue enterprise integration and messaging benchmark tracking for #331

## Measured current-TFM results
| Pattern | Scenario | Fluent mean | Fluent alloc | Generated mean | Generated alloc |
| --- | --- | ---: | ---: | ---: | ---: |
| Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B |
| Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B |
| Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B |
| Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B |
| Wire Tap | Construction | 47.13 ns | 496 B | 40.99 ns | 336 B |
| Wire Tap | Execution | 214.72 ns | 1,232 B | 191.45 ns | 1,064 B |

## Validation
- dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *ScatterGatherBenchmarks* --artifacts artifacts\benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *ResequencerBenchmarks* --artifacts artifacts\benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *WireTapBenchmarks* --artifacts artifacts\benchmarks --join --job short
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- git diff --check
- dotnet test PatternKit.slnx --configuration Release --no-restore

Closes part of #331