### PR TITLE
test: add event store messaging scenario benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,12 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
+| Event-Carried State Transfer | Construction | 7.552 ns | 48 B | 6.751 ns | 48 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Event-Carried State Transfer | Execution | 58.508 ns | 448 B | 59.071 ns | 448 B | Effectively equivalent for the inventory projection workflow. |
+| Event Notification | Construction | 30.920 ns | 232 B | 31.926 ns | 232 B | Effectively equivalent for this microbenchmark. |
+| Event Notification | Execution | 93.209 ns | 704 B | 106.973 ns | 704 B | Same allocation; fluent was faster for order notification publishing. |
+| Event-Driven Consumer | Construction | 41.394 ns | 336 B | 25.216 ns | 192 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -502,10 +508,14 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
 | Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
+| Message Envelope | Construction | 248.580 ns | 1,688 B | 228.019 ns | 1,688 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Message Envelope | Execution | 455.486 ns | 2,752 B | 427.664 ns | 2,752 B | Same allocation; generated was slightly faster for message context enrichment. |
 | Message Filter | Construction | 25.431 ns | 232 B | 25.626 ns | 232 B | Effectively equivalent for this microbenchmark. |
 | Message Filter | Execution | 44.637 ns | 424 B | 45.826 ns | 424 B | Same allocation; fluent was slightly faster for order fraud screening. |
 | Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
 | Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
+| Message Store | Construction | 18.824 ns | 216 B | 18.721 ns | 216 B | Effectively equivalent for this microbenchmark. |
+| Message Store | Execution | 274.799 ns | 1,576 B | 265.470 ns | 1,576 B | Same allocation; generated was slightly faster for record-and-replay lookup. |
 | Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
 | Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Messaging/EventCarriedStateTransferBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/EventCarriedStateTransferBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.EnterpriseIntegration.EventCarriedStateTransfer;
