### PR TITLE
perf: add GoF structural benchmark scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Abstract Factory | Construction | 715.345 ns | 5,992 B | 720.811 ns | 5,992 B | Effectively equivalent for tenant widget factory composition. |
 | Abstract Factory | Execution | 750.189 ns | 6,200 B | 735.733 ns | 6,200 B | Same allocation; generated was slightly faster for login widget creation. |
+| Adapter | Construction | 34.668 ns | 320 B | 3.607 ns | 24 B | Generated adapter construction was materially faster and allocated less. |
+| Adapter | Execution | 59.084 ns | 416 B | 20.479 ns | 80 B | Generated adapter execution was faster and allocated less for shipment adaptation. |
 | Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -478,6 +480,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Builder | Construction | 48.24 ns | 320 B | 160.455 us | 129,236 B | Fluent builder construction is much lighter; generated measures full HostApplicationBuilder composition. |
 | Builder | Execution | 65.14 ns | 352 B | 500.676 us | 279,923 B | Fluent option building is much lighter; generated exercises the full host-backed application build. |
+| Bridge | Construction | 53.115 ns | 504 B | 3.821 ns | 24 B | Generated bridge construction was materially faster and allocated less. |
+| Bridge | Execution | 91.848 ns | 664 B | 30.004 ns | 160 B | Generated bridge forwarding was faster and allocated less for notice rendering. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -490,6 +494,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Claim Check | Execution | 355.24 ns | 2,976 B | 342.12 ns | 2,976 B | Same allocation; generated was slightly faster for the large-document restore workflow. |
 | Competing Consumers | Construction | 35.66 ns | 328 B | 35.40 ns | 328 B | Effectively equivalent for this microbenchmark. |
 | Competing Consumers | Execution | 75.34 ns | 416 B | 75.23 ns | 416 B | Effectively equivalent for the fulfillment dispatch workflow. |
+| Composite | Construction | 82.460 ns | 848 B | 30.685 ns | 216 B | Generated composite construction was faster and allocated less for the storage tree. |
+| Composite | Execution | 90.010 ns | 848 B | 36.760 ns | 216 B | Generated composite traversal was faster and allocated less for size calculation. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Content-Based Router | Construction | 42.913 ns | 400 B | 44.118 ns | 400 B | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -502,6 +508,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
+| Decorator | Construction | 34.293 ns | 264 B | 17.669 ns | 168 B | Generated decorator composition was faster and allocated less. |
+| Decorator | Execution | 60.765 ns | 384 B | 35.551 ns | 304 B | Generated decorator execution was faster and allocated less for decorated storage reads. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
 | Event-Carried State Transfer | Construction | 7.552 ns | 48 B | 6.751 ns | 48 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -516,8 +524,12 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
 | Factory Method | Construction | 72.397 ns | 512 B | 0.355 ns | 0 B | Generated static factory surface resolution avoids runtime builder allocation. |
 | Factory Method | Execution | 1.792 us | 10,568 B | 1.681 us | 10,056 B | Generated was faster and allocated less for service-module registration. |
+| Facade | Construction | 59.132 ns | 624 B | 12.567 ns | 112 B | Generated facade construction was faster and allocated less for the shipping facade. |
+| Facade | Execution | 100.182 ns | 664 B | 68.503 ns | 208 B | Generated facade execution was faster and allocated less for shipping quote calculation. |
 | Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
+| Flyweight | Construction | 20.595 ns | 192 B | 23.842 ns | 272 B | Fluent construction was lighter; generated route includes LRU cache infrastructure. |
+| Flyweight | Execution | 58.502 ns | 400 B | 109.987 ns | 704 B | Fluent was faster and allocated less in this LRU-vs-unbounded cache comparison. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
 | Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -558,6 +570,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Prototype | Construction | 886.538 ns | 6,888 B | 20.985 ns | 152 B | Generated clone source construction is much lighter than populating the fluent registry. |
 | Prototype | Execution | 1.193 us | 7,832 B | 21.717 ns | 152 B | Generated cloning was materially faster and allocated less for the character prototype. |
