### PR TITLE
test: add messaging routing scenario benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 
 | Pattern | Phase | Fluent mean | Fluent allocation | Generated mean | Generated allocation | Read |
 | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -480,6 +482,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Competing Consumers | Execution | 75.34 ns | 416 B | 75.23 ns | 416 B | Effectively equivalent for the fulfillment dispatch workflow. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
+| Content-Based Router | Construction | 42.913 ns | 400 B | 44.118 ns | 400 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Content-Based Router | Execution | 52.789 ns | 520 B | 60.816 ns | 576 B | Fluent was faster and allocated less for wholesale order routing. |
 | Control Bus | Construction | 115.64 ns | 880 B | 79.88 ns | 624 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Control Bus | Execution | 290.44 ns | 1,688 B | 232.48 ns | 1,432 B | Generated reduced execution time and allocation for operational command dispatch. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -526,10 +530,14 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
+| Recipient List | Construction | 30.304 ns | 288 B | 30.380 ns | 288 B | Effectively equivalent for this microbenchmark. |
+| Recipient List | Execution | 123.057 ns | 992 B | 120.325 ns | 968 B | Generated was slightly faster and allocated slightly less for shipment fan-out. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
 | Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
+| Routing Slip | Construction | 35.508 ns | 256 B | 32.448 ns | 256 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |
@@ -550,6 +558,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
+| Splitter | Construction | 3.664 ns | 24 B | 4.020 ns | 24 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Splitter | Execution | 135.516 ns | 808 B | 134.062 ns | 832 B | Generated was slightly faster; fluent allocated slightly less for order line splitting. |
 | Strangler Fig | Construction | 53.71 ns | 416 B | 42.35 ns | 288 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Strangler Fig | Execution | 24.64 ns | 200 B | 20.50 ns | 168 B | Generated reduced execution time and allocation for the enterprise checkout routing workflow. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Messaging/AggregatorBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/AggregatorBenchmarks.cs
