### PR TITLE
test: harden async polling consumer backoff scenario

### DIFF
--- a/test/PatternKit.Tests/Messaging/Consumers/AsyncPollingConsumerTests.cs
+++ b/test/PatternKit.Tests/Messaging/Consumers/AsyncPollingConsumerTests.cs
@@ -88,30 +88,28 @@ public sealed class AsyncPollingConsumerTests
     [Fact]
     public async Task RunAsync_EmptyPoll_ExponentialBackOff()
     {
-        var pollTimestamps = new List<DateTimeOffset>();
+        var pollCount = 0;
         using var cts = new CancellationTokenSource();
 
         var consumer = AsyncPollingConsumer<string>.Create()
             .WithSource(async (_, _) =>
             {
                 await Task.CompletedTask;
-                pollTimestamps.Add(DateTimeOffset.UtcNow);
+                if (Interlocked.Increment(ref pollCount) >= 3)
+                {
+                    cts.Cancel();
+                }
+
                 return null;
             })
             .WithInterval(TimeSpan.FromMilliseconds(10))
             .OnEmpty(BackOffPolicy.Exponential, cap: TimeSpan.FromMilliseconds(500))
             .Build();
 
-        _ = Task.Run(async () =>
-        {
-            await Task.Delay(300);
-            cts.Cancel();
-        });
-
         await consumer.RunAsync(async (_, _, _) => await Task.CompletedTask, cancellationToken: cts.Token);
 
-        // With exponential backoff, later intervals should be longer
-        ScenarioExpect.True(pollTimestamps.Count >= 2);
+        // Exponential backoff should continue polling after empty source results until cancellation.
+        ScenarioExpect.Equal(3, pollCount);
     }
 
     [Scenario("RunAsync JitterIsApplied")]


### PR DESCRIPTION
## Summary
- remove wall-clock cancellation from the exponential backoff polling scenario
- cancel deterministically from the poll source after the expected empty poll count
- keep the scenario on TinyBDD assertion helpers

## Validation
- targeted net8 Release scenario test passed
- full Release solution test passed
- git diff --check passed