### PR TITLE
test: add messaging workflow benchmark coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Canonical Data Model | Construction | 75.482 ns | 632 B | 59.947 ns | 496 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Canonical Data Model | Execution | 116.680 ns | 832 B | 92.082 ns | 696 B | Generated reduced execution time and allocation for order normalization. |
 | Channel Adapter | Construction | 38.469 ns | 384 B | 38.681 ns | 384 B | Effectively equivalent for this microbenchmark. |
 | Channel Adapter | Execution | 204.907 ns | 888 B | 198.374 ns | 888 B | Same allocation; generated was slightly faster for the ERP order document round-trip workflow. |
 | Claim Check | Construction | 111.92 ns | 1,664 B | 110.71 ns | 1,664 B | Effectively equivalent for this microbenchmark. |
@@ -506,10 +508,16 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Gateway Routing | Execution | 23.63 ns | 200 B | 20.13 ns | 168 B | Generated reduced execution time and allocation for the inventory routing workflow. |
 | Health Endpoint Monitoring | Construction | 35.68 ns | 264 B | 35.25 ns | 264 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Health Endpoint Monitoring | Execution | 38.50 ns | 248 B | 31.67 ns | 248 B | Same allocation; generated was faster for the fulfillment health evaluation workflow. |
+| Idempotent Receiver | Construction | 17.022 ns | 184 B | 17.021 ns | 184 B | Effectively equivalent for this microbenchmark. |
+| Idempotent Receiver | Execution | 99.419 ns | 608 B | 99.051 ns | 608 B | Effectively equivalent for idempotent command handling. |
+| Inbox | Construction | 22.259 ns | 208 B | 21.675 ns | 208 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Inbox | Execution | 113.126 ns | 632 B | 110.770 ns | 608 B | Generated reduced execution time and allocation for inbox command processing. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
+| Mailbox | Construction | 17.030 ns | 216 B | 29.867 ns | 360 B | Fluent was faster and allocated less for disposable mailbox construction. |
+| Mailbox | Execution | 1.856 us | 2,620 B | 1.956 us | 2,474 B | Generated allocated less, while fluent was faster for serialized mailbox processing. |
 | Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
 | Message Envelope | Construction | 248.580 ns | 1,688 B | 228.019 ns | 1,688 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -524,6 +532,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
 | Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |
 | Messaging Gateway | Execution | 66.597 ns | 560 B | 67.558 ns | 560 B | Same allocation; fluent was slightly faster for payment authorization. |
