### PR TITLE
test: add cloud resilience scenario benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,8 +466,12 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
+| Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
@@ -488,6 +492,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
+| Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Rate Limiting | Execution | 247.62 ns | 1,200 B | 245.56 ns | 1,200 B | Same allocation; generated was slightly faster for the tenant rejection workflow. |
 | Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Cloud/BulkheadBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/BulkheadBenchmarks.cs
@@ -1,0 +1,41 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.Bulkhead;
+using PatternKit.Examples.BulkheadDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "Bulkhead")]
+public class BulkheadBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create bulkhead policy")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public BulkheadPolicy<ShippingAllocation> Fluent_CreatePolicy()
+        => ShippingBulkheadPolicies.CreateFluentPolicy();
+
+    [Benchmark(Description = "Generated: create bulkhead policy")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public BulkheadPolicy<ShippingAllocation> Generated_CreatePolicy()
+        => GeneratedShippingBulkheadPolicy.CreateGeneratedPolicy();
+
+    [Benchmark(Description = "Fluent: reserve shipping allocation")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<ShippingBulkheadSubmission> Fluent_ReserveAllocation()
+    {
+        var service = new ShippingBulkheadService(
+            new ScriptedShippingAllocator(new ShippingAllocation("ORDER-100", "ground", true)),
+            ShippingBulkheadPolicies.CreateFluentPolicy());
+
+        return service.ReserveAsync("ORDER-100");
+    }
+
+    [Benchmark(Description = "Generated: reserve shipping allocation")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<ShippingBulkheadSubmission> Generated_ReserveAllocation()
+    {
+        var service = new ShippingBulkheadService(
+            new ScriptedShippingAllocator(new ShippingAllocation("ORDER-100", "ground", true)),
+            GeneratedShippingBulkheadPolicy.CreateGeneratedPolicy());
+
+        return service.ReserveAsync("ORDER-100");
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Cloud/CircuitBreakerBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/CircuitBreakerBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.CircuitBreaker;
+using PatternKit.Examples.CircuitBreakerDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "CircuitBreaker")]
+public class CircuitBreakerBenchmarks
+{
+    private static readonly FulfillmentResponse Accepted = new("ORDER-42", 202, "accepted");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create circuit breaker policy")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public CircuitBreakerPolicy<FulfillmentResponse> Fluent_CreatePolicy()
+        => FulfillmentCircuitBreakerPolicies.CreateFluentPolicy();
+
+    [Benchmark(Description = "Generated: create circuit breaker policy")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public CircuitBreakerPolicy<FulfillmentResponse> Generated_CreatePolicy()
+        => GeneratedFulfillmentCircuitBreakerPolicy.CreateGeneratedPolicy();
+
+    [Benchmark(Description = "Fluent: submit accepted fulfillment")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<FulfillmentSubmissionResult> Fluent_SubmitAcceptedFulfillment()
+    {
+        var service = new FulfillmentCircuitBreakerService(
+            new ScriptedFulfillmentGateway(Accepted),
+            FulfillmentCircuitBreakerPolicies.CreateFluentPolicy());
+
+        return service.SubmitAsync("ORDER-42");
+    }
+
+    [Benchmark(Description = "Generated: submit accepted fulfillment")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<FulfillmentSubmissionResult> Generated_SubmitAcceptedFulfillment()
+    {
+        var service = new FulfillmentCircuitBreakerService(
+            new ScriptedFulfillmentGateway(Accepted),
+            GeneratedFulfillmentCircuitBreakerPolicy.CreateGeneratedPolicy());
+
+        return service.SubmitAsync("ORDER-42");
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Cloud/RateLimitingBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/RateLimitingBenchmarks.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.RateLimiting;
+using PatternKit.Examples.RateLimitingDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "RateLimiting")]
+public class RateLimitingBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create rate limit policy")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public RateLimitPolicy<SearchResponse> Fluent_CreatePolicy()
+        => ProductSearchRateLimitPolicies.CreateFluentPolicy();
+
+    [Benchmark(Description = "Generated: create rate limit policy")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public RateLimitPolicy<SearchResponse> Generated_CreatePolicy()
+        => GeneratedProductSearchRateLimitPolicy.CreateGeneratedPolicy();
+
+    [Benchmark(Description = "Fluent: reject third tenant request")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public async ValueTask<ProductSearchRateLimitResult> Fluent_RejectThirdTenantRequest()
+    {
+        var service = new ProductSearchRateLimitService(
+            new ScriptedProductSearchService(),
+            ProductSearchRateLimitPolicies.CreateFluentPolicy());
+
+        _ = await service.SearchAsync("tenant-a", "boots");
+        _ = await service.SearchAsync("tenant-a", "coats");
+        return await service.SearchAsync("tenant-a", "gloves");
+    }
+
+    [Benchmark(Description = "Generated: reject third tenant request")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public async ValueTask<ProductSearchRateLimitResult> Generated_RejectThirdTenantRequest()
+    {
+        var service = new ProductSearchRateLimitService(
+            new ScriptedProductSearchService(),
+            GeneratedProductSearchRateLimitPolicy.CreateGeneratedPolicy());
+
+        _ = await service.SearchAsync("tenant-a", "boots");
+        _ = await service.SearchAsync("tenant-a", "coats");
+        return await service.SearchAsync("tenant-a", "gloves");
+    }
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -13,8 +13,12 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
+| Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
@@ -35,6 +39,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
+| Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Rate Limiting | Execution | 247.62 ns | 1,200 B | 245.56 ns | 1,200 B | Same allocation; generated was slightly faster for the tenant rejection workflow. |
 | Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -30,8 +30,12 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
+| Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
@@ -52,6 +56,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
+| Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Rate Limiting | Execution | 247.62 ns | 1,200 B | 245.56 ns | 1,200 B | Same allocation; generated was slightly faster for the tenant rejection workflow. |
 | Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet fluent-vs-generated scenario benchmarks for Bulkhead, Circuit Breaker, and Rate Limiting
- publish current-TFM timing and allocation rows in README and benchmark docs
- keep each scenario tied to the production-shaped cloud examples

## Current-TFM results
| Pattern | Phase | Fluent | Generated |
| --- | --- | --- | --- |
| Bulkhead | Construction | 20.56 ns / 216 B | 20.48 ns / 216 B |
| Bulkhead | Execution | 102.70 ns / 592 B | 106.11 ns / 592 B |
| Circuit Breaker | Construction | 14.33 ns / 128 B | 13.73 ns / 128 B |
| Circuit Breaker | Execution | 85.34 ns / 488 B | 85.19 ns / 488 B |
| Rate Limiting | Construction | 19.16 ns / 168 B | 18.19 ns / 168 B |
| Rate Limiting | Execution | 247.62 ns / 1,200 B | 245.56 ns / 1,200 B |

## Validation
- dotnet build benchmarks\\PatternKit.Benchmarks\\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run -c Release --framework net10.0 --project benchmarks\\PatternKit.Benchmarks -- --filter *BulkheadBenchmarks* --artifacts artifacts\\benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks\\PatternKit.Benchmarks -- --filter *CircuitBreakerBenchmarks* --artifacts artifacts\\benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks\\PatternKit.Benchmarks -- --filter *RateLimitingBenchmarks* --artifacts artifacts\\benchmarks --join --job short
- dotnet test test\\PatternKit.Examples.Tests\\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger console;verbosity=minimal
- git diff --check

Refs #328