### PR TITLE
test: add backplane messaging benchmark scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,10 +550,14 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
+| Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
+| Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Recipient List | Construction | 30.304 ns | 288 B | 30.380 ns | 288 B | Effectively equivalent for this microbenchmark. |
 | Recipient List | Execution | 123.057 ns | 992 B | 120.325 ns | 968 B | Generated was slightly faster and allocated slightly less for shipment fan-out. |
+| Request-Reply | Construction | 79.15 ns | 672 B | 78.63 ns | 672 B | Effectively equivalent for request/reply topology composition. |
+| Request-Reply | Execution | 11.196 us | 13,492 B | 10.864 us | 13,493 B | Generated was slightly faster; allocations were effectively equivalent for the request/reply exchange. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
 | Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Messaging/PublishSubscribeBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/PublishSubscribeBenchmarks.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "PublishSubscribe")]
+public class PublishSubscribeBenchmarks
+{
+    private static readonly MessageHeaders Headers =
+        MessageHeaders.Empty
+            .WithMessageId("msg-order-submitted")
+            .WithCorrelationId("corr-order-submitted");
+
+    private static readonly BenchmarkOrderSubmitted Event = new("order-100", 125m);
+
+    [Benchmark(Baseline = true, Description = "Fluent: configure publish-subscribe topology")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public BackplaneHostBuilder Fluent_ConfigurePublishSubscribeTopology()
+        => ConfigureFluent(new BackplaneHostBuilder(), new BenchmarkPublishSubscribeServices());
+
+    [Benchmark(Description = "Generated: configure publish-subscribe topology")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public BackplaneHostBuilder Generated_ConfigurePublishSubscribeTopology()
+        => BenchmarkPublishSubscribeTopology.Configure(new BackplaneHostBuilder(), new BenchmarkPublishSubscribeServices());
+
+    [Benchmark(Description = "Fluent: publish event to subscribers")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public async ValueTask<int> Fluent_PublishEventToSubscribers()
+    {
+        var services = new BenchmarkPublishSubscribeServices();
+        await using var host = await ConfigureFluent(new BackplaneHostBuilder(), services)
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        await host.Client.PublishAsync("orders.submitted", Event, Headers).ConfigureAwait(false);
+        return services.Deliveries.Count;
+    }
+
+    [Benchmark(Description = "Generated: publish event to subscribers")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public async ValueTask<int> Generated_PublishEventToSubscribers()
+    {
+        var services = new BenchmarkPublishSubscribeServices();
+        await using var host = await BenchmarkPublishSubscribeTopology.Configure(new BackplaneHostBuilder(), services)
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        await host.Client.PublishAsync("orders.submitted", Event, Headers).ConfigureAwait(false);
+        return services.Deliveries.Count;
+    }
+
+    internal static BackplaneHostBuilder ConfigureFluent(
+        BackplaneHostBuilder builder,
+        BenchmarkPublishSubscribeServices services)
+        => builder
+            .ReceiveEndpoint("billing-service", endpoint =>
+                endpoint.Subscribe<BenchmarkOrderSubmitted>("orders.submitted", services.CapturePaymentAsync))
+            .ReceiveEndpoint("audit-service", endpoint =>
+                endpoint.Subscribe<BenchmarkOrderSubmitted>("orders.submitted", services.AuditOrderAsync));
+}
+
+[GenerateBackplaneTopology(typeof(BenchmarkPublishSubscribeServices), HostBuilderType = typeof(BackplaneHostBuilder))]
+[BackplaneSubscription(
+    typeof(BenchmarkOrderSubmitted),
+    "orders.submitted",
+    "billing-service",
+    nameof(BenchmarkPublishSubscribeServices.CapturePaymentAsync))]
+[BackplaneSubscription(
+    typeof(BenchmarkOrderSubmitted),
+    "orders.submitted",
+    "audit-service",
+    nameof(BenchmarkPublishSubscribeServices.AuditOrderAsync))]
+public static partial class BenchmarkPublishSubscribeTopology;
+
+public sealed class BenchmarkPublishSubscribeServices
+{
+    private readonly ConcurrentQueue<string> _deliveries = new();
+
+    public IReadOnlyCollection<string> Deliveries => _deliveries;
+
+    public ValueTask CapturePaymentAsync(
+        Message<BenchmarkOrderSubmitted> message,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        _ = context;
+        _ = cancellationToken;
+        _deliveries.Enqueue($"billing:{message.Payload.OrderId}");
+        return default;
+    }
+
+    public ValueTask AuditOrderAsync(
+        Message<BenchmarkOrderSubmitted> message,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        _deliveries.Enqueue($"audit:{message.Payload.OrderId}:{context.Headers.CorrelationId}");
+        return default;
+    }
+}
+
+public sealed record BenchmarkOrderSubmitted(string OrderId, decimal Total);

--- a/benchmarks/PatternKit.Benchmarks/Messaging/RequestReplyBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Messaging/RequestReplyBenchmarks.cs
@@ -1,0 +1,84 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Messaging;
+using PatternKit.Generators.Messaging;
+using PatternKit.Messaging;
+
+namespace PatternKit.Benchmarks.Messaging;
+
+[BenchmarkCategory("EnterpriseIntegration", "Messaging", "RequestReply")]
+public class RequestReplyBenchmarks
+{
+    private static readonly Message<BenchmarkOrderRequest> Request =
+        Message<BenchmarkOrderRequest>
+            .Create(new("order-100", 125m))
+            .WithCorrelationId("corr-order-100");
+
+    [Benchmark(Baseline = true, Description = "Fluent: configure request-reply topology")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public BackplaneHostBuilder Fluent_ConfigureRequestReplyTopology()
+        => ConfigureFluent(new BackplaneHostBuilder(), new BenchmarkRequestReplyServices());
+
+    [Benchmark(Description = "Generated: configure request-reply topology")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public BackplaneHostBuilder Generated_ConfigureRequestReplyTopology()
+        => BenchmarkRequestReplyTopology.Configure(new BackplaneHostBuilder(), new BenchmarkRequestReplyServices());
+
+    [Benchmark(Description = "Fluent: send request and receive reply")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public async ValueTask<BenchmarkOrderReply> Fluent_SendRequestAndReceiveReply()
+    {
+        await using var host = await ConfigureFluent(new BackplaneHostBuilder(), new BenchmarkRequestReplyServices())
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        return await host.Client.RequestAsync<BenchmarkOrderRequest, BenchmarkOrderReply>(Request).ConfigureAwait(false);
+    }
+
+    [Benchmark(Description = "Generated: send request and receive reply")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public async ValueTask<BenchmarkOrderReply> Generated_SendRequestAndReceiveReply()
+    {
+        await using var host = await BenchmarkRequestReplyTopology.Configure(
+                new BackplaneHostBuilder(),
+                new BenchmarkRequestReplyServices())
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        return await host.Client.RequestAsync<BenchmarkOrderRequest, BenchmarkOrderReply>(Request).ConfigureAwait(false);
+    }
+
+    internal static BackplaneHostBuilder ConfigureFluent(
+        BackplaneHostBuilder builder,
+        BenchmarkRequestReplyServices services)
+        => builder
+            .MapDefaultCommand<BenchmarkOrderRequest, BenchmarkOrderReply>("orders.request-reply")
+            .ReceiveEndpoint("orders.request-reply", endpoint =>
+                endpoint.HandleCommand<BenchmarkOrderRequest, BenchmarkOrderReply>(services.AcceptOrderAsync));
+}
+
+[GenerateBackplaneTopology(typeof(BenchmarkRequestReplyServices), HostBuilderType = typeof(BackplaneHostBuilder))]
+[BackplaneRequestReply(
+    typeof(BenchmarkOrderRequest),
+    typeof(BenchmarkOrderReply),
+    "orders.request-reply",
+    nameof(BenchmarkRequestReplyServices.AcceptOrderAsync))]
+public static partial class BenchmarkRequestReplyTopology;
+
+public sealed class BenchmarkRequestReplyServices
+{
+    public ValueTask<BenchmarkOrderReply> AcceptOrderAsync(
+        Message<BenchmarkOrderRequest> message,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        return new ValueTask<BenchmarkOrderReply>(new BenchmarkOrderReply(
+            message.Payload.OrderId,
+            "accepted",
+            context.Headers.CorrelationId ?? string.Empty));
+    }
+}
+
+public sealed record BenchmarkOrderRequest(string OrderId, decimal Total);
+
+public sealed record BenchmarkOrderReply(string OrderId, string Status, string CorrelationId);

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -97,10 +97,14 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
+| Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
+| Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Recipient List | Construction | 30.304 ns | 288 B | 30.380 ns | 288 B | Effectively equivalent for this microbenchmark. |
 | Recipient List | Execution | 123.057 ns | 992 B | 120.325 ns | 968 B | Generated was slightly faster and allocated slightly less for shipment fan-out. |
+| Request-Reply | Construction | 79.15 ns | 672 B | 78.63 ns | 672 B | Effectively equivalent for request/reply topology composition. |
+| Request-Reply | Execution | 11.196 us | 13,492 B | 10.864 us | 13,493 B | Generated was slightly faster; allocations were effectively equivalent for the request/reply exchange. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
 | Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -114,10 +114,14 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
+| Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
+| Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Reliability Pipeline | Execution | 2.303 us | 3,992 B | 381.36 ns | 1,872 B | Generated was materially faster and allocated less for duplicate inbox processing plus outbox dispatch. |
 | Recipient List | Construction | 30.304 ns | 288 B | 30.380 ns | 288 B | Effectively equivalent for this microbenchmark. |
 | Recipient List | Execution | 123.057 ns | 992 B | 120.325 ns | 968 B | Generated was slightly faster and allocated slightly less for shipment fan-out. |
+| Request-Reply | Construction | 79.15 ns | 672 B | 78.63 ns | 672 B | Effectively equivalent for request/reply topology composition. |
+| Request-Reply | Execution | 11.196 us | 13,492 B | 10.864 us | 13,493 B | Generated was slightly faster; allocations were effectively equivalent for the request/reply exchange. |
 | Repository | Construction | 9.793 ns | 112 B | 9.239 ns | 112 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Repository | Execution | 146.37 ns | 888 B | 143.27 ns | 888 B | Same allocation; generated was slightly faster for the seed-and-query workflow. |
 | Resequencer | Construction | 16.89 ns | 192 B | 17.27 ns | 192 B | Effectively equivalent for this microbenchmark. |

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -199,6 +199,12 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
         if (patternName == "IdentityMap")
             return "Identity Map";
 
+        if (patternName == "PublishSubscribe")
+            return "Publish-Subscribe";
+
+        if (patternName == "RequestReply")
+            return "Request-Reply";
+
         if (patternName == "ScatterGather")
             return "Scatter-Gather";
 


### PR DESCRIPTION
## Summary
- Add dedicated BenchmarkDotNet scenarios for Publish-Subscribe and Request-Reply backplane flows
- Compare fluent topology setup with source-generated topology setup and execution paths
- Publish measured current-TFM timing/allocation rows in README and benchmark guides

## Benchmarks captured
- Publish-Subscribe construction: fluent 156.89 ns / 1,616 B, generated 153.49 ns / 1,616 B
- Publish-Subscribe execution: fluent 6.380 us / 10,386 B, generated 6.275 us / 10,417 B
- Request-Reply construction: fluent 79.15 ns / 672 B, generated 78.63 ns / 672 B
- Request-Reply execution: fluent 11.196 us / 13,492 B, generated 10.864 us / 13,493 B

## Validation
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run --project benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories PublishSubscribe RequestReply
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore --logger "console;verbosity=minimal"
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"
- git diff --check