+| Proxy | Construction | 9.099 ns | 88 B | 6.037 ns | 48 B | Generated proxy construction was faster and allocated less. |
+| Proxy | Execution | 20.148 ns | 120 B | 3.116 ns | 0 B | Generated proxy execution avoided allocation and was materially faster for price calculation. |
 | Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
 | Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |

--- a/benchmarks/PatternKit.Benchmarks/Structural/AdapterBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Structural/AdapterBenchmarks.cs
@@ -1,0 +1,91 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Generators.Adapter;
+using PatternKit.Structural.Adapter;
+
+namespace PatternKit.Benchmarks.Structural;
+
+[BenchmarkCategory("Structural", "GoF", "Adapter")]
+public class AdapterBenchmarks
+{
+    private static readonly LegacyShipment LegacyShipment = new("WH-100", 3, 16, "Austin");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create adapter")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Adapter<LegacyShipment, ModernShipment> Fluent_CreateAdapter()
+        => Adapter<LegacyShipment, ModernShipment>
+            .Create(static () => new ModernShipment())
+            .Map(static (in LegacyShipment source, ModernShipment target) =>
+            {
+                target.TrackingCode = source.LegacyId;
+                target.TotalOunces = source.Pounds * 16 + source.Ounces;
+                target.Destination = source.Route;
+            })
+            .Require(static (in LegacyShipment _, ModernShipment target) =>
+                target.TotalOunces <= 0 ? "Shipment weight is required." : null)
+            .Build();
+
+    [Benchmark(Description = "Generated: create adapter")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IModernShipment Generated_CreateAdapter()
+        => new GeneratedShipmentAdapter(LegacyShipment);
+
+    [Benchmark(Description = "Fluent: adapt shipment")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public string Fluent_AdaptShipment()
+    {
+        var shipment = Fluent_CreateAdapter().Adapt(LegacyShipment);
+        return shipment.FormatLabel();
+    }
+
+    [Benchmark(Description = "Generated: adapt shipment")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public string Generated_AdaptShipment()
+    {
+        IModernShipment adapter = new GeneratedShipmentAdapter(LegacyShipment);
+        return adapter.FormatLabel();
+    }
+}
+
+public sealed record LegacyShipment(string LegacyId, int Pounds, int Ounces, string Route);
+
+public sealed class ModernShipment
+{
+    public string TrackingCode { get; set; } = string.Empty;
+
+    public int TotalOunces { get; set; }
+
+    public string Destination { get; set; } = string.Empty;
+
+    public string FormatLabel() => $"{TrackingCode}:{Destination}:{TotalOunces}";
+}
+
+public interface IModernShipment
+{
+    string TrackingCode { get; }
+
+    int TotalOunces { get; }
+
+    string Destination { get; }
+
+    string FormatLabel();
+}
+
+[GenerateAdapter(
+    Target = typeof(IModernShipment),
+    Adaptee = typeof(LegacyShipment),
+    AdapterTypeName = "GeneratedShipmentAdapter")]
+public static partial class ShipmentAdapterMappings
+{
+    [AdapterMap(TargetMember = nameof(IModernShipment.TrackingCode))]
+    public static string MapTrackingCode(LegacyShipment shipment) => shipment.LegacyId;
+
+    [AdapterMap(TargetMember = nameof(IModernShipment.TotalOunces))]
+    public static int MapTotalOunces(LegacyShipment shipment) => shipment.Pounds * 16 + shipment.Ounces;
+
+    [AdapterMap(TargetMember = nameof(IModernShipment.Destination))]
+    public static string MapDestination(LegacyShipment shipment) => shipment.Route;
+
+    [AdapterMap(TargetMember = nameof(IModernShipment.FormatLabel))]
+    public static string MapFormatLabel(LegacyShipment shipment)
+        => $"{shipment.LegacyId}:{shipment.Route}:{shipment.Pounds * 16 + shipment.Ounces}";
+}

--- a/benchmarks/PatternKit.Benchmarks/Structural/BridgeBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Structural/BridgeBenchmarks.cs
@@ -1,0 +1,65 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Generators.Bridge;
+using PatternKit.Structural.Bridge;
+
+namespace PatternKit.Benchmarks.Structural;
+
+[BenchmarkCategory("Structural", "GoF", "Bridge")]
+public class BridgeBenchmarks
+{
+    private static readonly ShipmentNotice Notice = new("order-100", "ops@example.com", 3);
+    private readonly EmailNoticeChannel _channel = new();
+    private readonly GeneratedNoticeRenderer _renderer = new();
+
+    [Benchmark(Baseline = true, Description = "Fluent: create bridge")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Bridge<ShipmentNotice, string, EmailNoticeChannel> Fluent_CreateBridge()
+        => Bridge<ShipmentNotice, string, EmailNoticeChannel>
+            .Create(() => _channel)
+            .Require(static (in ShipmentNotice notice, EmailNoticeChannel _) =>
+                string.IsNullOrWhiteSpace(notice.Recipient) ? "Recipient is required." : null)
+            .Operation(static (in ShipmentNotice notice, EmailNoticeChannel channel) => channel.Render(notice))
+            .After(static (in ShipmentNotice _, EmailNoticeChannel __, string label) => label.ToUpperInvariant())
+            .Build();
+
+    [Benchmark(Description = "Generated: create bridge")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedShipmentNoticeDefault Generated_CreateBridge()
+        => new(_renderer);
+
+    [Benchmark(Description = "Fluent: render notice")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public string Fluent_RenderNotice()
+        => Fluent_CreateBridge().Execute(Notice);
+
+    [Benchmark(Description = "Generated: render notice")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public string Generated_RenderNotice()
+        => new GeneratedShipmentNoticeDefault(_renderer).Render(Notice);
+}
+
+public sealed record ShipmentNotice(string OrderId, string Recipient, int PackageCount);
+
+public sealed class EmailNoticeChannel
+{
+    public string Render(in ShipmentNotice notice)
+        => $"{notice.Recipient}:{notice.OrderId}:{notice.PackageCount}";
+}
+
+[BridgeImplementor]
+public partial interface IGeneratedNoticeRenderer
+{
+    string RenderNotice(ShipmentNotice notice);
+}
+
+public sealed class GeneratedNoticeRenderer : IGeneratedNoticeRenderer
+{
+    public string RenderNotice(ShipmentNotice notice)
+        => $"{notice.Recipient}:{notice.OrderId}:{notice.PackageCount}".ToUpperInvariant();
+}
+
+[BridgeAbstraction(typeof(IGeneratedNoticeRenderer), GenerateDefault = true, DefaultTypeName = "GeneratedShipmentNoticeDefault")]
+public partial class GeneratedShipmentNotice
+{
+    public string Render(ShipmentNotice notice) => RenderNotice(notice);
+}

--- a/benchmarks/PatternKit.Benchmarks/Structural/CompositeBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Structural/CompositeBenchmarks.cs
@@ -1,0 +1,79 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Generators.Composite;
+using PatternKit.Structural.Composite;
+
+namespace PatternKit.Benchmarks.Structural;
+
+[BenchmarkCategory("Structural", "GoF", "Composite")]
+public class CompositeBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create composite")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Composite<string, long> Fluent_CreateComposite()
+        => Composite<string, long>
+            .Node(static (in string _) => 0L, static (in string _, long total, long child) => total + child)
+            .AddChild(Composite<string, long>.Leaf(static (in string _) => 2_048L))
+            .AddChild(Composite<string, long>.Leaf(static (in string _) => 4_096L))
+            .AddChild(Composite<string, long>.Leaf(static (in string _) => 8_192L))
+            .Build();
+
+    [Benchmark(Description = "Generated: create composite")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedFolder Generated_CreateComposite()
+        => CreateGeneratedFolder();
+
+    [Benchmark(Description = "Fluent: calculate tree size")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public long Fluent_CalculateTreeSize()
+        => Fluent_CreateComposite().Execute("");
+
+    [Benchmark(Description = "Generated: calculate tree size")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public long Generated_CalculateTreeSize()
+        => CreateGeneratedFolder().TotalBytes();
+
+    private static GeneratedFolder CreateGeneratedFolder()
+    {
+        var folder = new GeneratedFolder("root");
+        folder.Add(new GeneratedFile("readme.md", 2_048));
+        folder.Add(new GeneratedFile("orders.json", 4_096));
+        folder.Add(new GeneratedFile("archive.zip", 8_192));
+        return folder;
+    }
+}
+
+[CompositeComponent(GenerateTraversalHelpers = true)]
+public partial interface IGeneratedStorageNode
+{
+    string Name { get; }
+}
+
+public sealed class GeneratedFile : GeneratedStorageNodeComponentBase
+{
+    private readonly long _bytes;
+
+    public GeneratedFile(string name, long bytes)
+    {
+        Name = name;
+        _bytes = bytes;
+    }
+
+    public override string Name { get; }
+
+    public long TotalBytes() => _bytes;
+}
+
+public sealed class GeneratedFolder : GeneratedStorageNodeCompositeBase
+{
+    public GeneratedFolder(string name) => Name = name;
+
+    public override string Name { get; }
+
+    public long TotalBytes()
+        => Children.Sum(static child => child switch
+        {
+            GeneratedFile file => file.TotalBytes(),
+            GeneratedFolder folder => folder.TotalBytes(),
+            _ => 0L
+        });
+}

--- a/benchmarks/PatternKit.Benchmarks/Structural/DecoratorBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Structural/DecoratorBenchmarks.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Decorators;
+using PatternKit.Structural.Decorator;
+
+namespace PatternKit.Benchmarks.Structural;
+
+[BenchmarkCategory("Structural", "GoF", "Decorator")]
+public class DecoratorBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create decorator")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Decorator<string, string> Fluent_CreateDecorator()
+        => Decorator<string, string>
+            .Create(static path => $"content:{path}")
+            .Before(static path => path.Trim())
+            .After(static (path, content) => $"{path}:{content.Length}")
+            .Build();
+
+    [Benchmark(Description = "Generated: create decorator")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IFileStorage Generated_CreateDecorator()
+        => FileStorageDecorators.Compose(
+            new InMemoryFileStorage(),
+            static inner => new MetricsFileStorage(inner));
+
+    [Benchmark(Description = "Fluent: read decorated content")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public string Fluent_ReadDecoratedContent()
+        => Fluent_CreateDecorator().Execute("orders.json");
+
+    [Benchmark(Description = "Generated: read decorated content")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public int Generated_ReadDecoratedContent()
+    {
+        var storage = Generated_CreateDecorator();
+        storage.WriteFile("orders.json", "processed");
+        return storage.ReadFile("orders.json").Length;
+    }
+}
+
+public sealed class MetricsFileStorage(IFileStorage inner) : FileStorageDecoratorBase(inner)
+{
+    public int Reads { get; private set; }
+
+    public override string ReadFile(string path)
+    {
+        Reads++;
+        return base.ReadFile(path);
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Structural/FacadeBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Structural/FacadeBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Examples.Generators.Facade;
+using PatternKit.Structural.Facade;
+
+namespace PatternKit.Benchmarks.Structural;
+
+[BenchmarkCategory("Structural", "GoF", "Facade")]
+public class FacadeBenchmarks
+{
+    private static readonly ShipmentQuoteRequest Request = new("national", 12m, "standard");
+
+    [Benchmark(Baseline = true, Description = "Fluent: create facade")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Facade<ShipmentQuoteRequest, string> Fluent_CreateFacade()
+        => Facade<ShipmentQuoteRequest, string>
+            .Create()
+            .Operation("quote", static (in ShipmentQuoteRequest request) =>
+            {
+                var baseRate = request.Destination == "local" ? 5.99m : 19.99m;
+                var surcharge = request.Weight > 5m ? (request.Weight - 5m) * 0.50m : 0m;
+                return $"${baseRate + surcharge:F2}";
+            })
+            .Default(static (in _) => "Invalid operation")
+            .Build();
+
+    [Benchmark(Description = "Generated: create facade")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public ShippingFacade Generated_CreateFacade()
+        => new(new DeliveryEstimator(), new RateCalculator(), new ShippingValidator());
+
+    [Benchmark(Description = "Fluent: get shipping quote")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public string Fluent_GetShippingQuote()
+        => Fluent_CreateFacade().Execute("quote", Request);
+
+    [Benchmark(Description = "Generated: get shipping quote")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public string Generated_GetShippingQuote()
+        => Generated_CreateFacade().GetQuote(Request.Destination, Request.Weight, Request.Speed);
+}
+
+public sealed record ShipmentQuoteRequest(string Destination, decimal Weight, string Speed);

--- a/benchmarks/PatternKit.Benchmarks/Structural/FlyweightBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Structural/FlyweightBenchmarks.cs
@@ -1,0 +1,49 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Generators.Flyweight;
+using PatternKit.Structural.Flyweight;
+
+namespace PatternKit.Benchmarks.Structural;
+
+[BenchmarkCategory("Structural", "GoF", "Flyweight")]
+public class FlyweightBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create flyweight")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Flyweight<string, SkuStyle> Fluent_CreateFlyweight()
+        => Flyweight<string, SkuStyle>
+            .Create()
+            .WithComparer(StringComparer.OrdinalIgnoreCase)
+            .WithFactory(static key => new SkuStyle(key.ToUpperInvariant(), key.Length))
+            .Build();
+
+    [Benchmark(Description = "Generated: create flyweight")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedSkuStyleCache Generated_CreateFlyweight()
+        => new();
+
+    [Benchmark(Description = "Fluent: resolve style")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public int Fluent_ResolveStyle()
+    {
+        var cache = Fluent_CreateFlyweight();
+        return cache.Get("header").Weight + cache.Get("HEADER").Weight;
+    }
+
+    [Benchmark(Description = "Generated: resolve style")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public int Generated_ResolveStyle()
+    {
+        var cache = new GeneratedSkuStyleCache();
+        return cache.Get("header").Weight + cache.Get("HEADER").Weight;
+    }
+}
+
+public sealed record SkuStyle(string Name, int Weight);
+
+[Flyweight(typeof(string), CacheTypeName = "GeneratedSkuStyleCache", Capacity = 32, Eviction = FlyweightEviction.Lru)]
+public readonly partial record struct GeneratedSkuStyle(string Name, int Weight)
+{
+    [FlyweightFactory]
+    private static GeneratedSkuStyle Create(string key)
+        => new(key.ToUpperInvariant(), key.Length);
+}

--- a/benchmarks/PatternKit.Benchmarks/Structural/ProxyBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Structural/ProxyBenchmarks.cs
@@ -1,0 +1,52 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Generators.Proxy;
+using PatternKit.Structural.Proxy;
+
+namespace PatternKit.Benchmarks.Structural;
+
+[BenchmarkCategory("Structural", "GoF", "Proxy")]
+public class ProxyBenchmarks
+{
+    private static readonly PriceRequest Request = new("SKU-100", 3);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create proxy")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Proxy<PriceRequest, decimal> Fluent_CreateProxy()
+        => Proxy<PriceRequest, decimal>
+            .Create(static request => request.Quantity * 12.50m)
+            .Intercept(static (PriceRequest request, Proxy<PriceRequest, decimal>.Subject next) =>
+            {
+                var normalized = request with { Sku = request.Sku.ToUpperInvariant() };
+                var total = next(normalized);
+                return normalized.Sku.StartsWith("SKU-", StringComparison.Ordinal) ? total : 0m;
+            })
+            .Build();
+
+    [Benchmark(Description = "Generated: create proxy")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public IPriceService Generated_CreateProxy()
+        => new PriceServiceProxy(new PriceService());
+
+    [Benchmark(Description = "Fluent: calculate price")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public decimal Fluent_CalculatePrice()
+        => Fluent_CreateProxy().Execute(Request);
+
+    [Benchmark(Description = "Generated: calculate price")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public decimal Generated_CalculatePrice()
+        => new PriceServiceProxy(new PriceService()).Calculate(Request);
+}
+
+public sealed record PriceRequest(string Sku, int Quantity);
+
+[GenerateProxy(InterceptorMode = ProxyInterceptorMode.None)]
+public partial interface IPriceService
+{
+    decimal Calculate(PriceRequest request);
+}
+
+public sealed class PriceService : IPriceService
+{
+    public decimal Calculate(PriceRequest request) => request.Quantity * 12.50m;
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -13,6 +13,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Abstract Factory | Construction | 715.345 ns | 5,992 B | 720.811 ns | 5,992 B | Effectively equivalent for tenant widget factory composition. |
 | Abstract Factory | Execution | 750.189 ns | 6,200 B | 735.733 ns | 6,200 B | Same allocation; generated was slightly faster for login widget creation. |
+| Adapter | Construction | 34.668 ns | 320 B | 3.607 ns | 24 B | Generated adapter construction was materially faster and allocated less. |
+| Adapter | Execution | 59.084 ns | 416 B | 20.479 ns | 80 B | Generated adapter execution was faster and allocated less for shipment adaptation. |
 | Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -25,6 +27,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Builder | Construction | 48.24 ns | 320 B | 160.455 us | 129,236 B | Fluent builder construction is much lighter; generated measures full HostApplicationBuilder composition. |
 | Builder | Execution | 65.14 ns | 352 B | 500.676 us | 279,923 B | Fluent option building is much lighter; generated exercises the full host-backed application build. |
+| Bridge | Construction | 53.115 ns | 504 B | 3.821 ns | 24 B | Generated bridge construction was materially faster and allocated less. |
+| Bridge | Execution | 91.848 ns | 664 B | 30.004 ns | 160 B | Generated bridge forwarding was faster and allocated less for notice rendering. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -37,6 +41,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Claim Check | Execution | 355.24 ns | 2,976 B | 342.12 ns | 2,976 B | Same allocation; generated was slightly faster for the large-document restore workflow. |
 | Competing Consumers | Construction | 35.66 ns | 328 B | 35.40 ns | 328 B | Effectively equivalent for this microbenchmark. |
 | Competing Consumers | Execution | 75.34 ns | 416 B | 75.23 ns | 416 B | Effectively equivalent for the fulfillment dispatch workflow. |
+| Composite | Construction | 82.460 ns | 848 B | 30.685 ns | 216 B | Generated composite construction was faster and allocated less for the storage tree. |
+| Composite | Execution | 90.010 ns | 848 B | 36.760 ns | 216 B | Generated composite traversal was faster and allocated less for size calculation. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Content-Based Router | Construction | 42.913 ns | 400 B | 44.118 ns | 400 B | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -49,6 +55,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
+| Decorator | Construction | 34.293 ns | 264 B | 17.669 ns | 168 B | Generated decorator composition was faster and allocated less. |
+| Decorator | Execution | 60.765 ns | 384 B | 35.551 ns | 304 B | Generated decorator execution was faster and allocated less for decorated storage reads. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
 | Event-Carried State Transfer | Construction | 7.552 ns | 48 B | 6.751 ns | 48 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -63,8 +71,12 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
 | Factory Method | Construction | 72.397 ns | 512 B | 0.355 ns | 0 B | Generated static factory surface resolution avoids runtime builder allocation. |
 | Factory Method | Execution | 1.792 us | 10,568 B | 1.681 us | 10,056 B | Generated was faster and allocated less for service-module registration. |
+| Facade | Construction | 59.132 ns | 624 B | 12.567 ns | 112 B | Generated facade construction was faster and allocated less for the shipping facade. |
+| Facade | Execution | 100.182 ns | 664 B | 68.503 ns | 208 B | Generated facade execution was faster and allocated less for shipping quote calculation. |
 | Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
+| Flyweight | Construction | 20.595 ns | 192 B | 23.842 ns | 272 B | Fluent construction was lighter; generated route includes LRU cache infrastructure. |
+| Flyweight | Execution | 58.502 ns | 400 B | 109.987 ns | 704 B | Fluent was faster and allocated less in this LRU-vs-unbounded cache comparison. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
 | Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -105,6 +117,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Prototype | Construction | 886.538 ns | 6,888 B | 20.985 ns | 152 B | Generated clone source construction is much lighter than populating the fluent registry. |
 | Prototype | Execution | 1.193 us | 7,832 B | 21.717 ns | 152 B | Generated cloning was materially faster and allocated less for the character prototype. |
+| Proxy | Construction | 9.099 ns | 88 B | 6.037 ns | 48 B | Generated proxy construction was faster and allocated less. |
+| Proxy | Execution | 20.148 ns | 120 B | 3.116 ns | 0 B | Generated proxy execution avoided allocation and was materially faster for price calculation. |
 | Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
 | Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -30,6 +30,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Abstract Factory | Construction | 715.345 ns | 5,992 B | 720.811 ns | 5,992 B | Effectively equivalent for tenant widget factory composition. |
 | Abstract Factory | Execution | 750.189 ns | 6,200 B | 735.733 ns | 6,200 B | Same allocation; generated was slightly faster for login widget creation. |
+| Adapter | Construction | 34.668 ns | 320 B | 3.607 ns | 24 B | Generated adapter construction was materially faster and allocated less. |
+| Adapter | Execution | 59.084 ns | 416 B | 20.479 ns | 80 B | Generated adapter execution was faster and allocated less for shipment adaptation. |
 | Aggregator | Construction | 14.562 ns | 168 B | 15.235 ns | 168 B | Same allocation; fluent was slightly faster in this microbenchmark. |
 | Aggregator | Execution | 188.000 ns | 1,088 B | 200.564 ns | 1,088 B | Same allocation; fluent was faster for order line aggregation. |
 | Ambassador | Construction | 55.42 ns | 448 B | 48.03 ns | 360 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -42,6 +44,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Backends For Frontends | Execution | 25.40 ns | 216 B | 29.77 ns | 216 B | Same allocation; fluent was faster for the web summary shaping workflow. |
 | Builder | Construction | 48.24 ns | 320 B | 160.455 us | 129,236 B | Fluent builder construction is much lighter; generated measures full HostApplicationBuilder composition. |
 | Builder | Execution | 65.14 ns | 352 B | 500.676 us | 279,923 B | Fluent option building is much lighter; generated exercises the full host-backed application build. |
+| Bridge | Construction | 53.115 ns | 504 B | 3.821 ns | 24 B | Generated bridge construction was materially faster and allocated less. |
+| Bridge | Execution | 91.848 ns | 664 B | 30.004 ns | 160 B | Generated bridge forwarding was faster and allocated less for notice rendering. |
 | Bulkhead | Construction | 20.56 ns | 216 B | 20.48 ns | 216 B | Effectively equivalent for this microbenchmark. |
 | Bulkhead | Execution | 102.70 ns | 592 B | 106.11 ns | 592 B | Same allocation; fluent was slightly faster for the shipping allocation workflow. |
 | Cache-Aside | Construction | 19.91 ns | 200 B | 19.85 ns | 200 B | Effectively equivalent for this microbenchmark. |
@@ -54,6 +58,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Claim Check | Execution | 355.24 ns | 2,976 B | 342.12 ns | 2,976 B | Same allocation; generated was slightly faster for the large-document restore workflow. |
 | Competing Consumers | Construction | 35.66 ns | 328 B | 35.40 ns | 328 B | Effectively equivalent for this microbenchmark. |
 | Competing Consumers | Execution | 75.34 ns | 416 B | 75.23 ns | 416 B | Effectively equivalent for the fulfillment dispatch workflow. |
+| Composite | Construction | 82.460 ns | 848 B | 30.685 ns | 216 B | Generated composite construction was faster and allocated less for the storage tree. |
+| Composite | Execution | 90.010 ns | 848 B | 36.760 ns | 216 B | Generated composite traversal was faster and allocated less for size calculation. |
 | Circuit Breaker | Construction | 14.33 ns | 128 B | 13.73 ns | 128 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Circuit Breaker | Execution | 85.34 ns | 488 B | 85.19 ns | 488 B | Effectively equivalent for the accepted fulfillment workflow. |
 | Content-Based Router | Construction | 42.913 ns | 400 B | 44.118 ns | 400 B | Same allocation; fluent was slightly faster in this microbenchmark. |
@@ -66,6 +72,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
+| Decorator | Construction | 34.293 ns | 264 B | 17.669 ns | 168 B | Generated decorator composition was faster and allocated less. |
+| Decorator | Execution | 60.765 ns | 384 B | 35.551 ns | 304 B | Generated decorator execution was faster and allocated less for decorated storage reads. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |
 | Domain Event | Execution | 367.2 ns | 1.77 KB | 346.4 ns | 1.55 KB | Generated reduced execution time and allocation for the order-placed dispatch workflow. |
 | Event-Carried State Transfer | Construction | 7.552 ns | 48 B | 6.751 ns | 48 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -80,8 +88,12 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | External Configuration Store | Execution | 34.94 ns | 48 B | 35.78 ns | 48 B | Same allocation; fluent was slightly faster for the cached tenant settings workflow. |
 | Factory Method | Construction | 72.397 ns | 512 B | 0.355 ns | 0 B | Generated static factory surface resolution avoids runtime builder allocation. |
 | Factory Method | Execution | 1.792 us | 10,568 B | 1.681 us | 10,056 B | Generated was faster and allocated less for service-module registration. |
+| Facade | Construction | 59.132 ns | 624 B | 12.567 ns | 112 B | Generated facade construction was faster and allocated less for the shipping facade. |
+| Facade | Execution | 100.182 ns | 664 B | 68.503 ns | 208 B | Generated facade execution was faster and allocated less for shipping quote calculation. |
 | Feature Toggle | Construction | 84.97 ns | 496 B | 82.73 ns | 496 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Feature Toggle | Execution | 151.85 ns | 1,120 B | 150.87 ns | 1,120 B | Effectively equivalent for checkout feature evaluation. |
+| Flyweight | Construction | 20.595 ns | 192 B | 23.842 ns | 272 B | Fluent construction was lighter; generated route includes LRU cache infrastructure. |
+| Flyweight | Execution | 58.502 ns | 400 B | 109.987 ns | 704 B | Fluent was faster and allocated less in this LRU-vs-unbounded cache comparison. |
 | Gateway Aggregation | Construction | 104.21 ns | 856 B | 64.99 ns | 560 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Gateway Aggregation | Execution | 109.55 ns | 632 B | 112.95 ns | 632 B | Same allocation; fluent was slightly faster for the dashboard aggregation workflow. |
 | Gateway Routing | Construction | 56.20 ns | 464 B | 50.72 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
@@ -122,6 +134,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Polling Consumer | Execution | 52.658 ns | 384 B | 15.783 ns | 96 B | Generated reduced execution time and allocation for the replenishment polling workflow. |
 | Prototype | Construction | 886.538 ns | 6,888 B | 20.985 ns | 152 B | Generated clone source construction is much lighter than populating the fluent registry. |
 | Prototype | Execution | 1.193 us | 7,832 B | 21.717 ns | 152 B | Generated cloning was materially faster and allocated less for the character prototype. |
+| Proxy | Construction | 9.099 ns | 88 B | 6.037 ns | 48 B | Generated proxy construction was faster and allocated less. |
+| Proxy | Execution | 20.148 ns | 120 B | 3.116 ns | 0 B | Generated proxy execution avoided allocation and was materially faster for price calculation. |
 | Publish-Subscribe | Construction | 156.89 ns | 1,616 B | 153.49 ns | 1,616 B | Same allocation; generated was slightly faster for topology composition. |
 | Publish-Subscribe | Execution | 6.380 us | 10,386 B | 6.275 us | 10,417 B | Generated was slightly faster; fluent allocated slightly less for two-subscriber dispatch. |
 | Reliability Pipeline | Construction | 34.90 ns | 392 B | 33.16 ns | 328 B | Generated reduced construction time and allocation in this microbenchmark. |


### PR DESCRIPTION
## Summary
- add dedicated BenchmarkDotNet scenarios for Adapter, Bridge, Composite, Decorator, Facade, Flyweight, and Proxy
- cover fluent and source-generated construction/execution routes for each structural pattern
- publish measured fluent vs generated timing/allocation rows in README and benchmark guides

## Validation
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run --project benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories Adapter Bridge Composite Decorator Facade Flyweight Proxy
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore --logger "console;verbosity=minimal"
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"
