### PR TITLE
test: add messaging channel scenario benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Channel Adapter | Construction | 38.469 ns | 384 B | 38.681 ns | 384 B | Effectively equivalent for this microbenchmark. |
+| Channel Adapter | Execution | 204.907 ns | 888 B | 198.374 ns | 888 B | Same allocation; generated was slightly faster for the ERP order document round-trip workflow. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -490,10 +492,18 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
+| Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
+| Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
+| Message Filter | Construction | 25.431 ns | 232 B | 25.626 ns | 232 B | Effectively equivalent for this microbenchmark. |
+| Message Filter | Execution | 44.637 ns | 424 B | 45.826 ns | 424 B | Same allocation; fluent was slightly faster for order fraud screening. |
 | Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
 | Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
 | Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
+| Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |
+| Messaging Gateway | Execution | 66.597 ns | 560 B | 67.558 ns | 560 B | Same allocation; fluent was slightly faster for payment authorization. |
+| Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
+| Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Messaging/ChannelAdapterBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/ChannelAdapterBenchmarks.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Adapters;
+using PatternKit.Messaging.Channels;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "ChannelAdapter")]
+public class ChannelAdapterBenchmarks
+{
+    private static readonly ErpOrderDocument Document = new("ERP-100", "149.95");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create channel adapter")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public ChannelAdapter<ErpOrderDocument, OrderIntegrationMessage> Fluent_CreateChannelAdapter()
+    {
+        var channels = CreateChannels();
+        return ErpChannelAdapters.Create(channels.Inbound, channels.Outbound);
+    }
+
+    [Benchmark(Description = "Generated: create channel adapter")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public ChannelAdapter<ErpOrderDocument, OrderIntegrationMessage> Generated_CreateChannelAdapter()
+    {
+        var channels = CreateChannels();
+        return GeneratedErpChannelAdapter.Create(channels.Inbound, channels.Outbound);
+    }
+
+    [Benchmark(Description = "Fluent: round-trip ERP order document")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ErpChannelAdapterSummary Fluent_RoundTripErpOrderDocument()
+    {
+        var channels = CreateChannels();
+        return new ErpChannelAdapterService(
+            ErpChannelAdapters.Create(channels.Inbound, channels.Outbound),
+            channels).RoundTrip(Document);
+    }
+
+    [Benchmark(Description = "Generated: round-trip ERP order document")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ErpChannelAdapterSummary Generated_RoundTripErpOrderDocument()
+    {
+        var channels = CreateChannels();
+        return new ErpChannelAdapterService(
+            GeneratedErpChannelAdapter.Create(channels.Inbound, channels.Outbound),
+            channels).RoundTrip(Document);
+    }
+
+    private static ErpChannelAdapterChannels CreateChannels()
+        => new(
+            MessageChannel<OrderIntegrationMessage>.Create("erp-inbound").Build(),
+            MessageChannel<OrderIntegrationMessage>.Create("erp-outbound").Build());
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MessageChannelBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MessageChannelBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Channels;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "MessageChannel")]
+public class MessageChannelBenchmarks
+{
+    private static readonly InventoryAdjustment Adjustment = new("SKU-100", 12, "cycle-count");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create message channel")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public MessageChannel<InventoryAdjustment> Fluent_CreateMessageChannel()
+        => InventoryMessageChannels.Create();
+
+    [Benchmark(Description = "Generated: create message channel")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public MessageChannel<InventoryAdjustment> Generated_CreateMessageChannel()
+        => GeneratedInventoryMessageChannel.Create();
+
+    [Benchmark(Description = "Fluent: enqueue and process inventory adjustment")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public InventoryChannelSummary Fluent_EnqueueAndProcessInventoryAdjustment()
+        => RunWith(InventoryMessageChannels.Create());
+
+    [Benchmark(Description = "Generated: enqueue and process inventory adjustment")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public InventoryChannelSummary Generated_EnqueueAndProcessInventoryAdjustment()
+        => RunWith(GeneratedInventoryMessageChannel.Create());
+
+    private static InventoryChannelSummary RunWith(MessageChannel<InventoryAdjustment> channel)
+    {
+        var service = new InventoryMessageChannelService(channel);
+        service.Enqueue(Adjustment);
+        return service.TryProcessNext();
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MessageFilterBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MessageFilterBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "MessageFilter")]
+public class MessageFilterBenchmarks
+{
+    private static readonly OrderMessageFilterCommand Command = new("order-100", "trusted", 149.95m, true);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create message filter")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public MessageFilter<OrderMessageFilterCommand> Fluent_CreateMessageFilter()
+        => OrderMessageFilters.CreateFraudScreen();
+
+    [Benchmark(Description = "Generated: create message filter")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public MessageFilter<OrderMessageFilterCommand> Generated_CreateMessageFilter()
+        => GeneratedOrderMessageFilter.Create();
+
+    [Benchmark(Description = "Fluent: screen order command")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderMessageFilterSummary Fluent_ScreenOrderCommand()
+        => OrderMessageFilterExampleRunner.RunFluent(Command);
+
+    [Benchmark(Description = "Generated: screen order command")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderMessageFilterSummary Generated_ScreenOrderCommand()
+        => new OrderMessageFilterService(GeneratedOrderMessageFilter.Create()).Screen(Command);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MessagingGatewayBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MessagingGatewayBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Channels;
+using PatternKit.Messaging.Gateways;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "MessagingGateway")]
+public class MessagingGatewayBenchmarks
+{
+    private static readonly PaymentAuthorizationRequest Request = new("order-100", 149.95m);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create messaging gateway")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public MessagingGateway<PaymentAuthorizationRequest, PaymentAuthorizationDecision> Fluent_CreateMessagingGateway()
+        => PaymentMessagingGateways.Create(CreateChannel());
+
+    [Benchmark(Description = "Generated: create messaging gateway")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public MessagingGateway<PaymentAuthorizationRequest, PaymentAuthorizationDecision> Generated_CreateMessagingGateway()
+        => GeneratedPaymentMessagingGateway.Create(CreateChannel());
+
+    [Benchmark(Description = "Fluent: authorize payment request")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public PaymentGatewaySummary Fluent_AuthorizePaymentRequest()
+        => PaymentMessagingGatewayExampleRunner.RunFluent(Request);
+
+    [Benchmark(Description = "Generated: authorize payment request")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public PaymentGatewaySummary Generated_AuthorizePaymentRequest()
+        => PaymentMessagingGatewayExampleRunner.RunGeneratedStatic(Request);
+
+    private static MessageChannel<PaymentAuthorizationRequest> CreateChannel()
+        => MessageChannel<PaymentAuthorizationRequest>.Create("payment-requests").Build();
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/PollingConsumerBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/PollingConsumerBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Channels;
+using PatternKit.Messaging.Consumers;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "PollingConsumer")]
+public class PollingConsumerBenchmarks
+{
+    private static readonly ReplenishmentRequest Request = new("SKU-100", 12);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create polling consumer")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public PollingConsumer<ReplenishmentRequest> Fluent_CreatePollingConsumer()
+        => WarehousePollingConsumers.Create(CreateLoadedChannel());
+
+    [Benchmark(Description = "Generated: create polling consumer")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public PollingConsumer<ReplenishmentRequest> Generated_CreatePollingConsumer()
+        => GeneratedWarehousePollingConsumer.Create();
+
+    [Benchmark(Description = "Fluent: poll replenishment request")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public WarehousePollingSummary Fluent_PollReplenishmentRequest()
+        => WarehousePollingConsumerExampleRunner.RunFluent(Request);
+
+    [Benchmark(Description = "Generated: poll replenishment request")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public WarehousePollingSummary Generated_PollReplenishmentRequest()
+    {
+        GeneratedWarehousePollingConsumer.Enqueue(Request);
+        return new WarehousePollingConsumerService(GeneratedWarehousePollingConsumer.Create()).Poll();
+    }
+
+    private static MessageChannel<ReplenishmentRequest> CreateLoadedChannel()
+    {
+        var channel = MessageChannel<ReplenishmentRequest>.Create("warehouse-replenishment").Build();
+        channel.Send(Message<ReplenishmentRequest>.Create(Request));
+        return channel;
+    }
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -19,6 +19,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Channel Adapter | Construction | 38.469 ns | 384 B | 38.681 ns | 384 B | Effectively equivalent for this microbenchmark. |
+| Channel Adapter | Execution | 204.907 ns | 888 B | 198.374 ns | 888 B | Same allocation; generated was slightly faster for the ERP order document round-trip workflow. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -37,10 +39,18 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
+| Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
+| Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
+| Message Filter | Construction | 25.431 ns | 232 B | 25.626 ns | 232 B | Effectively equivalent for this microbenchmark. |
+| Message Filter | Execution | 44.637 ns | 424 B | 45.826 ns | 424 B | Same allocation; fluent was slightly faster for order fraud screening. |
 | Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
 | Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
 | Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
+| Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |
+| Messaging Gateway | Execution | 66.597 ns | 560 B | 67.558 ns | 560 B | Same allocation; fluent was slightly faster for payment authorization. |
+| Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
+| Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -36,6 +36,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Channel Adapter | Construction | 38.469 ns | 384 B | 38.681 ns | 384 B | Effectively equivalent for this microbenchmark. |
+| Channel Adapter | Execution | 204.907 ns | 888 B | 198.374 ns | 888 B | Same allocation; generated was slightly faster for the ERP order document round-trip workflow. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -54,10 +56,18 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
+| Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
+| Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
+| Message Filter | Construction | 25.431 ns | 232 B | 25.626 ns | 232 B | Effectively equivalent for this microbenchmark. |
+| Message Filter | Execution | 44.637 ns | 424 B | 45.826 ns | 424 B | Same allocation; fluent was slightly faster for order fraud screening. |
 | Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
 | Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
 | Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
+| Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |
+| Messaging Gateway | Execution | 66.597 ns | 560 B | 67.558 ns | 560 B | Same allocation; fluent was slightly faster for payment authorization. |
+| Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
+| Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet scenario benchmarks for Channel Adapter, Message Channel, Message Filter, Messaging Gateway, and Polling Consumer
- exercise the existing production-style examples with direct fluent vs source-generated construction and execution paths
- publish current-TFM benchmark results in README and benchmark docs

## Benchmark results
| Pattern | Path | Fluent mean | Fluent alloc | Generated mean | Generated alloc | Decision signal |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Channel Adapter | Construction | 38.469 ns | 384 B | 38.681 ns | 384 B | Effectively equivalent for this microbenchmark. |
| Channel Adapter | Execution | 204.907 ns | 888 B | 198.374 ns | 888 B | Same allocation; generated was slightly faster for the ERP order document round-trip workflow. |
| Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
| Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
| Message Filter | Construction | 25.431 ns | 232 B | 25.626 ns | 232 B | Effectively equivalent for this microbenchmark. |
| Message Filter | Execution | 44.637 ns | 424 B | 45.826 ns | 424 B | Same allocation; fluent was slightly faster for order fraud screening. |
| Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |
| Messaging Gateway | Execution | 66.597 ns | 560 B | 67.558 ns | 560 B | Same allocation; fluent was slightly faster for payment authorization. |
| Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
| Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |

## Validation
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *MessageChannelBenchmarks* *ChannelAdapterBenchmarks* *MessageFilterBenchmarks* *MessagingGatewayBenchmarks* *PollingConsumerBenchmarks* --artifacts artifacts\benchmarks --join --job short
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"
- git diff --check

Refs #331