### PR TITLE
test: add cloud edge scenario benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
+| Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |
+| Queue-Based Load Leveling | Execution | 94.49 ns | 480 B | 94.42 ns | 480 B | Effectively equivalent for the fulfillment enqueue workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -510,12 +512,16 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
+| Sidecar | Construction | 59.96 ns | 488 B | 52.09 ns | 400 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Sidecar | Execution | 99.61 ns | 640 B | 100.51 ns | 640 B | Same allocation; fluent was slightly faster for the order sidecar submission workflow. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
 | Service Layer | Construction | 56.33 ns | 496 B | 41.36 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
+| Strangler Fig | Construction | 53.71 ns | 416 B | 42.35 ns | 288 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Strangler Fig | Execution | 24.64 ns | 200 B | 20.50 ns | 168 B | Generated reduced execution time and allocation for the enterprise checkout routing workflow. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Table Data Gateway | Execution | 90.51 ns | 600 B | 96.35 ns | 600 B | Same allocation; fluent was slightly faster for the insert-update-query workflow. |
 | Transaction Script | Construction | 20.634 ns | 240 B | 5.839 ns | 40 B | Generated materially reduced construction time and allocation in this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Cloud/QueueLoadLevelingBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/QueueLoadLevelingBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.QueueLoadLeveling;