+using PatternKit.Examples.EventCarriedStateTransferDemo;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "EventCarriedStateTransfer")]
+public class EventCarriedStateTransferBenchmarks
+{
+    private static readonly InventoryAdjustedEvent Event = new("SKU-100", 12, "CHI-01", 4);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create event-carried state transfer")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public EventCarriedStateTransfer<InventoryAdjustedEvent, string, InventoryReadModel> Fluent_CreateStateTransfer()
+        => InventoryStateTransfers.CreateFluent();
+
+    [Benchmark(Description = "Generated: create event-carried state transfer")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public EventCarriedStateTransfer<InventoryAdjustedEvent, string, InventoryReadModel> Generated_CreateStateTransfer()
+        => GeneratedInventoryStateTransfer.Create();
+
+    [Benchmark(Description = "Fluent: project carried inventory state")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public InventoryProjectionSummary Fluent_ProjectCarriedInventoryState()
+        => new InventoryProjectionService(InventoryStateTransfers.CreateFluent(), new InMemoryInventoryReadModelStore()).Project(Event);
+
+    [Benchmark(Description = "Generated: project carried inventory state")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public InventoryProjectionSummary Generated_ProjectCarriedInventoryState()
+        => new InventoryProjectionService(GeneratedInventoryStateTransfer.Create(), new InMemoryInventoryReadModelStore()).Project(Event);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/EventDrivenConsumerBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/EventDrivenConsumerBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Consumers;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "EventDrivenConsumer")]
+public class EventDrivenConsumerBenchmarks
+{
+    private static readonly OrderAcceptedEvent Event = new("O-100", 149.95m);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create event-driven consumer")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public EventDrivenConsumer<OrderAcceptedEvent> Fluent_CreateEventDrivenConsumer()
+        => OrderEventDrivenConsumers.Create(new OrderEventDrivenAuditSink());
+
+    [Benchmark(Description = "Generated: create event-driven consumer")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public EventDrivenConsumer<OrderAcceptedEvent> Generated_CreateEventDrivenConsumer()
+        => GeneratedOrderEventDrivenConsumer.Create();
+
+    [Benchmark(Description = "Fluent: accept order event")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderEventDrivenSummary Fluent_AcceptOrderEvent()
+        => OrderEventDrivenConsumerExampleRunner.RunFluent(Event);
+
+    [Benchmark(Description = "Generated: accept order event")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderEventDrivenSummary Generated_AcceptOrderEvent()
+        => OrderEventDrivenConsumerExampleRunner.RunGeneratedStatic(Event);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/EventNotificationBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/EventNotificationBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.EnterpriseIntegration.EventNotification;
+using PatternKit.Examples.EventNotificationDemo;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "EventNotification")]
+public class EventNotificationBenchmarks
+{
+    private static readonly OrderAcceptedNotificationEvent Event = new("O-100", "C-900", "web", true);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create event notification")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public EventNotification<OrderAcceptedNotificationEvent, string> Fluent_CreateEventNotification()
+        => OrderNotifications.CreateFluent();
+
+    [Benchmark(Description = "Generated: create event notification")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public EventNotification<OrderAcceptedNotificationEvent, string> Generated_CreateEventNotification()
+        => GeneratedOrderAcceptedNotification.Create();
+
+    [Benchmark(Description = "Fluent: publish order notification")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderNotificationSummary? Fluent_PublishOrderNotification()
+        => new OrderNotificationService(OrderNotifications.CreateFluent(), new InMemoryOrderNotificationPublisher()).Notify(Event);
+
+    [Benchmark(Description = "Generated: publish order notification")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderNotificationSummary? Generated_PublishOrderNotification()
+        => new OrderNotificationService(GeneratedOrderAcceptedNotification.Create(), new InMemoryOrderNotificationPublisher()).Notify(Event);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MessageEnvelopeBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MessageEnvelopeBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "MessageEnvelope")]
+public class MessageEnvelopeBenchmarks
+{
+    private static readonly OrderAccepted Accepted = new("order-42", 199.95m);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create message envelope")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Message<OrderAccepted> Fluent_CreateMessageEnvelope()
+        => Message<OrderAccepted>
+            .Create(Accepted)
+            .WithMessageId("msg-100")
+            .WithCorrelationId("order-42")
+            .WithCausationId("checkout-7")
+            .WithIdempotencyKey("order-42:accepted")
+            .WithContentType("application/vnd.patternkit.order+json");
+
+    [Benchmark(Description = "Generated: create message envelope")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Message<OrderAccepted> Generated_CreateMessageEnvelope()
+        => GeneratedOrderAcceptedEnvelope.CreateAccepted(
+            Accepted,
+            "msg-100",
+            "order-42",
+            "checkout-7",
+            "order-42:accepted",
+            "application/vnd.patternkit.order+json");
+
+    [Benchmark(Description = "Fluent: enrich message context")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public Summary Fluent_EnrichMessageContext()
+        => MessageEnvelopeExample.RunFluent();
+
+    [Benchmark(Description = "Generated: enrich message context")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public Summary Generated_EnrichMessageContext()
+        => MessageEnvelopeExample.RunGenerated();
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MessageStoreBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MessageStoreBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Storage;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "MessageStore")]
+public class MessageStoreBenchmarks
+{
+    private static readonly OrderMessageStoreEvent Event = new("O-100", "accepted", 149.95m, false);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create message store")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public MessageStore<OrderMessageStoreEvent> Fluent_CreateMessageStore()
+        => OrderMessageStores.CreateAuditStore();
+
+    [Benchmark(Description = "Generated: create message store")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public MessageStore<OrderMessageStoreEvent> Generated_CreateMessageStore()
+        => GeneratedOrderMessageStore.Create();
+
+    [Benchmark(Description = "Fluent: record and replay order event")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderMessageStoreSummary Fluent_RecordAndReplayOrderEvent()
+        => OrderMessageStoreExampleRunner.RunFluent(Event, "msg-100", "corr-100");
+
+    [Benchmark(Description = "Generated: record and replay order event")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderMessageStoreSummary Generated_RecordAndReplayOrderEvent()
+        => new OrderMessageStoreService(GeneratedOrderMessageStore.Create()).Record(Event, "msg-100", "corr-100");
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -35,6 +35,12 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
+| Event-Carried State Transfer | Construction | 7.552 ns | 48 B | 6.751 ns | 48 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Event-Carried State Transfer | Execution | 58.508 ns | 448 B | 59.071 ns | 448 B | Effectively equivalent for the inventory projection workflow. |
+| Event Notification | Construction | 30.920 ns | 232 B | 31.926 ns | 232 B | Effectively equivalent for this microbenchmark. |
+| Event Notification | Execution | 93.209 ns | 704 B | 106.973 ns | 704 B | Same allocation; fluent was faster for order notification publishing. |
+| Event-Driven Consumer | Construction | 41.394 ns | 336 B | 25.216 ns | 192 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -49,10 +55,14 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
 | Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
+| Message Envelope | Construction | 248.580 ns | 1,688 B | 228.019 ns | 1,688 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Message Envelope | Execution | 455.486 ns | 2,752 B | 427.664 ns | 2,752 B | Same allocation; generated was slightly faster for message context enrichment. |
 | Message Filter | Construction | 25.431 ns | 232 B | 25.626 ns | 232 B | Effectively equivalent for this microbenchmark. |
 | Message Filter | Execution | 44.637 ns | 424 B | 45.826 ns | 424 B | Same allocation; fluent was slightly faster for order fraud screening. |
 | Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
 | Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
+| Message Store | Construction | 18.824 ns | 216 B | 18.721 ns | 216 B | Effectively equivalent for this microbenchmark. |
+| Message Store | Execution | 274.799 ns | 1,576 B | 265.470 ns | 1,576 B | Same allocation; generated was slightly faster for record-and-replay lookup. |
 | Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
 | Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -52,6 +52,12 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
+| Event-Carried State Transfer | Construction | 7.552 ns | 48 B | 6.751 ns | 48 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Event-Carried State Transfer | Execution | 58.508 ns | 448 B | 59.071 ns | 448 B | Effectively equivalent for the inventory projection workflow. |
+| Event Notification | Construction | 30.920 ns | 232 B | 31.926 ns | 232 B | Effectively equivalent for this microbenchmark. |
+| Event Notification | Execution | 93.209 ns | 704 B | 106.973 ns | 704 B | Same allocation; fluent was faster for order notification publishing. |
+| Event-Driven Consumer | Construction | 41.394 ns | 336 B | 25.216 ns | 192 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -66,10 +72,14 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
 | Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
+| Message Envelope | Construction | 248.580 ns | 1,688 B | 228.019 ns | 1,688 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Message Envelope | Execution | 455.486 ns | 2,752 B | 427.664 ns | 2,752 B | Same allocation; generated was slightly faster for message context enrichment. |
 | Message Filter | Construction | 25.431 ns | 232 B | 25.626 ns | 232 B | Effectively equivalent for this microbenchmark. |
 | Message Filter | Execution | 44.637 ns | 424 B | 45.826 ns | 424 B | Same allocation; fluent was slightly faster for order fraud screening. |
 | Message Routing | Construction | 23.42 ns | 224 B | 23.33 ns | 224 B | Effectively equivalent for this microbenchmark. |
 | Message Routing | Execution | 707.34 ns | 4,744 B | 679.97 ns | 4,632 B | Generated reduced execution time and allocation for the route/split/aggregate workflow. |
+| Message Store | Construction | 18.824 ns | 216 B | 18.721 ns | 216 B | Effectively equivalent for this microbenchmark. |
+| Message Store | Execution | 274.799 ns | 1,576 B | 265.470 ns | 1,576 B | Same allocation; generated was slightly faster for record-and-replay lookup. |
 | Message Translator | Construction | 39.49 ns | 424 B | 39.65 ns | 424 B | Effectively equivalent for this microbenchmark. |
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
 | Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -172,6 +172,12 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
         if (patternName == "PipesAndFilters")
             return "Pipes and Filters";
 
+        if (patternName == "EventCarriedStateTransfer")
+            return "Event-Carried State Transfer";
+
+        if (patternName == "EventDrivenConsumer")
+            return "Event-Driven Consumer";
+
         var chars = new List<char>(patternName.Length + 4);
         for (var index = 0; index < patternName.Length; index++)
         {


### PR DESCRIPTION
## Summary
- Adds dedicated BenchmarkDotNet scenario coverage for Event Notification, Event-Carried State Transfer, Event-Driven Consumer, Message Envelope, and Message Store.
- Publishes fluent vs source-generated construction/execution timings in the README and benchmark docs.
- Extends the production-readiness benchmark coverage guard for hyphenated event pattern names.

## Benchmark Results
Captured on Windows 11, Intel Core i9-14900K, .NET SDK 10.0.108, .NET 10.0.8, BenchmarkDotNet 0.15.8, current-tfm short job.

| Pattern | Phase | Fluent | Fluent alloc | Generated | Generated alloc | Signal |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Event-Carried State Transfer | Construction | 7.552 ns | 48 B | 6.751 ns | 48 B | Same allocation; generated slightly faster. |
| Event-Carried State Transfer | Execution | 58.508 ns | 448 B | 59.071 ns | 448 B | Effectively equivalent. |
| Event Notification | Construction | 30.920 ns | 232 B | 31.926 ns | 232 B | Effectively equivalent. |
| Event Notification | Execution | 93.209 ns | 704 B | 106.973 ns | 704 B | Same allocation; fluent faster. |
| Event-Driven Consumer | Construction | 41.394 ns | 336 B | 25.216 ns | 192 B | Generated faster and lower allocation. |
| Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated faster and lower allocation. |
| Message Envelope | Construction | 248.580 ns | 1,688 B | 228.019 ns | 1,688 B | Same allocation; generated slightly faster. |
| Message Envelope | Execution | 455.486 ns | 2,752 B | 427.664 ns | 2,752 B | Same allocation; generated slightly faster. |
| Message Store | Construction | 18.824 ns | 216 B | 18.721 ns | 216 B | Effectively equivalent. |
| Message Store | Execution | 274.799 ns | 1,576 B | 265.470 ns | 1,576 B | Same allocation; generated slightly faster. |

## Validation
- `dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore`
- `dotnet run -c Release --framework net10.0 --project benchmarks\PatternKit.Benchmarks -- --filter *EventNotificationBenchmarks* *EventCarriedStateTransferBenchmarks* *EventDrivenConsumerBenchmarks* *MessageEnvelopeBenchmarks* *MessageStoreBenchmarks* --artifacts artifacts\benchmarks --join --job short`
- `dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore`
- `dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"`
- `git diff --check`

Refs #331