### PR TITLE
perf: add GoF creational benchmark scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
             --collect:"XPlat Code Coverage" \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[PatternKit*]*" \
-            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests]*"
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests]*" \
+            -- RunConfiguration.TestSessionTimeout=1800000
 
       - name: Install ReportGenerator
         run: dotnet tool update -g dotnet-reportgenerator-globaltool

--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 
 | Pattern | Phase | Fluent mean | Fluent allocation | Generated mean | Generated allocation | Read |
 | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Abstract Factory | Construction | 715.345 ns | 5,992 B | 720.811 ns | 5,992 B | Effectively equivalent for tenant widget factory composition. |
+| Abstract Factory | Execution | 750.189 ns | 6,200 B | 735.733 ns | 6,200 B | Same allocation; generated was slightly faster for login widget creation. |
 | Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -474,6 +476,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Audit Log | Execution | 265.81 ns | 968 B | 273.42 ns | 968 B | Same allocation; fluent was slightly faster for submit-and-approve audit logging. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
+| Builder | Construction | 48.24 ns | 320 B | 160.455 us | 129,236 B | Fluent builder construction is much lighter; generated measures full HostApplicationBuilder composition. |
+| Builder | Execution | 65.14 ns | 352 B | 500.676 us | 279,923 B | Fluent option building is much lighter; generated exercises the full host-backed application build. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -510,6 +514,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
+| Factory Method | Construction | 72.397 ns | 512 B | 0.355 ns | 0 B | Generated static factory surface resolution avoids runtime builder allocation. |
+| Factory Method | Execution | 1.792 us | 10,568 B | 1.681 us | 10,056 B | Generated was faster and allocated less for service-module registration. |
 | Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -550,6 +556,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
+| Prototype | Construction | 886.538 ns | 6,888 B | 20.985 ns | 152 B | Generated clone source construction is much lighter than populating the fluent registry. |
+| Prototype | Execution | 1.193 us | 7,832 B | 21.717 ns | 152 B | Generated cloning was materially faster and allocated less for the character prototype. |
 | Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
 | Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -566,6 +574,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
 | Saga / Process Manager | Construction | 39.453 ns | 272 B | 42.138 ns | 272 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Saga / Process Manager | Execution | 89.969 ns | 672 B | 105.648 ns | 784 B | Fluent was faster and allocated less for the order saga workflow. |