+using PatternKit.Examples.QueueLoadLevelingDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "QueueLoadLeveling")]
+public class QueueLoadLevelingBenchmarks
+{
+    private static readonly FulfillmentWorkItem Work = new("order-100", "central");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create queue load leveling policy")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public QueueLoadLevelingPolicy<FulfillmentQueueResult> Fluent_CreatePolicy()
+        => FulfillmentQueueLoadLevelingPolicies.CreateFluentPolicy();
+
+    [Benchmark(Description = "Generated: create queue load leveling policy")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public QueueLoadLevelingPolicy<FulfillmentQueueResult> Generated_CreatePolicy()
+        => GeneratedFulfillmentQueueLoadLevelingPolicy.CreatePolicy();
+
+    [Benchmark(Description = "Fluent: enqueue fulfillment work")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<FulfillmentQueueResult> Fluent_EnqueueFulfillmentWork()
+        => EnqueueWith(FulfillmentQueueLoadLevelingPolicies.CreateFluentPolicy());
+
+    [Benchmark(Description = "Generated: enqueue fulfillment work")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<FulfillmentQueueResult> Generated_EnqueueFulfillmentWork()
+        => EnqueueWith(GeneratedFulfillmentQueueLoadLevelingPolicy.CreatePolicy());
+
+    private static ValueTask<FulfillmentQueueResult> EnqueueWith(QueueLoadLevelingPolicy<FulfillmentQueueResult> policy)
+        => new FulfillmentQueueLoadLevelingService(new ScriptedFulfillmentWorker(), policy).EnqueueAsync(Work);
+}

--- a/benchmarks/PatternKit.Benchmarks/Cloud/SidecarBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/SidecarBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.Sidecar;
+using PatternKit.Examples.SidecarDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "Sidecar")]
+public class SidecarBenchmarks
+{
+    private static readonly OrderTelemetryRequest Request = new("O-200", 50m);
+    private static readonly IOrderTelemetrySink Telemetry = new NoopOrderTelemetrySink();
+    private readonly Sidecar<OrderTelemetryRequest, OrderTelemetryResponse> _fluent =
+        OrderTelemetrySidecars.CreateFluent(Telemetry);
+    private readonly Sidecar<OrderTelemetryRequest, OrderTelemetryResponse> _generated =
+        GeneratedOrderTelemetrySidecar.Create();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create sidecar")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Sidecar<OrderTelemetryRequest, OrderTelemetryResponse> Fluent_CreateSidecar()
+        => OrderTelemetrySidecars.CreateFluent(Telemetry);
+
+    [Benchmark(Description = "Generated: create sidecar")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Sidecar<OrderTelemetryRequest, OrderTelemetryResponse> Generated_CreateSidecar()
+        => GeneratedOrderTelemetrySidecar.Create();
+
+    [Benchmark(Description = "Fluent: submit order through sidecar")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public SidecarResult<OrderTelemetryResponse> Fluent_SubmitOrder()
+        => _fluent.Invoke(Request);
+
+    [Benchmark(Description = "Generated: submit order through sidecar")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public SidecarResult<OrderTelemetryResponse> Generated_SubmitOrder()
+        => _generated.Invoke(Request);
+
+    private sealed class NoopOrderTelemetrySink : IOrderTelemetrySink
+    {
+        public void Capture(string eventName, string value)
+        {
+        }
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Cloud/StranglerFigBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Cloud/StranglerFigBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Cloud.StranglerFig;
+using PatternKit.Examples.StranglerFigDemo;
+
+namespace PatternKit.Benchmarks.Cloud;
+
+[BenchmarkCategory("Cloud", "StranglerFig")]
+public class StranglerFigBenchmarks
+{
+    private static readonly CheckoutMigrationRequest Request = new("enterprise-a", "O-200", 50m);
+    private static readonly DemoLegacyCheckoutSystem Legacy = new();
+    private static readonly DemoModernCheckoutSystem Modern = new();
+    private readonly StranglerFig<CheckoutMigrationRequest, CheckoutMigrationResponse> _fluent =
+        CheckoutMigrationRoutes.CreateFluent(Legacy, Modern);
+    private readonly StranglerFig<CheckoutMigrationRequest, CheckoutMigrationResponse> _generated =
+        GeneratedCheckoutMigration.Create();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create Strangler Fig migration")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public StranglerFig<CheckoutMigrationRequest, CheckoutMigrationResponse> Fluent_CreateMigration()
+        => CheckoutMigrationRoutes.CreateFluent(Legacy, Modern);
+
+    [Benchmark(Description = "Generated: create Strangler Fig migration")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public StranglerFig<CheckoutMigrationRequest, CheckoutMigrationResponse> Generated_CreateMigration()
+        => GeneratedCheckoutMigration.Create();
+
+    [Benchmark(Description = "Fluent: route enterprise checkout")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public StranglerFigResult<CheckoutMigrationResponse> Fluent_RouteEnterpriseCheckout()
+        => _fluent.Route(Request);
+
+    [Benchmark(Description = "Generated: route enterprise checkout")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public StranglerFigResult<CheckoutMigrationResponse> Generated_RouteEnterpriseCheckout()
+        => _generated.Route(Request);
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -49,6 +49,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
+| Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |
+| Queue-Based Load Leveling | Execution | 94.49 ns | 480 B | 94.42 ns | 480 B | Effectively equivalent for the fulfillment enqueue workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -57,12 +59,16 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
+| Sidecar | Construction | 59.96 ns | 488 B | 52.09 ns | 400 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Sidecar | Execution | 99.61 ns | 640 B | 100.51 ns | 640 B | Same allocation; fluent was slightly faster for the order sidecar submission workflow. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
 | Service Layer | Construction | 56.33 ns | 496 B | 41.36 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
+| Strangler Fig | Construction | 53.71 ns | 416 B | 42.35 ns | 288 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Strangler Fig | Execution | 24.64 ns | 200 B | 20.50 ns | 168 B | Generated reduced execution time and allocation for the enterprise checkout routing workflow. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Table Data Gateway | Execution | 90.51 ns | 600 B | 96.35 ns | 600 B | Same allocation; fluent was slightly faster for the insert-update-query workflow. |
 | Transaction Script | Construction | 20.634 ns | 240 B | 5.839 ns | 40 B | Generated materially reduced construction time and allocation in this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -66,6 +66,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
+| Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |
+| Queue-Based Load Leveling | Execution | 94.49 ns | 480 B | 94.42 ns | 480 B | Effectively equivalent for the fulfillment enqueue workflow. |
 | Retry | Construction | 25.36 ns | 208 B | 27.18 ns | 208 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -74,12 +76,16 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
+| Sidecar | Construction | 59.96 ns | 488 B | 52.09 ns | 400 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Sidecar | Execution | 99.61 ns | 640 B | 100.51 ns | 640 B | Same allocation; fluent was slightly faster for the order sidecar submission workflow. |
 | Service Activator | Construction | 4.825 ns | 32 B | 4.641 ns | 32 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Service Activator | Execution | 25.48 ns | 256 B | 26.49 ns | 256 B | Same allocation; fluent was slightly faster in this path. |
 | Service Layer | Construction | 56.33 ns | 496 B | 41.36 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
+| Strangler Fig | Construction | 53.71 ns | 416 B | 42.35 ns | 288 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Strangler Fig | Execution | 24.64 ns | 200 B | 20.50 ns | 168 B | Generated reduced execution time and allocation for the enterprise checkout routing workflow. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Table Data Gateway | Execution | 90.51 ns | 600 B | 96.35 ns | 600 B | Same allocation; fluent was slightly faster for the insert-update-query workflow. |
 | Transaction Script | Construction | 20.634 ns | 240 B | 5.839 ns | 40 B | Generated materially reduced construction time and allocation in this microbenchmark. |

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -166,6 +166,9 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
         if (patternName == "CacheAside")
             return "Cache-Aside";
 
+        if (patternName == "QueueLoadLeveling")
+            return "Queue-Based Load Leveling";
+
         var chars = new List<char>(patternName.Length + 4);
         for (var index = 0; index < patternName.Length; index++)
         {


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet scenario benchmarks for Queue-Based Load Leveling, Sidecar, and Strangler Fig
- publish fluent vs generated construction/execution results in README and benchmark docs
- update the benchmark coverage guard to preserve the Queue-Based Load Leveling catalog name

## Benchmark results
| Pattern | Path | Fluent mean | Fluent alloc | Generated mean | Generated alloc | Decision signal |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |
| Queue-Based Load Leveling | Execution | 94.49 ns | 480 B | 94.42 ns | 480 B | Effectively equivalent for the fulfillment enqueue workflow. |
| Sidecar | Construction | 59.96 ns | 488 B | 52.09 ns | 400 B | Generated reduced construction time and allocation in this microbenchmark. |
| Sidecar | Execution | 99.61 ns | 640 B | 100.51 ns | 640 B | Same allocation; fluent was slightly faster for the order sidecar submission workflow. |
| Strangler Fig | Construction | 53.71 ns | 416 B | 42.35 ns | 288 B | Generated reduced construction time and allocation in this microbenchmark. |
| Strangler Fig | Execution | 24.64 ns | 200 B | 20.50 ns | 168 B | Generated reduced execution time and allocation for the enterprise checkout routing workflow. |

The Sidecar benchmark uses a no-op telemetry sink so the measurement isolates sidecar overhead instead of unbounded demo-list growth.

## Validation
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *QueueLoadLevelingBenchmarks* --artifacts artifacts\benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *SidecarBenchmarks* --artifacts artifacts\benchmarks --join --job short
- dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *StranglerFigBenchmarks* --artifacts artifacts\benchmarks --join --job short
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"
- git diff --check

Refs #328