+| Outbox | Construction | 9.544 ns | 88 B | 9.672 ns | 88 B | Effectively equivalent for this microbenchmark. |
+| Outbox | Execution | 118.307 ns | 424 B | 122.972 ns | 424 B | Same allocation; fluent was slightly faster for enqueue-and-dispatch processing. |
 | Pipes and Filters | Construction | 32.99 ns | 264 B | 32.98 ns | 264 B | Effectively equivalent for this microbenchmark. |
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
@@ -538,6 +548,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Routing Slip | Construction | 35.508 ns | 256 B | 32.448 ns | 256 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
+| Saga / Process Manager | Construction | 39.453 ns | 272 B | 42.138 ns | 272 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Saga / Process Manager | Execution | 89.969 ns | 672 B | 105.648 ns | 784 B | Fluent was faster and allocated less for the order saga workflow. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Messaging/CanonicalDataModelBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/CanonicalDataModelBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.EnterpriseIntegration.CanonicalDataModel;
+using PatternKit.Examples.CanonicalDataModelDemo;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "CanonicalDataModel")]
+public class CanonicalDataModelBenchmarks
+{
+    private static readonly MarketplaceOrderDocument MarketplaceOrder = new("M-200", 7500, "usd");
+    private static readonly PartnerOrderDocument PartnerOrder = new("P-100", 42.50m, "usd");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create canonical data model")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public CanonicalDataModel<CanonicalCommerceOrder> Fluent_CreateModel()
+        => CanonicalOrderModels.CreateFluent();
+
+    [Benchmark(Description = "Generated: create canonical data model")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public CanonicalDataModel<CanonicalCommerceOrder> Generated_CreateModel()
+        => GeneratedPartnerOrderCanonicalDataModel.Create();
+
+    [Benchmark(Description = "Fluent: normalize marketplace order")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public CanonicalOrderSummary Fluent_NormalizeMarketplaceOrder()
+    {
+        var result = CanonicalOrderModels.CreateFluent().Normalize(MarketplaceOrder);
+        var canonical = result.Value!;
+        return new(result.ModelName, result.AdapterName, canonical.OrderId, canonical.Total, canonical.Currency);
+    }
+
+    [Benchmark(Description = "Generated: normalize partner order")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public CanonicalOrderSummary Generated_NormalizePartnerOrder()
+    {
+        var result = GeneratedPartnerOrderCanonicalDataModel.Create().Normalize(PartnerOrder);
+        var canonical = result.Value!;
+        return new(result.ModelName, result.AdapterName, canonical.OrderId, canonical.Total, canonical.Currency);
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/IdempotentReceiverBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/IdempotentReceiverBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Reliability;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("MessagingReliability", "Messaging", "IdempotentReceiver")]
+public class IdempotentReceiverBenchmarks
+{
+    private static readonly Message<AcceptOrder> Command = Message<AcceptOrder>
+        .Create(new AcceptOrder("order-42"))
+        .WithIdempotencyKey("accept-order-42");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create idempotent receiver")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public IdempotentReceiver<AcceptOrder, string> Fluent_CreateReceiver()
+        => IdempotentReceiver<AcceptOrder, string>.Create(
+                new InMemoryIdempotencyStore(),
+                static (message, _, _) => new ValueTask<string>(message.Payload.OrderId))
+            .OnDuplicate(DuplicateMessagePolicy.ReplayCompleted)
+            .Build();
+
+    [Benchmark(Description = "Generated: create idempotent receiver")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IdempotentReceiver<AcceptOrder, string> Generated_CreateReceiver()
+        => GeneratedReliabilityOrderPipeline.CreateOrderReceiver(new InMemoryIdempotencyStore());
+
+    [Benchmark(Description = "Fluent: handle idempotent command")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<IdempotentReceiverResult<string>> Fluent_HandleCommand()
+        => Fluent_CreateReceiver().HandleAsync(Command);
+
+    [Benchmark(Description = "Generated: handle idempotent command")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<IdempotentReceiverResult<string>> Generated_HandleCommand()
+        => GeneratedReliabilityOrderPipeline.CreateOrderReceiver(new InMemoryIdempotencyStore()).HandleAsync(Command);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/InboxBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/InboxBenchmarks.cs
@@ -1,0 +1,39 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Reliability;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("MessagingReliability", "Messaging", "Inbox")]
+public class InboxBenchmarks
+{
+    private static readonly Message<AcceptOrder> Command = Message<AcceptOrder>
+        .Create(new AcceptOrder("order-42"))
+        .WithIdempotencyKey("accept-order-42");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create inbox")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public InboxProcessor<AcceptOrder, string> Fluent_CreateInbox()
+        => InboxProcessor<AcceptOrder, string>.Create(
+            IdempotentReceiver<AcceptOrder, string>.Create(
+                    new InMemoryIdempotencyStore(),
+                    static (message, _, _) => new ValueTask<string>(message.Payload.OrderId))
+                .OnDuplicate(DuplicateMessagePolicy.ReplayCompleted)
+                .Build());
+
+    [Benchmark(Description = "Generated: create inbox")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public InboxProcessor<AcceptOrder, string> Generated_CreateInbox()
+        => GeneratedReliabilityOrderPipeline.CreateInbox(new InMemoryIdempotencyStore());
+
+    [Benchmark(Description = "Fluent: process inbox command")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<IdempotentReceiverResult<string>> Fluent_ProcessCommand()
+        => Fluent_CreateInbox().ProcessAsync(Command);
+
+    [Benchmark(Description = "Generated: process inbox command")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<IdempotentReceiverResult<string>> Generated_ProcessCommand()
+        => GeneratedReliabilityOrderPipeline.CreateInbox(new InMemoryIdempotencyStore()).ProcessAsync(Command);
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/MailboxBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/MailboxBenchmarks.cs
@@ -1,0 +1,39 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging.Mailboxes;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "Mailbox")]
+public class MailboxBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create mailbox")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public int Fluent_CreateMailbox()
+    {
+        using var mailbox = Mailbox<MailboxWorkItem>.Create(static (_, _, _) => default)
+            .Bounded(8, MailboxBackpressurePolicy.Wait)
+            .OnError(MailboxErrorPolicy.Continue)
+            .Build();
+
+        return 8;
+    }
+
+    [Benchmark(Description = "Generated: create mailbox")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public int Generated_CreateMailbox()
+    {
+        using var mailbox = GeneratedMailboxWorkQueue.CreateWorkQueue();
+        return 8;
+    }
+
+    [Benchmark(Description = "Fluent: process mailbox work")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<IReadOnlyList<string>> Fluent_ProcessMailboxWork()
+        => MailboxExample.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: process mailbox work")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<IReadOnlyList<string>> Generated_ProcessMailboxWork()
+        => MailboxExample.RunGeneratedAsync();
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/OutboxBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/OutboxBenchmarks.cs
@@ -1,0 +1,49 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Reliability;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("MessagingReliability", "Messaging", "Outbox")]
+public class OutboxBenchmarks
+{
+    private static readonly Message<ReliabilityOrderAccepted> Accepted = Message<ReliabilityOrderAccepted>
+        .Create(new ReliabilityOrderAccepted("order-42"));
+
+    private static readonly RecordingOutboxDispatcher Dispatcher = new();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create outbox")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public InMemoryOutbox<ReliabilityOrderAccepted> Fluent_CreateOutbox()
+        => new();
+
+    [Benchmark(Description = "Generated: create outbox")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public InMemoryOutbox<ReliabilityOrderAccepted> Generated_CreateOutbox()
+        => GeneratedReliabilityOrderPipeline.CreateOutbox();
+
+    [Benchmark(Description = "Fluent: enqueue and dispatch outbox")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public async ValueTask<int> Fluent_EnqueueAndDispatch()
+    {
+        var outbox = new InMemoryOutbox<ReliabilityOrderAccepted>();
+        await outbox.EnqueueAsync(Accepted, id: "accepted-order-42");
+        return await outbox.DispatchPendingAsync(Dispatcher);
+    }
+
+    [Benchmark(Description = "Generated: enqueue and dispatch outbox")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public async ValueTask<int> Generated_EnqueueAndDispatch()
+    {
+        var outbox = GeneratedReliabilityOrderPipeline.CreateOutbox();
+        await outbox.EnqueueAsync(Accepted, id: "accepted-order-42");
+        return await outbox.DispatchPendingAsync(Dispatcher);
+    }
+
+    private sealed class RecordingOutboxDispatcher : IOutboxDispatcher<ReliabilityOrderAccepted>
+    {
+        public ValueTask DispatchAsync(OutboxMessage<ReliabilityOrderAccepted> message, CancellationToken cancellationToken = default)
+            => default;
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Messaging/SagaProcessManagerBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/SagaProcessManagerBenchmarks.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Sagas;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "SagaProcessManager")]
+public class SagaProcessManagerBenchmarks
+{
+    private static readonly Message<OrderSubmitted> Submitted = Message<OrderSubmitted>.Create(new("order-42"));
+    private static readonly Message<OrderPaid> Paid = Message<OrderPaid>.Create(new("order-42"));
+
+    [Benchmark(Baseline = true, Description = "Fluent: create saga")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Saga<OrderSagaState> Fluent_CreateSaga()
+        => Saga<OrderSagaState>.Create()
+            .On<OrderSubmitted>()
+            .Then(static (state, message, _) => state with { OrderId = message.Payload.OrderId, Submitted = true })
+            .On<OrderPaid>()
+            .Then(static (state, message, _) => state.OrderId == message.Payload.OrderId ? state with { Paid = true } : state)
+            .CompleteWhen(static state => state.Submitted && state.Paid)
+            .Build();
+
+    [Benchmark(Description = "Generated: create saga")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Saga<OrderSagaState> Generated_CreateSaga()
+        => OrderSaga.Create();
+
+    [Benchmark(Description = "Fluent: complete order saga")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public SagaSummary Fluent_CompleteOrderSaga()
+    {
+        var saga = Fluent_CreateSaga();
+        var started = saga.Handle(OrderSagaState.Empty, Submitted);
+        var paid = saga.Handle(started.State, Paid);
+        return new(paid.State.OrderId!, paid.State.Submitted, paid.State.Paid, paid.Completed);
+    }
+
+    [Benchmark(Description = "Generated: complete order saga")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public SagaSummary Generated_CompleteOrderSaga()
+        => SagaExample.Run();
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -21,6 +21,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Canonical Data Model | Construction | 75.482 ns | 632 B | 59.947 ns | 496 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Canonical Data Model | Execution | 116.680 ns | 832 B | 92.082 ns | 696 B | Generated reduced execution time and allocation for order normalization. |
 | Channel Adapter | Construction | 38.469 ns | 384 B | 38.681 ns | 384 B | Effectively equivalent for this microbenchmark. |
 | Channel Adapter | Execution | 204.907 ns | 888 B | 198.374 ns | 888 B | Same allocation; generated was slightly faster for the ERP order document round-trip workflow. |
 | Claim Check | Construction | 111.92 ns | 1,664 B | 110.71 ns | 1,664 B | Effectively equivalent for this microbenchmark. |
@@ -53,10 +55,16 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Gateway Routing | Execution | 23.63 ns | 200 B | 20.13 ns | 168 B | Generated reduced execution time and allocation for the inventory routing workflow. |
 | Health Endpoint Monitoring | Construction | 35.68 ns | 264 B | 35.25 ns | 264 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Health Endpoint Monitoring | Execution | 38.50 ns | 248 B | 31.67 ns | 248 B | Same allocation; generated was faster for the fulfillment health evaluation workflow. |
+| Idempotent Receiver | Construction | 17.022 ns | 184 B | 17.021 ns | 184 B | Effectively equivalent for this microbenchmark. |
+| Idempotent Receiver | Execution | 99.419 ns | 608 B | 99.051 ns | 608 B | Effectively equivalent for idempotent command handling. |
+| Inbox | Construction | 22.259 ns | 208 B | 21.675 ns | 208 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Inbox | Execution | 113.126 ns | 632 B | 110.770 ns | 608 B | Generated reduced execution time and allocation for inbox command processing. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
+| Mailbox | Construction | 17.030 ns | 216 B | 29.867 ns | 360 B | Fluent was faster and allocated less for disposable mailbox construction. |
+| Mailbox | Execution | 1.856 us | 2,620 B | 1.956 us | 2,474 B | Generated allocated less, while fluent was faster for serialized mailbox processing. |
 | Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
 | Message Envelope | Construction | 248.580 ns | 1,688 B | 228.019 ns | 1,688 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -71,6 +79,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
 | Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |
 | Messaging Gateway | Execution | 66.597 ns | 560 B | 67.558 ns | 560 B | Same allocation; fluent was slightly faster for payment authorization. |
+| Outbox | Construction | 9.544 ns | 88 B | 9.672 ns | 88 B | Effectively equivalent for this microbenchmark. |
+| Outbox | Execution | 118.307 ns | 424 B | 122.972 ns | 424 B | Same allocation; fluent was slightly faster for enqueue-and-dispatch processing. |
 | Pipes and Filters | Construction | 32.99 ns | 264 B | 32.98 ns | 264 B | Effectively equivalent for this microbenchmark. |
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
@@ -85,6 +95,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Routing Slip | Construction | 35.508 ns | 256 B | 32.448 ns | 256 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
+| Saga / Process Manager | Construction | 39.453 ns | 272 B | 42.138 ns | 272 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Saga / Process Manager | Execution | 89.969 ns | 672 B | 105.648 ns | 784 B | Fluent was faster and allocated less for the order saga workflow. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -38,6 +38,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
 | Cache-Aside | Execution | 216.50 ns | 1,048 B | 208.60 ns | 1,048 B | Same allocation; generated was slightly faster for the miss-then-hit workflow. |
+| Canonical Data Model | Construction | 75.482 ns | 632 B | 59.947 ns | 496 B | Generated reduced construction time and allocation in this microbenchmark. |
+| Canonical Data Model | Execution | 116.680 ns | 832 B | 92.082 ns | 696 B | Generated reduced execution time and allocation for order normalization. |
 | Channel Adapter | Construction | 38.469 ns | 384 B | 38.681 ns | 384 B | Effectively equivalent for this microbenchmark. |
 | Channel Adapter | Execution | 204.907 ns | 888 B | 198.374 ns | 888 B | Same allocation; generated was slightly faster for the ERP order document round-trip workflow. |
 | Claim Check | Construction | 111.92 ns | 1,664 B | 110.71 ns | 1,664 B | Effectively equivalent for this microbenchmark. |
@@ -70,10 +72,16 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Gateway Routing | Execution | 23.63 ns | 200 B | 20.13 ns | 168 B | Generated reduced execution time and allocation for the inventory routing workflow. |
 | Health Endpoint Monitoring | Construction | 35.68 ns | 264 B | 35.25 ns | 264 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Health Endpoint Monitoring | Execution | 38.50 ns | 248 B | 31.67 ns | 248 B | Same allocation; generated was faster for the fulfillment health evaluation workflow. |
+| Idempotent Receiver | Construction | 17.022 ns | 184 B | 17.021 ns | 184 B | Effectively equivalent for this microbenchmark. |
+| Idempotent Receiver | Execution | 99.419 ns | 608 B | 99.051 ns | 608 B | Effectively equivalent for idempotent command handling. |
+| Inbox | Construction | 22.259 ns | 208 B | 21.675 ns | 208 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Inbox | Execution | 113.126 ns | 632 B | 110.770 ns | 608 B | Generated reduced execution time and allocation for inbox command processing. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Materialized View | Execution | 389.5 ns | 2.02 KB | 386.0 ns | 2.02 KB | Effectively equivalent for this scenario. |
+| Mailbox | Construction | 17.030 ns | 216 B | 29.867 ns | 360 B | Fluent was faster and allocated less for disposable mailbox construction. |
+| Mailbox | Execution | 1.856 us | 2,620 B | 1.956 us | 2,474 B | Generated allocated less, while fluent was faster for serialized mailbox processing. |
 | Message Channel | Construction | 10.282 ns | 120 B | 10.148 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Message Channel | Execution | 72.921 ns | 512 B | 71.924 ns | 512 B | Same allocation; generated was slightly faster for the inventory adjustment workflow. |
 | Message Envelope | Construction | 248.580 ns | 1,688 B | 228.019 ns | 1,688 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -88,6 +96,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Message Translator | Execution | 365.30 ns | 2,528 B | 381.79 ns | 2,528 B | Same allocation; fluent was slightly faster in this path. |
 | Messaging Gateway | Construction | 14.094 ns | 160 B | 14.167 ns | 160 B | Effectively equivalent for this microbenchmark. |
 | Messaging Gateway | Execution | 66.597 ns | 560 B | 67.558 ns | 560 B | Same allocation; fluent was slightly faster for payment authorization. |
+| Outbox | Construction | 9.544 ns | 88 B | 9.672 ns | 88 B | Effectively equivalent for this microbenchmark. |
+| Outbox | Execution | 118.307 ns | 424 B | 122.972 ns | 424 B | Same allocation; fluent was slightly faster for enqueue-and-dispatch processing. |
 | Pipes and Filters | Construction | 32.99 ns | 264 B | 32.98 ns | 264 B | Effectively equivalent for this microbenchmark. |
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
@@ -102,6 +112,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Resequencer | Execution | 311.90 ns | 2,456 B | 303.94 ns | 2,456 B | Same allocation; generated was slightly faster for the three-event shipment resequencing workflow. |
 | Routing Slip | Construction | 35.508 ns | 256 B | 32.448 ns | 256 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
+| Saga / Process Manager | Construction | 39.453 ns | 272 B | 42.138 ns | 272 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Saga / Process Manager | Execution | 89.969 ns | 672 B | 105.648 ns | 784 B | Fluent was faster and allocated less for the order saga workflow. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -181,6 +181,9 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
         if (patternName == "ContentBasedRouter")
             return "Content-Based Router";
 
+        if (patternName == "SagaProcessManager")
+            return "Saga / Process Manager";
+
         var chars = new List<char>(patternName.Length + 4);
         for (var index = 0; index < patternName.Length; index++)
         {


### PR DESCRIPTION
## Summary
- add dedicated fluent/source-generated BenchmarkDotNet scenarios for canonical data model, mailbox, saga/process manager, idempotent receiver, inbox, and outbox
- publish measured current-tfm timing and allocation rows in README and benchmark docs
- extend benchmark coverage humanization for saga/process manager scenario classes

## Validation
- dotnet build benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run --project benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories CanonicalDataModel Mailbox SagaProcessManager IdempotentReceiver Inbox Outbox
- dotnet test test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore --logger "console;verbosity=minimal"
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"