+| Singleton | Construction | 26.618 ns | 184 B | 0.366 ns | 0 B | Generated static singleton surface resolution avoids runtime builder allocation. |
+| Singleton | Execution | 74.198 ns | 504 B | 0.205 ns | 0 B | Generated static singleton access avoids the fluent resolver allocation path. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Creational/AbstractFactoryBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Creational/AbstractFactoryBenchmarks.cs
@@ -1,0 +1,60 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Creational.AbstractFactory;
+using PatternKit.Examples.AbstractFactoryDemo;
+using static PatternKit.Examples.AbstractFactoryDemo.AbstractFactoryDemo;
+
+namespace PatternKit.Benchmarks.Creational;
+
+[BenchmarkCategory("Creational", "GoF", "AbstractFactory")]
+public class AbstractFactoryBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create abstract factory")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public AbstractFactory<Platform> Fluent_CreateAbstractFactory()
+        => AbstractFactory<Platform>.Create()
+            .Family(Platform.Windows)
+            .Product<IButton>(() => new WindowsButton())
+            .Product<ITextBox>(() => new WindowsTextBox())
+            .Product<ICheckBox>(() => new WindowsCheckBox())
+            .Product<IDialog>(() => new WindowsDialog())
+            .Family(Platform.MacOS)
+            .Product<IButton>(() => new MacButton())
+            .Product<ITextBox>(() => new MacTextBox())
+            .Product<ICheckBox>(() => new MacCheckBox())
+            .Product<IDialog>(() => new MacDialog())
+            .Family(Platform.Linux)
+            .Product<IButton>(() => new LinuxButton())
+            .Product<ITextBox>(() => new LinuxTextBox())
+            .Product<ICheckBox>(() => new LinuxCheckBox())
+            .Product<IDialog>(() => new LinuxDialog())
+            .Build();
+
+    [Benchmark(Description = "Generated: create abstract factory")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public AbstractFactory<Platform> Generated_CreateAbstractFactory()
+        => GeneratedPlatformWidgetFactory.Create();
+
+    [Benchmark(Description = "Fluent: create login widgets")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public WidgetRenderSummary Fluent_CreateLoginWidgets()
+        => RenderWidgets(Fluent_CreateAbstractFactory().GetFamily(Platform.Linux));
+
+    [Benchmark(Description = "Generated: create login widgets")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public WidgetRenderSummary Generated_CreateLoginWidgets()
+        => RenderWidgets(GeneratedPlatformWidgetFactory.Create().GetFamily(Platform.Linux));
+
+    private static WidgetRenderSummary RenderWidgets(AbstractFactory<Platform>.ProductFamily family)
+    {
+        var username = family.Create<ITextBox>();
+        var rememberMe = family.Create<ICheckBox>();
+        var button = family.Create<IButton>();
+
+        username.SetText("user@example.com");
+        rememberMe.Toggle();
+
+        return new WidgetRenderSummary(username.Render(), rememberMe.Render(), button.Render());
+    }
+}
+
+public sealed record WidgetRenderSummary(string UserName, string RememberMe, string Submit);

--- a/benchmarks/PatternKit.Benchmarks/Creational/BuilderBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Creational/BuilderBenchmarks.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Creational.Builder;
+using PatternKit.Examples.Generators.Builders.CorporateApplicationBuilderDemo;
+
+namespace PatternKit.Benchmarks.Creational;
+
+[BenchmarkCategory("Creational", "GoF", "Builder")]
+public class BuilderBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create builder")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public MutableBuilder<BenchmarkEndpointOptions> Fluent_CreateBuilder()
+        => MutableBuilder<BenchmarkEndpointOptions>
+            .New(static () => new BenchmarkEndpointOptions())
+            .With(static options => options.Route = "/orders")
+            .With(static options => options.TimeoutMilliseconds = 250)
+            .RequireNotEmpty(static options => options.Route, nameof(BenchmarkEndpointOptions.Route))
+            .RequireRange(static options => options.TimeoutMilliseconds, 1, 1_000, nameof(BenchmarkEndpointOptions.TimeoutMilliseconds));
+
+    [Benchmark(Description = "Generated: create builder")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public CorporateApplicationBuilder Generated_CreateBuilder()
+        => CorporateApplicationDemo.CreateBuilder();
+
+    [Benchmark(Description = "Fluent: build endpoint options")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public BenchmarkEndpointOptions Fluent_BuildEndpointOptions()
+        => Fluent_CreateBuilder().Build();
+
+    [Benchmark(Description = "Generated: build corporate application")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public async ValueTask<int> Generated_BuildCorporateApplication()
+    {
+        var app = await CorporateApplicationDemo.CreateBuilder()
+            .ForEnvironment(CorporateEnvironment.Production)
+            .EnableMessaging()
+            .EnableJobs()
+            .LoadSecrets()
+            .RequireModules()
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        var featureCount = app.Host.Services.GetService<INotificationPublisher>() is null ? 0 : app.Log.Count;
+        app.Host.Dispose();
+        return featureCount;
+    }
+}
+
+public sealed class BenchmarkEndpointOptions
+{
+    public string Route { get; set; } = string.Empty;
+
+    public int TimeoutMilliseconds { get; set; }
+}

--- a/benchmarks/PatternKit.Benchmarks/Creational/FactoryMethodBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Creational/FactoryMethodBenchmarks.cs
@@ -1,0 +1,73 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Creational.Factory;
+using PatternKit.Examples.Generators.Factories;
+
+namespace PatternKit.Benchmarks.Creational;
+
+[BenchmarkCategory("Creational", "GoF", "FactoryMethod")]
+public class FactoryMethodBenchmarks
+{
+    private static readonly string[] Modules = ["metrics", "workers"];
+
+    [Benchmark(Baseline = true, Description = "Fluent: create factory method")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Factory<string, IServiceCollection, IServiceCollection> Fluent_CreateFactoryMethod()
+        => Factory<string, IServiceCollection, IServiceCollection>
+            .Create(StringComparer.OrdinalIgnoreCase)
+            .Map("metrics", static (in IServiceCollection services) =>
+            {
+                services.AddSingleton<IMetricsSink, ConsoleMetricsSink>();
+                return services;
+            })
+            .Map("caching", static (in IServiceCollection services) =>
+            {
+                services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
+                return services;
+            })
+            .Map("workers", static (in IServiceCollection services) =>
+            {
+                services.AddSingleton<IWorker, BackgroundWorker>();
+                return services;
+            })
+            .Default(static (in IServiceCollection services) =>
+            {
+                services.AddSingleton<IMetricsSink, ConsoleMetricsSink>();
+                services.AddSingleton<IWorker, BackgroundWorker>();
+                return services;
+            })
+            .Build();
+
+    [Benchmark(Description = "Generated: resolve factory method surface")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Type Generated_ResolveFactoryMethodSurface()
+        => typeof(ServiceModules);
+
+    [Benchmark(Description = "Fluent: configure service modules")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public int Fluent_ConfigureServiceModules()
+    {
+        var services = new ServiceCollection();
+        var factory = Fluent_CreateFactoryMethod();
+        foreach (var module in Modules)
+            factory.Create(module, services);
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetServices<IWorker>().Count() + provider.GetServices<IMetricsSink>().Count();
+    }
+
+    [Benchmark(Description = "Generated: configure service modules")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public int Generated_ConfigureServiceModules()
+    {
+        var provider = ServiceModuleBootstrap.Build(Modules);
+        try
+        {
+            return provider.GetServices<IWorker>().Count() + provider.GetServices<IMetricsSink>().Count();
+        }
+        finally
+        {
+            (provider as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Creational/PrototypeBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Creational/PrototypeBenchmarks.cs
@@ -1,0 +1,57 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Creational.Prototype;
+using PatternKit.Examples.PrototypeDemo;
+using PatternKit.Generators.Prototype;
+
+namespace PatternKit.Benchmarks.Creational;
+
+[BenchmarkCategory("Creational", "GoF", "Prototype")]
+public class PrototypeBenchmarks
+{
+    private static readonly GeneratedPrototypeCharacter SourceGeneratedCharacter = new()
+    {
+        Id = "warrior-base",
+        Name = "Warrior",
+        Level = 1,
+        Abilities = ["Slash", "Block"]
+    };
+
+    [Benchmark(Baseline = true, Description = "Fluent: create prototype registry")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Prototype<string, PrototypeDemo.GameCharacter> Fluent_CreatePrototypeRegistry()
+        => PrototypeDemo.CreateCharacterFactory();
+
+    [Benchmark(Description = "Generated: create prototype source")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedPrototypeCharacter Generated_CreatePrototypeSource()
+        => new()
+        {
+            Id = SourceGeneratedCharacter.Id,
+            Name = SourceGeneratedCharacter.Name,
+            Level = SourceGeneratedCharacter.Level,
+            Abilities = new List<string>(SourceGeneratedCharacter.Abilities)
+        };
+
+    [Benchmark(Description = "Fluent: clone character prototype")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public PrototypeDemo.GameCharacter Fluent_CloneCharacterPrototype()
+        => PrototypeDemo.CreateCharacterFactory().Create("elite-warrior");
+
+    [Benchmark(Description = "Generated: clone character prototype")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public GeneratedPrototypeCharacter Generated_CloneCharacterPrototype()
+        => SourceGeneratedCharacter.Clone();
+}
+
+[Prototype(Mode = PrototypeMode.Shallow)]
+public sealed partial class GeneratedPrototypeCharacter
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public int Level { get; set; }
+
+    [PrototypeStrategy(PrototypeCloneStrategy.Clone)]
+    public List<string> Abilities { get; set; } = [];
+}

--- a/benchmarks/PatternKit.Benchmarks/Creational/SingletonBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Creational/SingletonBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Creational.Singleton;
+using PatternKit.Examples.Singleton;
+using PatternKit.Examples.SingletonGeneratorDemo;
+
+namespace PatternKit.Benchmarks.Creational;
+
+[BenchmarkCategory("Creational", "GoF", "Singleton")]
+public class SingletonBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create singleton")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Singleton<PosAppState> Fluent_CreateSingleton()
+        => PosAppStateDemo.BuildLazy();
+
+    [Benchmark(Description = "Generated: resolve singleton surface")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Type Generated_ResolveSingletonSurface()
+        => typeof(ConfigManager);
+
+    [Benchmark(Description = "Fluent: access singleton instance")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public int Fluent_AccessSingletonInstance()
+    {
+        PosAppStateDemo.ResetCounters();
+        var singleton = PosAppStateDemo.BuildLazy();
+        return singleton.Instance.Pricing.WarmedCount + singleton.Instance.Log.Count;
+    }
+
+    [Benchmark(Description = "Generated: access singleton instance")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public string Generated_AccessSingletonInstance()
+        => ConfigManager.Instance.ConnectionString;
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -11,6 +11,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 
 | Pattern | Phase | Fluent mean | Fluent allocation | Generated mean | Generated allocation | Decision signal |
 | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Abstract Factory | Construction | 715.345 ns | 5,992 B | 720.811 ns | 5,992 B | Effectively equivalent for tenant widget factory composition. |
+| Abstract Factory | Execution | 750.189 ns | 6,200 B | 735.733 ns | 6,200 B | Same allocation; generated was slightly faster for login widget creation. |
 | Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -21,6 +23,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Audit Log | Execution | 265.81 ns | 968 B | 273.42 ns | 968 B | Same allocation; fluent was slightly faster for submit-and-approve audit logging. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
+| Builder | Construction | 48.24 ns | 320 B | 160.455 us | 129,236 B | Fluent builder construction is much lighter; generated measures full HostApplicationBuilder composition. |
+| Builder | Execution | 65.14 ns | 352 B | 500.676 us | 279,923 B | Fluent option building is much lighter; generated exercises the full host-backed application build. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -57,6 +61,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
+| Factory Method | Construction | 72.397 ns | 512 B | 0.355 ns | 0 B | Generated static factory surface resolution avoids runtime builder allocation. |
+| Factory Method | Execution | 1.792 us | 10,568 B | 1.681 us | 10,056 B | Generated was faster and allocated less for service-module registration. |
 | Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -97,6 +103,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
+| Prototype | Construction | 886.538 ns | 6,888 B | 20.985 ns | 152 B | Generated clone source construction is much lighter than populating the fluent registry. |
+| Prototype | Execution | 1.193 us | 7,832 B | 21.717 ns | 152 B | Generated cloning was materially faster and allocated less for the character prototype. |
 | Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
 | Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -113,6 +121,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
 | Saga / Process Manager | Construction | 39.453 ns | 272 B | 42.138 ns | 272 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Saga / Process Manager | Execution | 89.969 ns | 672 B | 105.648 ns | 784 B | Fluent was faster and allocated less for the order saga workflow. |
+| Singleton | Construction | 26.618 ns | 184 B | 0.366 ns | 0 B | Generated static singleton surface resolution avoids runtime builder allocation. |
+| Singleton | Execution | 74.198 ns | 504 B | 0.205 ns | 0 B | Generated static singleton access avoids the fluent resolver allocation path. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -28,6 +28,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 
 | Pattern | Phase | Fluent mean | Fluent allocation | Generated mean | Generated allocation | Decision signal |
 | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Abstract Factory | Construction | 715.345 ns | 5,992 B | 720.811 ns | 5,992 B | Effectively equivalent for tenant widget factory composition. |
+| Abstract Factory | Execution | 750.189 ns | 6,200 B | 735.733 ns | 6,200 B | Same allocation; generated was slightly faster for login widget creation. |
 | Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -38,6 +40,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Audit Log | Execution | 265.81 ns | 968 B | 273.42 ns | 968 B | Same allocation; fluent was slightly faster for submit-and-approve audit logging. |
 | Backends For Frontends | Construction | 58.00 ns | 512 B | 42.48 ns | 296 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
+| Builder | Construction | 48.24 ns | 320 B | 160.455 us | 129,236 B | Fluent builder construction is much lighter; generated measures full HostApplicationBuilder composition. |
+| Builder | Execution | 65.14 ns | 352 B | 500.676 us | 279,923 B | Fluent option building is much lighter; generated exercises the full host-backed application build. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -74,6 +78,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Event-Driven Consumer | Execution | 135.584 ns | 888 B | 122.305 ns | 688 B | Generated reduced execution time and allocation for the order-accepted event workflow. |
 | External Configuration Store | Construction | 42.02 ns | 392 B | 41.06 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
+| Factory Method | Construction | 72.397 ns | 512 B | 0.355 ns | 0 B | Generated static factory surface resolution avoids runtime builder allocation. |
+| Factory Method | Execution | 1.792 us | 10,568 B | 1.681 us | 10,056 B | Generated was faster and allocated less for service-module registration. |
 | Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -114,6 +120,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Pipes and Filters | Execution | 138.66 ns | 800 B | 137.18 ns | 800 B | Same allocation; generated was slightly faster for the fulfillment pipeline workflow. |
 | Polling Consumer | Construction | 35.577 ns | 328 B | 4.367 ns | 32 B | Generated materially reduced construction time and allocation in this microbenchmark. |
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
+| Prototype | Construction | 886.538 ns | 6,888 B | 20.985 ns | 152 B | Generated clone source construction is much lighter than populating the fluent registry. |
+| Prototype | Execution | 1.193 us | 7,832 B | 21.717 ns | 152 B | Generated cloning was materially faster and allocated less for the character prototype. |
 | Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
 | Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -130,6 +138,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Routing Slip | Execution | 515.138 ns | 3,504 B | 507.633 ns | 3,568 B | Generated was slightly faster; fluent allocated slightly less for the fulfillment itinerary. |
 | Saga / Process Manager | Construction | 39.453 ns | 272 B | 42.138 ns | 272 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Saga / Process Manager | Execution | 89.969 ns | 672 B | 105.648 ns | 784 B | Fluent was faster and allocated less for the order saga workflow. |
+| Singleton | Construction | 26.618 ns | 184 B | 0.366 ns | 0 B | Generated static singleton surface resolution avoids runtime builder allocation. |
+| Singleton | Execution | 74.198 ns | 504 B | 0.205 ns | 0 B | Generated static singleton access avoids the fluent resolver allocation path. |
 | Priority Queue | Construction | 14.67 ns | 128 B | 14.33 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Priority Queue | Execution | 95.63 ns | 536 B | 93.42 ns | 536 B | Same allocation; generated was slightly faster for the fulfillment scheduling workflow. |
 | Queue-Based Load Leveling | Construction | 17.64 ns | 176 B | 17.54 ns | 176 B | Effectively equivalent for this microbenchmark. |


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet scenarios for Abstract Factory, Builder, Factory Method, Prototype, and Singleton
- cover fluent and source-generated construction/execution routes for each creational pattern
- publish measured fluent vs generated timings in README and benchmark guides

## Validation
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run --project benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories AbstractFactory Builder FactoryMethod Prototype Singleton
- dotnet run --project benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories Builder
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore --logger "console;verbosity=minimal"
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"