@@ -1,0 +1,52 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "Aggregator")]
+public class AggregatorBenchmarks
+{
+    private static readonly Message<RoutedLine> FirstLine = Message<RoutedLine>
+        .Create(new RoutedLine("sku-1", 30m))
+        .WithMessageId("line:sku-1")
+        .WithCorrelationId("order-42");
+
+    private static readonly Message<RoutedLine> SecondLine = Message<RoutedLine>
+        .Create(new RoutedLine("sku-2", 70m))
+        .WithMessageId("line:sku-2")
+        .WithCorrelationId("order-42");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create aggregator")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Aggregator<string, RoutedLine, decimal> Fluent_CreateAggregator()
+        => Aggregator<string, RoutedLine, decimal>.Create()
+            .KeyBy(static (message, _) => message.Headers.CorrelationId ?? message.Payload.Sku)
+            .CompleteWhen(static (_, messages, _) => messages.Count == 2)
+            .Project(static (_, messages, _) => messages.Sum(message => message.Payload.Amount))
+            .Build();
+
+    [Benchmark(Description = "Generated: create aggregator")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Aggregator<string, RoutedLine, decimal> Generated_CreateAggregator()
+        => GeneratedOrderLineAggregator.CreateLineTotalAggregator();
+
+    [Benchmark(Description = "Fluent: aggregate order lines")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public AggregationResult<string, decimal> Fluent_AggregateOrderLines()
+    {
+        var aggregator = Fluent_CreateAggregator();
+        aggregator.Add(FirstLine);
+        return aggregator.Add(SecondLine);
+    }
+
+    [Benchmark(Description = "Generated: aggregate order lines")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public AggregationResult<string, decimal> Generated_AggregateOrderLines()
+    {
+        var aggregator = GeneratedOrderLineAggregator.CreateLineTotalAggregator();
+        aggregator.Add(FirstLine);
+        return aggregator.Add(SecondLine);
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/ContentBasedRouterBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/ContentBasedRouterBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "ContentBasedRouter")]
+public class ContentBasedRouterBenchmarks
+{
+    private static readonly Message<GeneratedOrder> WholesaleOrder = Message<GeneratedOrder>.Create(new("wholesale"));
+
+    [Benchmark(Baseline = true, Description = "Fluent: create content-based router")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public ContentRouter<GeneratedOrder, string> Fluent_CreateContentBasedRouter()
+        => ContentRouter<GeneratedOrder, string>.Create()
+            .When(static (message, _) => message.Payload.Channel == "wholesale")
+            .Then(static (_, _) => "wholesale")
+            .When(static (message, _) => message.Payload.Channel == "retail")
+            .Then(static (_, _) => "retail")
+            .Default(static (_, _) => "default")
+            .Build();
+
+    [Benchmark(Description = "Generated: create content-based router")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public ContentRouter<GeneratedOrder, string> Generated_CreateContentBasedRouter()
+        => GeneratedOrderRouter.Create();
+
+    [Benchmark(Description = "Fluent: route wholesale order")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public string Fluent_RouteWholesaleOrder()
+        => Fluent_CreateContentBasedRouter().Route(WholesaleOrder);
+
+    [Benchmark(Description = "Generated: route wholesale order")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public string Generated_RouteWholesaleOrder()
+        => ContentRouterGeneratorExample.Run("wholesale");
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/RecipientListBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/RecipientListBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "RecipientList")]
+public class RecipientListBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create recipient list")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public RecipientList<GeneratedShipmentEvent> Fluent_CreateRecipientList()
+        => RecipientList<GeneratedShipmentEvent>.Create()
+            .When("priority-audit", static (message, _) => message.Payload.Priority == "priority")
+            .Then(static (_, _) => { })
+            .When("billing-ledger", static (message, _) => message.Payload.Total >= 100m)
+            .Then(static (_, _) => { })
+            .Build();
+
+    [Benchmark(Description = "Generated: create recipient list")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public RecipientList<GeneratedShipmentEvent> Generated_CreateRecipientList()
+        => GeneratedShipmentRecipients.Create();
+
+    [Benchmark(Description = "Fluent: dispatch shipment event")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public RecipientListSummary Fluent_DispatchShipmentEvent()
+        => RecipientListGeneratorExample.RunFluent();
+
+    [Benchmark(Description = "Generated: dispatch shipment event")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public RecipientListSummary Generated_DispatchShipmentEvent()
+        => RecipientListGeneratorExample.RunGenerated();
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/RoutingSlipBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/RoutingSlipBenchmarks.cs
@@ -1,0 +1,48 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "RoutingSlip")]
+public class RoutingSlipBenchmarks
+{
+    private static readonly Message<FulfillmentOrder> Order = Message<FulfillmentOrder>.Create(new("order-42", "new"));
+
+    [Benchmark(Baseline = true, Description = "Fluent: create routing slip")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public RoutingSlip<FulfillmentOrder> Fluent_CreateRoutingSlip()
+        => CreateFluentRoutingSlip();
+
+    [Benchmark(Description = "Generated: create routing slip")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public RoutingSlip<FulfillmentOrder> Generated_CreateRoutingSlip()
+        => OrderFulfillmentSlip.Create();
+
+    [Benchmark(Description = "Fluent: execute fulfillment itinerary")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public RoutingSlipSummary Fluent_ExecuteFulfillmentItinerary()
+    {
+        var result = CreateFluentRoutingSlip().Execute(Order);
+        return ToSummary(result);
+    }
+
+    [Benchmark(Description = "Generated: execute fulfillment itinerary")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public RoutingSlipSummary Generated_ExecuteFulfillmentItinerary()
+        => RoutingSlipExample.Run();
+
+    private static RoutingSlip<FulfillmentOrder> CreateFluentRoutingSlip()
+        => RoutingSlip<FulfillmentOrder>.Create()
+            .Step("validate", static (message, _) => message.WithPayload(message.Payload with { Status = "validated" }))
+            .Step("reserve-inventory", static (message, _) => message.WithPayload(message.Payload with { Status = $"{message.Payload.Status},reserved" }))
+            .Step("ship", static (message, _) => message.WithPayload(message.Payload with { Status = $"{message.Payload.Status},shipped" }))
+            .Build();
+
+    private static RoutingSlipSummary ToSummary(RoutingSlipResult<FulfillmentOrder> result)
+        => new(
+            result.Message.Payload.Status,
+            result.CompletedSteps.ToArray(),
+            result.Message.Headers.GetString(MessageHeaderNames.RoutingSlipIndex)!);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/SplitterBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/SplitterBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Routing;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "Splitter")]
+public class SplitterBenchmarks
+{
+    private static readonly Message<RoutedOrder> Order = Message<RoutedOrder>
+        .Create(new RoutedOrder("order-42", "enterprise", [
+            new RoutedLine("sku-1", 30m),
+            new RoutedLine("sku-2", 70m)
+        ]))
+        .WithMessageId("msg-order-42")
+        .WithCorrelationId("order-42");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create splitter")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Splitter<RoutedOrder, RoutedLine> Fluent_CreateSplitter()
+        => Splitter<RoutedOrder, RoutedLine>.Create()
+            .Use(static (message, _) => message.Payload.Lines)
+            .Build();
+
+    [Benchmark(Description = "Generated: create splitter")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Splitter<RoutedOrder, RoutedLine> Generated_CreateSplitter()
+        => GeneratedOrderLineSplitter.CreateLineSplitter();
+
+    [Benchmark(Description = "Fluent: split order lines")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public IReadOnlyList<Message<RoutedLine>> Fluent_SplitOrderLines()
+        => Fluent_CreateSplitter().Split(Order);
+
+    [Benchmark(Description = "Generated: split order lines")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public IReadOnlyList<Message<RoutedLine>> Generated_SplitOrderLines()
+        => GeneratedOrderLineSplitter.CreateLineSplitter().Split(Order);
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -11,6 +11,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 
 | Pattern | Phase | Fluent mean | Fluent allocation | Generated mean | Generated allocation | Decision signal |
 | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -27,6 +29,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Competing Consumers | Execution | 75.34 ns | 416 B | 75.23 ns | 416 B | Effectively equivalent for the fulfillment dispatch workflow. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
+| Content-Based Router | Construction | 42.913 ns | 400 B | 44.118 ns | 400 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Content-Based Router | Execution | 52.789 ns | 520 B | 60.816 ns | 576 B | Fluent was faster and allocated less for wholesale order routing. |
 | Control Bus | Construction | 115.64 ns | 880 B | 79.88 ns | 624 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Control Bus | Execution | 290.44 ns | 1,688 B | 232.48 ns | 1,432 B | Generated reduced execution time and allocation for operational command dispatch. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -73,10 +77,14 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
+| Recipient List | Construction | 30.304 ns | 288 B | 30.380 ns | 288 B | Effectively equivalent for this microbenchmark. |
+| Recipient List | Execution | 123.057 ns | 992 B | 120.325 ns | 968 B | Generated was slightly faster and allocated slightly less for shipment fan-out. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
 | Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
+| Routing Slip | Construction | 35.508 ns | 256 B | 32.448 ns | 256 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |
@@ -97,6 +105,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
+| Splitter | Construction | 3.664 ns | 24 B | 4.020 ns | 24 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Splitter | Execution | 135.516 ns | 808 B | 134.062 ns | 832 B | Generated was slightly faster; fluent allocated slightly less for order line splitting. |
 | Strangler Fig | Construction | 53.71 ns | 416 B | 42.35 ns | 288 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Strangler Fig | Execution | 24.64 ns | 200 B | 20.50 ns | 168 B | Generated reduced execution time and allocation for the enterprise checkout routing workflow. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -28,6 +28,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 
 | Pattern | Phase | Fluent mean | Fluent allocation | Generated mean | Generated allocation | Decision signal |
 | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -44,6 +46,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Competing Consumers | Execution | 75.34 ns | 416 B | 75.23 ns | 416 B | Effectively equivalent for the fulfillment dispatch workflow. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
+| Content-Based Router | Construction | 42.913 ns | 400 B | 44.118 ns | 400 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Content-Based Router | Execution | 52.789 ns | 520 B | 60.816 ns | 576 B | Fluent was faster and allocated less for wholesale order routing. |
 | Control Bus | Construction | 115.64 ns | 880 B | 79.88 ns | 624 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Control Bus | Execution | 290.44 ns | 1,688 B | 232.48 ns | 1,432 B | Generated reduced execution time and allocation for operational command dispatch. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -90,10 +94,14 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
+| Recipient List | Construction | 30.304 ns | 288 B | 30.380 ns | 288 B | Effectively equivalent for this microbenchmark. |
+| Recipient List | Execution | 123.057 ns | 992 B | 120.325 ns | 968 B | Generated was slightly faster and allocated slightly less for shipment fan-out. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
 | Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
+| Routing Slip | Construction | 35.508 ns | 256 B | 32.448 ns | 256 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |
@@ -114,6 +122,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Service Layer | Execution | 151.32 ns | 960 B | 148.10 ns | 872 B | Generated slightly reduced execution time and allocation for the register-customer workflow. |
 | Specification | Construction | 196.03 ns | 1,704 B | 136.87 ns | 1,008 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Specification | Execution | 111.25 ns | 344 B | 93.30 ns | 344 B | Same allocation; generated was faster for loan-application evaluation. |
+| Splitter | Construction | 3.664 ns | 24 B | 4.020 ns | 24 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Splitter | Execution | 135.516 ns | 808 B | 134.062 ns | 832 B | Generated was slightly faster; fluent allocated slightly less for order line splitting. |
 | Strangler Fig | Construction | 53.71 ns | 416 B | 42.35 ns | 288 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Strangler Fig | Execution | 24.64 ns | 200 B | 20.50 ns | 168 B | Generated reduced execution time and allocation for the enterprise checkout routing workflow. |
 | Table Data Gateway | Construction | 9.740 ns | 120 B | 9.698 ns | 120 B | Effectively equivalent for this microbenchmark. |

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -178,6 +178,9 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
         if (patternName == "EventDrivenConsumer")
             return "Event-Driven Consumer";
 
+        if (patternName == "ContentBasedRouter")
+            return "Content-Based Router";
+
         var chars = new List<char>(patternName.Length + 4);
         for (var index = 0; index < patternName.Length; index++)
         {


### PR DESCRIPTION
## Summary
- Adds dedicated BenchmarkDotNet scenario coverage for Aggregator, Content-Based Router, Recipient List, Routing Slip, and Splitter.
- Publishes fluent vs source-generated construction/execution timing rows in README and benchmark docs.
- Extends the benchmark coverage guard name mapping for `ContentBasedRouterBenchmarks`.

## Benchmark Results
Captured on Windows 11, Intel Core i9-14900K, .NET SDK 10.0.108, .NET 10.0.8, BenchmarkDotNet 0.15.8, current-tfm job.

| Pattern | Phase | Fluent | Fluent alloc | Generated | Generated alloc | Signal |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent slightly faster. |
| Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent faster. |
| Content-Based Router | Construction | 42.913 ns | 400 B | 44.118 ns | 400 B | Same allocation; fluent slightly faster. |
| Content-Based Router | Execution | 52.789 ns | 520 B | 60.816 ns | 576 B | Fluent faster and lower allocation. |
| Recipient List | Construction | 30.304 ns | 288 B | 30.380 ns | 288 B | Effectively equivalent. |
| Recipient List | Execution | 123.057 ns | 992 B | 120.325 ns | 968 B | Generated slightly faster and lower allocation. |
| Routing Slip | Construction | 35.508 ns | 256 B | 32.448 ns | 256 B | Same allocation; generated slightly faster. |
| Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated slightly faster; fluent lower allocation. |
| Splitter | Construction | 3.664 ns | 24 B | 4.020 ns | 24 B | Same allocation; fluent slightly faster. |
| Splitter | Execution | 135.516 ns | 808 B | 134.062 ns | 832 B | Generated slightly faster; fluent lower allocation. |

## Validation
- `dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore`
- BenchmarkDotNet current-tfm/short runs for Aggregator, ContentBasedRouter, RecipientList, RoutingSlip, and Splitter benchmark classes
- `dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore`
- `dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"`
- `git diff --check`

Refs #331