### PR TITLE
test: add application architecture benchmark scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,10 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Anti-Corruption Layer | Construction | 59.62 ns | 440 B | 59.77 ns | 440 B | Effectively equivalent for this microbenchmark. |
+| Anti-Corruption Layer | Execution | 109.13 ns | 656 B | 107.42 ns | 656 B | Same allocation; generated was slightly faster for legacy order import. |
+| Audit Log | Construction | 19.70 ns | 192 B | 18.62 ns | 192 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Audit Log | Execution | 265.81 ns | 968 B | 273.42 ns | 968 B | Same allocation; fluent was slightly faster for submit-and-approve audit logging. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
@@ -488,6 +492,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Content-Based Router | Execution | 52.789 ns | 520 B | 60.816 ns | 576 B | Fluent was faster and allocated less for wholesale order routing. |
 | Control Bus | Construction | 115.64 ns | 880 B | 79.88 ns | 624 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Control Bus | Execution | 290.44 ns | 1,688 B | 232.48 ns | 1,432 B | Generated reduced execution time and allocation for operational command dispatch. |
+| CQRS | Construction | 199.3 ns | 2.09 KB | 88.001 us | 309.24 KB | Fluent mediator construction is much lighter; generated measurement includes full IServiceCollection dispatcher composition. |
+| CQRS | Execution | 479.9 ns | 3.40 KB | 96.453 us | 324.83 KB | Fluent route is much lighter in this microbenchmark; generated route exercises the full DI-integrated dispatcher workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
@@ -498,10 +504,14 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Event-Carried State Transfer | Execution | 58.508 ns | 448 B | 59.071 ns | 448 B | Effectively equivalent for the inventory projection workflow. |
 | Event Notification | Construction | 30.920 ns | 232 B | 31.926 ns | 232 B | Effectively equivalent for this microbenchmark. |
 | Event Notification | Execution | 93.209 ns | 704 B | 106.973 ns | 704 B | Same allocation; fluent was faster for order notification publishing. |
+| Event Sourcing | Construction | 12.92 ns | 144 B | 13.00 ns | 144 B | Effectively equivalent for this microbenchmark. |
+| Event Sourcing | Execution | 239.97 ns | 1,168 B | 245.13 ns | 1,168 B | Same allocation; fluent was slightly faster for place-and-pay event replay. |
 | Event-Driven Consumer | Construction | 41.394 ns | 336 B | 25.216 ns | 192 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
+| Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
 | Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -512,6 +522,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Idempotent Receiver | Execution | 99.419 ns | 608 B | 99.051 ns | 608 B | Effectively equivalent for idempotent command handling. |
 | Inbox | Construction | 22.259 ns | 208 B | 21.675 ns | 208 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Inbox | Execution | 113.126 ns | 632 B | 110.770 ns | 608 B | Generated reduced execution time and allocation for inbox command processing. |
