### PR TITLE
test: add cloud gateway scenario benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -476,6 +478,10 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
+| Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
+| Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Gateway Routing | Execution | 23.63 ns | 200 B | 20.13 ns | 168 B | Generated reduced execution time and allocation for the inventory routing workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Cloud/BackendsForFrontendsBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/BackendsForFrontendsBenchmarks.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.BackendsForFrontends;
+using PatternKit.Examples.BackendsForFrontendsDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "BackendsForFrontends")]
+public class BackendsForFrontendsBenchmarks
+{
+    private static readonly CommerceClientRequest Request = new("web", "C-100");
+    private static readonly DemoCommerceSummaryBackend Backend = new();
+    private readonly BackendsForFrontends<CommerceClientRequest, CommerceClientResponse> _fluent =
+        CommerceBackendsForFrontends.CreateFluent(Backend);
+    private readonly BackendsForFrontends<CommerceClientRequest, CommerceClientResponse> _generated =
+        GeneratedCommerceBackendsForFrontends.Create();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create BFF router")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public BackendsForFrontends<CommerceClientRequest, CommerceClientResponse> Fluent_CreateRouter()
+        => CommerceBackendsForFrontends.CreateFluent(Backend);
+
+    [Benchmark(Description = "Generated: create BFF router")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public BackendsForFrontends<CommerceClientRequest, CommerceClientResponse> Generated_CreateRouter()
+        => GeneratedCommerceBackendsForFrontends.Create();
+
+    [Benchmark(Description = "Fluent: shape web summary")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public CommerceClientResponse Fluent_ShapeWebSummary()
+        => _fluent.Dispatch(Request).Response!;
+
+    [Benchmark(Description = "Generated: shape web summary")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public CommerceClientResponse Generated_ShapeWebSummary()
+        => _generated.Dispatch(Request).Response!;
+}

--- a/benchmarks/PatternKit.Benchmarks/Cloud/GatewayAggregationBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/GatewayAggregationBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.GatewayAggregation;
+using PatternKit.Examples.GatewayAggregationDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "GatewayAggregation")]
+public class GatewayAggregationBenchmarks
+{
+    private static readonly CustomerDashboardRequest Request = new("C-100");
+    private static readonly DemoCustomerProfileClient Profiles = new();
+    private static readonly DemoCustomerOrdersClient Orders = new();
+    private static readonly DemoCustomerRecommendationClient Recommendations = new();
+    private readonly GatewayAggregation<CustomerDashboardRequest, CustomerDashboardResponse> _fluent =
+        CustomerDashboardGateways.CreateFluent(Profiles, Orders, Recommendations);
+    private readonly GatewayAggregation<CustomerDashboardRequest, CustomerDashboardResponse> _generated =
+        GeneratedCustomerDashboardGateway.Create();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create aggregation gateway")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public GatewayAggregation<CustomerDashboardRequest, CustomerDashboardResponse> Fluent_CreateGateway()
+        => CustomerDashboardGateways.CreateFluent(Profiles, Orders, Recommendations);
+
+    [Benchmark(Description = "Generated: create aggregation gateway")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GatewayAggregation<CustomerDashboardRequest, CustomerDashboardResponse> Generated_CreateGateway()
+        => GeneratedCustomerDashboardGateway.Create();
+
+    [Benchmark(Description = "Fluent: aggregate dashboard")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public CustomerDashboardResponse Fluent_AggregateDashboard()
+        => _fluent.Aggregate(Request).Response!;
+
+    [Benchmark(Description = "Generated: aggregate dashboard")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public CustomerDashboardResponse Generated_AggregateDashboard()
+        => _generated.Aggregate(Request).Response!;
+}

--- a/benchmarks/PatternKit.Benchmarks/Cloud/GatewayRoutingBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/GatewayRoutingBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.GatewayRouting;
+using PatternKit.Examples.GatewayRoutingDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "GatewayRouting")]
+public class GatewayRoutingBenchmarks
+{
+    private static readonly ProductGatewayRequest Request = new("/inventory/SKU-42", "tenant-a");
+    private static readonly DemoProductInventoryApi Inventory = new();
+    private static readonly DemoProductPricingApi Pricing = new();
+    private readonly GatewayRouting<ProductGatewayRequest, ProductGatewayResponse> _fluent =
+        ProductGatewayRoutes.CreateFluent(Inventory, Pricing);
+    private readonly GatewayRouting<ProductGatewayRequest, ProductGatewayResponse> _generated =
+        GeneratedProductGatewayRouting.Create();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create gateway router")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public GatewayRouting<ProductGatewayRequest, ProductGatewayResponse> Fluent_CreateRouter()
+        => ProductGatewayRoutes.CreateFluent(Inventory, Pricing);
+
+    [Benchmark(Description = "Generated: create gateway router")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GatewayRouting<ProductGatewayRequest, ProductGatewayResponse> Generated_CreateRouter()
+        => GeneratedProductGatewayRouting.Create();
+
+    [Benchmark(Description = "Fluent: route inventory request")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public GatewayRoutingResult<ProductGatewayResponse> Fluent_RouteInventoryRequest()
+        => _fluent.Route(Request);
+
+    [Benchmark(Description = "Generated: route inventory request")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public GatewayRoutingResult<ProductGatewayResponse> Generated_RouteInventoryRequest()
+        => _generated.Route(Request);
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -13,6 +13,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -23,6 +25,10 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
+| Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
+| Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Gateway Routing | Execution | 23.63 ns | 200 B | 20.13 ns | 168 B | Generated reduced execution time and allocation for the inventory routing workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -30,6 +30,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -40,6 +42,10 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
+| Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
+| Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Gateway Routing | Execution | 23.63 ns | 200 B | 20.13 ns | 168 B | Generated reduced execution time and allocation for the inventory routing workflow. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet classes for Backends for Frontends, Gateway Aggregation, and Gateway Routing
- publish fluent versus generated construction/execution timing snapshots in README and benchmark docs
- extend the benchmark-results timing table used by the production readiness coverage guard

## Measured current-tfm results
- Backends For Frontends construction: fluent 58.00 ns / 512 B, generated 42.48 ns / 296 B
- Backends For Frontends execution: fluent 25.40 ns / 216 B, generated 29.77 ns / 216 B
- Gateway Aggregation construction: fluent 104.21 ns / 856 B, generated 64.99 ns / 560 B
- Gateway Aggregation execution: fluent 109.55 ns / 632 B, generated 112.95 ns / 632 B
- Gateway Routing construction: fluent 56.20 ns / 464 B, generated 50.72 ns / 336 B
- Gateway Routing execution: fluent 23.63 ns / 200 B, generated 20.13 ns / 168 B

## Validation
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"
- git diff --check

Refs #328