+| Identity Map | Construction | 10.62 ns | 112 B | 10.68 ns | 112 B | Effectively equivalent for this microbenchmark. |
+| Identity Map | Execution | 108.91 ns | 968 B | 94.83 ns | 968 B | Same allocation; generated was faster for scoped identity-map reuse. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -558,8 +570,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Rate Limiting | Execution | 247.62 ns | 1,200 B | 245.56 ns | 1,200 B | Same allocation; generated was slightly faster for the tenant rejection workflow. |
-| Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
-| Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
+| Scatter-Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Scatter-Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Sidecar | Construction | 59.96 ns | 488 B | 52.09 ns | 400 B | Generated reduced construction time and allocation in this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Application/AntiCorruptionLayerBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/AntiCorruptionLayerBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.AntiCorruption;
+using PatternKit.Examples.AntiCorruptionDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "AntiCorruptionLayer")]
+public class AntiCorruptionLayerBenchmarks
+{
+    private static readonly LegacyOrderDto LegacyOrder = new(" order-100 ", 125m, "USD", " cust-42 ");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create anti-corruption layer")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public AntiCorruptionLayer<LegacyOrderDto, CommerceOrder> Fluent_CreateLayer()
+        => LegacyOrderAntiCorruptionPolicies.CreateFluentLayer();
+
+    [Benchmark(Description = "Generated: create anti-corruption layer")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public AntiCorruptionLayer<LegacyOrderDto, CommerceOrder> Generated_CreateLayer()
+        => GeneratedLegacyOrderAntiCorruptionLayer.CreateGeneratedLayer();
+
+    [Benchmark(Description = "Fluent: import legacy order")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderImportResult Fluent_ImportLegacyOrder()
+    {
+        var service = new LegacyOrderImportService(new ScriptedLegacyOrderFeed(), LegacyOrderAntiCorruptionPolicies.CreateFluentLayer());
+        return service.Import(LegacyOrder);
+    }
+
+    [Benchmark(Description = "Generated: import legacy order")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderImportResult Generated_ImportLegacyOrder()
+    {
+        var service = new LegacyOrderImportService(new ScriptedLegacyOrderFeed(), GeneratedLegacyOrderAntiCorruptionLayer.CreateGeneratedLayer());
+        return service.Import(LegacyOrder);
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Application/AuditLogBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/AuditLogBenchmarks.cs
@@ -1,0 +1,29 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.AuditLog;
+using PatternKit.Examples.AuditLogDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "AuditLog")]
+public class AuditLogBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create audit log")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public IAuditLog<OrderAuditEntry, string> Fluent_CreateLog()
+        => OrderAuditLogPolicies.CreateFluentLog();
+
+    [Benchmark(Description = "Generated: create audit log")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IAuditLog<OrderAuditEntry, string> Generated_CreateLog()
+        => GeneratedOrderAuditLog.CreateLog();
+
+    [Benchmark(Description = "Fluent: submit and approve order")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<OrderAuditLogSummary> Fluent_SubmitAndApprove()
+        => OrderAuditLogDemo.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: submit and approve order")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<OrderAuditLogSummary> Generated_SubmitAndApprove()
+        => OrderAuditLogDemo.RunGeneratedAsync();
+}

--- a/benchmarks/PatternKit.Benchmarks/Application/CqrsBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/CqrsBenchmarks.cs
@@ -1,0 +1,90 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using PatternKit.Behavioral.Mediator;
+using PatternKit.Examples.Messaging;
+using SourceGenerated = PatternKit.Examples.Messaging.SourceGenerated;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "CQRS")]
+public class CqrsBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create CQRS mediator")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Mediator Fluent_CreateMediator()
+    {
+        var log = new List<string>();
+        var orders = new Dictionary<int, CqrsOrder>();
+        var nextOrderId = 1000;
+
+        return Mediator.Create()
+            .Pre((in object? request, CancellationToken _) =>
+            {
+                log.Add($"pre:{request?.GetType().Name}");
+                return ValueTask.CompletedTask;
+            })
+            .Post((in object? request, object? response, CancellationToken _) =>
+            {
+                log.Add($"post:{request?.GetType().Name}:{response?.GetType().Name ?? "void"}");
+                return ValueTask.CompletedTask;
+            })
+            .Command<CreateCqrsOrder, CqrsOrder>((in CreateCqrsOrder command, CancellationToken _) =>
+            {
+                var order = new CqrsOrder(++nextOrderId, command.CustomerId, command.Lines, command.Lines.Sum(static line => line.Quantity * line.UnitPrice));
+                orders[order.Id] = order;
+                return new ValueTask<CqrsOrder>(order);
+            })
+            .Command<GetCqrsOrder, CqrsOrder?>((in GetCqrsOrder query, CancellationToken _) =>
+            {
+                orders.TryGetValue(query.OrderId, out var order);
+                return new ValueTask<CqrsOrder?>(order);
+            })
+            .Notification<CqrsOrderCreated>((in CqrsOrderCreated notification, CancellationToken _) =>
+            {
+                log.Add($"event:order-created:{notification.OrderId}");
+                return ValueTask.CompletedTask;
+            })
+            .Build();
+    }
+
+    [Benchmark(Description = "Generated: create CQRS dispatcher services")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public int Generated_CreateDispatcherServices()
+    {
+        using var provider = CreateGeneratedProvider();
+        return provider.GetServices<object>().Count();
+    }
+
+    [Benchmark(Description = "Fluent: command query workflow")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<CqrsSummary> Fluent_CommandQueryWorkflow()
+        => CqrsPatternExample.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: command query workflow")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public async ValueTask<CqrsSummary> Generated_CommandQueryWorkflow()
+    {
+        await using var provider = CreateGeneratedProvider();
+        return await CqrsPatternExample.RunSourceGeneratedAsync(provider);
+    }
+
+    private static ServiceProvider CreateGeneratedProvider()
+    {
+        var services = new ServiceCollection()
+            .AddSourceGeneratedCqrsServices();
+
+        services.Replace(ServiceDescriptor.Singleton<SourceGenerated.ILogger, QuietLogger>());
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    private sealed class QuietLogger : SourceGenerated.ILogger
+    {
+        private readonly List<string> _logs = [];
+
+        public void Log(string message) => _logs.Add(message);
+
+        public List<string> GetLogs() => _logs;
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Application/EventSourcingBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/EventSourcingBenchmarks.cs
@@ -1,0 +1,29 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.EventSourcing;
+using PatternKit.Examples.EventSourcingDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "EventSourcing")]
+public class EventSourcingBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create event store")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public IEventStore<OrderEvent, string> Fluent_CreateStore()
+        => OrderEventSourcingPolicies.CreateFluentStore();
+
+    [Benchmark(Description = "Generated: create event store")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IEventStore<OrderEvent, string> Generated_CreateStore()
+        => GeneratedOrderEventStore.CreateStore();
+
+    [Benchmark(Description = "Fluent: place and pay order")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ValueTask<OrderEventSourcingSummary> Fluent_PlaceAndPayOrder()
+        => OrderEventSourcingDemo.RunFluentAsync();
+
+    [Benchmark(Description = "Generated: place and pay order")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ValueTask<OrderEventSourcingSummary> Generated_PlaceAndPayOrder()
+        => OrderEventSourcingDemo.RunGeneratedAsync();
+}

--- a/benchmarks/PatternKit.Benchmarks/Application/FeatureToggleBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/FeatureToggleBenchmarks.cs
@@ -1,0 +1,29 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.FeatureToggles;
+using PatternKit.Examples.FeatureToggleDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "FeatureToggle")]
+public class FeatureToggleBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create feature toggle set")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public IFeatureToggleSet<CheckoutFeatureContext> Fluent_CreateToggleSet()
+        => CheckoutFeatureTogglePolicies.CreateFluentToggleSet();
+
+    [Benchmark(Description = "Generated: create feature toggle set")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IFeatureToggleSet<CheckoutFeatureContext> Generated_CreateToggleSet()
+        => GeneratedCheckoutFeatureToggles.CreateToggles();
+
+    [Benchmark(Description = "Fluent: evaluate checkout features")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public CheckoutFeatureToggleSummary Fluent_EvaluateCheckoutFeatures()
+        => CheckoutFeatureToggleDemo.RunFluent();
+
+    [Benchmark(Description = "Generated: evaluate checkout features")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public CheckoutFeatureToggleSummary Generated_EvaluateCheckoutFeatures()
+        => CheckoutFeatureToggleDemo.RunGenerated();
+}

--- a/benchmarks/PatternKit.Benchmarks/Application/IdentityMapBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Application/IdentityMapBenchmarks.cs
@@ -1,0 +1,29 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Application.IdentityMap;
+using PatternKit.Examples.IdentityMapDemo;
+
+namespace PatternKit.Benchmarks.Application;
+
+[BenchmarkCategory("ApplicationArchitecture", "IdentityMap")]
+public class IdentityMapBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create identity map")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public IIdentityMap<TrackedOrder, string> Fluent_CreateMap()
+        => OrderIdentityMapPolicies.CreateFluentMap();
+
+    [Benchmark(Description = "Generated: create identity map")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IIdentityMap<TrackedOrder, string> Generated_CreateMap()
+        => GeneratedOrderIdentityMap.CreateMap();
+
+    [Benchmark(Description = "Fluent: load tracked order twice")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderIdentityMapSummary Fluent_LoadTrackedOrderTwice()
+        => OrderIdentityMapDemo.RunFluent();
+
+    [Benchmark(Description = "Generated: load tracked order twice")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderIdentityMapSummary Generated_LoadTrackedOrderTwice()
+        => OrderIdentityMapDemo.RunGenerated();
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -15,6 +15,10 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Anti-Corruption Layer | Construction | 59.62 ns | 440 B | 59.77 ns | 440 B | Effectively equivalent for this microbenchmark. |
+| Anti-Corruption Layer | Execution | 109.13 ns | 656 B | 107.42 ns | 656 B | Same allocation; generated was slightly faster for legacy order import. |
+| Audit Log | Construction | 19.70 ns | 192 B | 18.62 ns | 192 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Audit Log | Execution | 265.81 ns | 968 B | 273.42 ns | 968 B | Same allocation; fluent was slightly faster for submit-and-approve audit logging. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
@@ -35,6 +39,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Content-Based Router | Execution | 52.789 ns | 520 B | 60.816 ns | 576 B | Fluent was faster and allocated less for wholesale order routing. |
 | Control Bus | Construction | 115.64 ns | 880 B | 79.88 ns | 624 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Control Bus | Execution | 290.44 ns | 1,688 B | 232.48 ns | 1,432 B | Generated reduced execution time and allocation for operational command dispatch. |
+| CQRS | Construction | 199.3 ns | 2.09 KB | 88.001 us | 309.24 KB | Fluent mediator construction is much lighter; generated measurement includes full IServiceCollection dispatcher composition. |
+| CQRS | Execution | 479.9 ns | 3.40 KB | 96.453 us | 324.83 KB | Fluent route is much lighter in this microbenchmark; generated route exercises the full DI-integrated dispatcher workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
@@ -45,10 +51,14 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Event-Carried State Transfer | Execution | 58.508 ns | 448 B | 59.071 ns | 448 B | Effectively equivalent for the inventory projection workflow. |
 | Event Notification | Construction | 30.920 ns | 232 B | 31.926 ns | 232 B | Effectively equivalent for this microbenchmark. |
 | Event Notification | Execution | 93.209 ns | 704 B | 106.973 ns | 704 B | Same allocation; fluent was faster for order notification publishing. |
+| Event Sourcing | Construction | 12.92 ns | 144 B | 13.00 ns | 144 B | Effectively equivalent for this microbenchmark. |
+| Event Sourcing | Execution | 239.97 ns | 1,168 B | 245.13 ns | 1,168 B | Same allocation; fluent was slightly faster for place-and-pay event replay. |
 | Event-Driven Consumer | Construction | 41.394 ns | 336 B | 25.216 ns | 192 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
+| Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
 | Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -59,6 +69,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Idempotent Receiver | Execution | 99.419 ns | 608 B | 99.051 ns | 608 B | Effectively equivalent for idempotent command handling. |
 | Inbox | Construction | 22.259 ns | 208 B | 21.675 ns | 208 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Inbox | Execution | 113.126 ns | 632 B | 110.770 ns | 608 B | Generated reduced execution time and allocation for inbox command processing. |
+| Identity Map | Construction | 10.62 ns | 112 B | 10.68 ns | 112 B | Effectively equivalent for this microbenchmark. |
+| Identity Map | Execution | 108.91 ns | 968 B | 94.83 ns | 968 B | Same allocation; generated was faster for scoped identity-map reuse. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -105,8 +117,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Rate Limiting | Execution | 247.62 ns | 1,200 B | 245.56 ns | 1,200 B | Same allocation; generated was slightly faster for the tenant rejection workflow. |
-| Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
-| Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
+| Scatter-Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Scatter-Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Sidecar | Construction | 59.96 ns | 488 B | 52.09 ns | 400 B | Generated reduced construction time and allocation in this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -32,6 +32,10 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Ambassador | Execution | 87.92 ns | 624 B | 93.72 ns | 624 B | Same allocation; fluent was slightly faster in this path. |
+| Anti-Corruption Layer | Construction | 59.62 ns | 440 B | 59.77 ns | 440 B | Effectively equivalent for this microbenchmark. |
+| Anti-Corruption Layer | Execution | 109.13 ns | 656 B | 107.42 ns | 656 B | Same allocation; generated was slightly faster for legacy order import. |
+| Audit Log | Construction | 19.70 ns | 192 B | 18.62 ns | 192 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Audit Log | Execution | 265.81 ns | 968 B | 273.42 ns | 968 B | Same allocation; fluent was slightly faster for submit-and-approve audit logging. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
@@ -52,6 +56,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Content-Based Router | Execution | 52.789 ns | 520 B | 60.816 ns | 576 B | Fluent was faster and allocated less for wholesale order routing. |
 | Control Bus | Construction | 115.64 ns | 880 B | 79.88 ns | 624 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Control Bus | Execution | 290.44 ns | 1,688 B | 232.48 ns | 1,432 B | Generated reduced execution time and allocation for operational command dispatch. |
+| CQRS | Construction | 199.3 ns | 2.09 KB | 88.001 us | 309.24 KB | Fluent mediator construction is much lighter; generated measurement includes full IServiceCollection dispatcher composition. |
+| CQRS | Execution | 479.9 ns | 3.40 KB | 96.453 us | 324.83 KB | Fluent route is much lighter in this microbenchmark; generated route exercises the full DI-integrated dispatcher workflow. |
 | Data Mapper | Construction | 40.56 ns | 288 B | 12.87 ns | 112 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
@@ -62,10 +68,14 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Event-Carried State Transfer | Execution | 58.508 ns | 448 B | 59.071 ns | 448 B | Effectively equivalent for the inventory projection workflow. |
 | Event Notification | Construction | 30.920 ns | 232 B | 31.926 ns | 232 B | Effectively equivalent for this microbenchmark. |
 | Event Notification | Execution | 93.209 ns | 704 B | 106.973 ns | 704 B | Same allocation; fluent was faster for order notification publishing. |
+| Event Sourcing | Construction | 12.92 ns | 144 B | 13.00 ns | 144 B | Effectively equivalent for this microbenchmark. |
+| Event Sourcing | Execution | 239.97 ns | 1,168 B | 245.13 ns | 1,168 B | Same allocation; fluent was slightly faster for place-and-pay event replay. |
 | Event-Driven Consumer | Construction | 41.394 ns | 336 B | 25.216 ns | 192 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
+| Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
+| Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
 | Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -76,6 +86,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Idempotent Receiver | Execution | 99.419 ns | 608 B | 99.051 ns | 608 B | Effectively equivalent for idempotent command handling. |
 | Inbox | Construction | 22.259 ns | 208 B | 21.675 ns | 208 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Inbox | Execution | 113.126 ns | 632 B | 110.770 ns | 608 B | Generated reduced execution time and allocation for inbox command processing. |
+| Identity Map | Construction | 10.62 ns | 112 B | 10.68 ns | 112 B | Effectively equivalent for this microbenchmark. |
+| Identity Map | Execution | 108.91 ns | 968 B | 94.83 ns | 968 B | Same allocation; generated was faster for scoped identity-map reuse. |
 | Leader Election | Construction | 14.28 ns | 104 B | 15.91 ns | 104 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Leader Election | Execution | 43.62 ns | 360 B | 144.37 ns | 312 B | Generated allocated about 13% less memory, while fluent was faster in this path. |
 | Materialized View | Construction | 140.9 ns | 1.05 KB | 147.4 ns | 1.05 KB | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -122,8 +134,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Retry | Execution | 110.53 ns | 600 B | 109.52 ns | 600 B | Same allocation; generated was slightly faster for the transient retry workflow. |
 | Rate Limiting | Construction | 19.16 ns | 168 B | 18.19 ns | 168 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Rate Limiting | Execution | 247.62 ns | 1,200 B | 245.56 ns | 1,200 B | Same allocation; generated was slightly faster for the tenant rejection workflow. |
-| Scatter Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
-| Scatter Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
+| Scatter-Gather | Construction | 59.78 ns | 408 B | 62.41 ns | 408 B | Same allocation; fluent was slightly faster in this microbenchmark. |
+| Scatter-Gather | Execution | 327.74 ns | 1,704 B | 388.12 ns | 2,064 B | Fluent was faster and allocated less for the supplier quote fan-out workflow. |
 | Scheduler Agent Supervisor | Construction | 47.29 ns | 400 B | 45.40 ns | 400 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Scheduler Agent Supervisor | Execution | 177.46 ns | 1,304 B | 180.14 ns | 1,304 B | Effectively equivalent for this scenario. |
 | Sidecar | Construction | 59.96 ns | 488 B | 52.09 ns | 400 B | Generated reduced construction time and allocation in this microbenchmark. |

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -181,8 +181,26 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
         if (patternName == "ContentBasedRouter")
             return "Content-Based Router";
 
+        if (patternName == "Cqrs")
+            return "CQRS";
+
         if (patternName == "SagaProcessManager")
             return "Saga / Process Manager";
+
+        if (patternName == "AntiCorruptionLayer")
+            return "Anti-Corruption Layer";
+
+        if (patternName == "EventSourcing")
+            return "Event Sourcing";
+
+        if (patternName == "FeatureToggle")
+            return "Feature Toggle";
+
+        if (patternName == "IdentityMap")
+            return "Identity Map";
+
+        if (patternName == "ScatterGather")
+            return "Scatter-Gather";
 
         var chars = new List<char>(patternName.Length + 4);
         for (var index = 0; index < patternName.Length; index++)


### PR DESCRIPTION
## Summary
- add dedicated fluent/source-generated BenchmarkDotNet scenarios for Anti-Corruption Layer, Audit Log, CQRS, Event Sourcing, Feature Toggle, and Identity Map
- publish measured current-tfm timing and allocation rows in README and benchmark docs
- add explicit benchmark result humanization for application acronyms/names and Scatter-Gather

## Validation
- dotnet build benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run --project benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories AntiCorruptionLayer AuditLog CQRS EventSourcing FeatureToggle IdentityMap
- dotnet run --project benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories CQRS
- dotnet test test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore --logger "console;verbosity=minimal"
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"