### PR TITLE
perf: add GoF behavioral benchmark scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,28 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
 | Wire Tap | Construction | 47.13 ns | 496 B | 40.99 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Wire Tap | Execution | 214.72 ns | 1,232 B | 191.45 ns | 1,064 B | Generated reduced execution time and allocation for the order observability workflow. |
+| Chain of Responsibility | Construction | 58.0959 ns | 656 B | 3.0491 ns | 24 B | Generated chain construction was materially faster and allocated less. |
+| Chain of Responsibility | Execution | 60.2624 ns | 656 B | 4.3664 ns | 0 B | Generated handler dispatch was faster and allocation-free for the approval route. |
+| Command | Construction | 19.6229 ns | 208 B | 3.2500 ns | 24 B | Generated command handler setup was faster and allocated less. |
+| Command | Execution | 23.1740 ns | 232 B | 0.0125 ns | 0 B | Generated static command dispatch removed fluent command allocation overhead in this microbenchmark. |
+| Interpreter | Construction | 149.7429 ns | 1,352 B | 109.6622 ns | 896 B | Generated interpreter factory reduced construction time and allocation. |
+| Interpreter | Execution | 240.8832 ns | 1,464 B | 189.7219 ns | 1,008 B | Generated interpreter rules were faster and allocated less for pricing expressions. |
+| Iterator | Construction | 34.2051 ns | 352 B | 4.8293 ns | 48 B | Generated iterator construction was materially lighter than fluent flow composition. |
+| Iterator | Execution | 84.8700 ns | 480 B | 14.2925 ns | 48 B | Generated iterator execution was faster and allocated less for revenue traversal. |
+| Mediator | Construction | 97.3925 ns | 1,144 B | 37.7610 ns | 416 B | Generated dispatcher mediator construction was faster and allocated less. |
+| Mediator | Execution | 154.8279 ns | 1,320 B | 64.4207 ns | 416 B | Generated dispatcher send path was faster and allocated less for command dispatch. |
+| Memento | Construction | 12.9626 ns | 128 B | 15.7943 ns | 120 B | Fluent construction was slightly faster; generated history allocated slightly less. |
+| Memento | Execution | 116.4308 ns | 376 B | 6.0277 ns | 48 B | Generated memento capture and restore was materially faster and allocated less. |
+| Observer | Construction | 4.9422 ns | 40 B | 6.9757 ns | 56 B | Fluent observer construction was slightly lighter for this small instance. |
+| Observer | Execution | 30.9549 ns | 176 B | 44.3640 ns | 368 B | Fluent publish was lighter for this single-subscriber microbenchmark. |
+| State | Construction | 173.0951 ns | 1,688 B | 3.0356 ns | 24 B | Generated state machine construction was materially faster and allocated less. |
+| State | Execution | 179.4049 ns | 1,688 B | 3.3041 ns | 24 B | Generated transition dispatch was materially faster and allocated less. |
+| Strategy | Construction | 49.6712 ns | 432 B | 49.4027 ns | 432 B | Fluent and generated strategy builders were effectively equivalent. |
+| Strategy | Execution | 51.8884 ns | 432 B | 49.9407 ns | 432 B | Generated strategy execution was slightly faster with the same allocation. |
+| Template Method | Construction | 10.3334 ns | 88 B | 3.0359 ns | 24 B | Generated template construction was faster and allocated less. |
+| Template Method | Execution | 12.9121 ns | 88 B | 0.1900 ns | 0 B | Generated template execution removed fluent delegate overhead in this microbenchmark. |
+| Visitor | Construction | 166.0976 ns | 1,720 B | 9.3177 ns | 112 B | Generated visitor builder construction was materially faster and allocated less. |
+| Visitor | Execution | 197.2918 ns | 1,760 B | 59.6870 ns | 432 B | Generated visitor dispatch was faster and allocated less for document nodes. |
 
 Run the benchmarks on target hardware before making final route decisions:
 

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/ChainOfResponsibilityBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/ChainOfResponsibilityBenchmarks.cs
@@ -1,0 +1,71 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Chain;
+using PatternKit.Generators.Chain;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "ChainOfResponsibility")]
+public class ChainOfResponsibilityBenchmarks
+{
+    private static readonly ApprovalRequest Request = new(2500m, true);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create responsibility chain")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public ResultChain<ApprovalRequest, ApprovalDecision> Fluent_CreateChain()
+        => ResultChain<ApprovalRequest, ApprovalDecision>.Create()
+            .When(static (in ApprovalRequest request) => request.RequiresReview)
+            .Then(static request => new ApprovalDecision("review", request.Amount))
+            .When(static (in ApprovalRequest request) => request.Amount <= 5000m)
+            .Then(static request => new ApprovalDecision("approved", request.Amount))
+            .Finally(static (in ApprovalRequest request, out ApprovalDecision decision, ResultChain<ApprovalRequest, ApprovalDecision>.Next _) =>
+            {
+                decision = new ApprovalDecision("escalated", request.Amount);
+                return true;
+            })
+            .Build();
+
+    [Benchmark(Description = "Generated: create responsibility chain")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedApprovalChain Generated_CreateChain()
+        => new();
+
+    [Benchmark(Description = "Fluent: handle approval request")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ApprovalDecision Fluent_HandleApproval()
+    {
+        var chain = Fluent_CreateChain();
+        chain.Execute(Request, out var decision);
+        return decision;
+    }
+
+    [Benchmark(Description = "Generated: handle approval request")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public ApprovalDecision Generated_HandleApproval()
+        => new GeneratedApprovalChain().Handle(Request);
+}
+
+public readonly record struct ApprovalRequest(decimal Amount, bool RequiresReview);
+
+public readonly record struct ApprovalDecision(string Route, decimal Amount);
+
+[Chain]
+public partial class GeneratedApprovalChain
+{
+    [ChainHandler(Order = 0)]
+    private bool TryReview(in ApprovalRequest request, out ApprovalDecision decision)
+    {
+        decision = new ApprovalDecision("review", request.Amount);
+        return request.RequiresReview;
+    }
+
+    [ChainHandler(Order = 1)]
+    private bool TryApprove(in ApprovalRequest request, out ApprovalDecision decision)
+    {
+        decision = new ApprovalDecision("approved", request.Amount);
+        return request.Amount <= 5000m;
+    }
+
+    [ChainDefault]
+    private ApprovalDecision Escalate(in ApprovalRequest request)
+        => new("escalated", request.Amount);
+}

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/CommandBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/CommandBenchmarks.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Command;
+using PatternKit.Generators.Command;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "Command")]
+public class CommandBenchmarks
+{
+    private readonly FulfillmentCommandService _handler = new();
+    private static readonly ShipOrderCommand Request = new("SO-100", 3);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create command")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Command<FulfillmentContext> Fluent_CreateCommand()
+        => Command<FulfillmentContext>.Create()
+            .Do(static context => context.Reserve(3))
+            .Undo(static context => context.Release(3))
+            .Build();
+
+    [Benchmark(Description = "Generated: create command handler")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public FulfillmentCommandService Generated_CreateCommandHandler()
+        => new();
+
+    [Benchmark(Description = "Fluent: execute command")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public int Fluent_ExecuteCommand()
+    {
+        var context = new FulfillmentContext();
+        Fluent_CreateCommand().Execute(context).GetAwaiter().GetResult();
+        return context.Reserved;
+    }
+
+    [Benchmark(Description = "Generated: execute command")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public int Generated_ExecuteCommand()
+    {
+        ShipOrderCommandCommand.Execute(_handler, in Request);
+        return _handler.TotalReserved;
+    }
+}
+
+public sealed class FulfillmentContext
+{
+    public int Reserved { get; private set; }
+
+    public void Reserve(int quantity) => Reserved += quantity;
+
+    public void Release(int quantity) => Reserved -= quantity;
+}
+
+[Command]
+public readonly partial record struct ShipOrderCommand(string OrderId, int Quantity);
+
+public sealed class FulfillmentCommandService
+{
+    public int TotalReserved { get; private set; }
+
+    [CommandHandler]
+    public void Handle(in ShipOrderCommand command) => TotalReserved += command.Quantity;
+}

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/InterpreterBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/InterpreterBenchmarks.cs
@@ -1,0 +1,61 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Interpreter;
+using PatternKit.Generators.Interpreter;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "Interpreter")]
+public class InterpreterBenchmarks
+{
+    private static readonly PricingContext Context = new(20m);
+    private static readonly IExpression Expression = new NonTerminalExpression(
+        "add",
+        new TerminalExpression("cart", ""),
+        new NonTerminalExpression(
+            "mul",
+            new TerminalExpression("number", "2"),
+            new TerminalExpression("number", "3")));
+
+    [Benchmark(Baseline = true, Description = "Fluent: create interpreter")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Interpreter<PricingContext, decimal> Fluent_CreateInterpreter()
+        => Interpreter.Create<PricingContext, decimal>()
+            .Terminal("number", static token => decimal.Parse(token))
+            .Terminal("cart", static (_, context) => context.CartTotal)
+            .Binary("add", static (left, right) => left + right)
+            .Binary("mul", static (left, right) => left * right)
+            .Build();
+
+    [Benchmark(Description = "Generated: create interpreter")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public Interpreter<PricingContext, decimal> Generated_CreateInterpreter()
+        => GeneratedPricingRules.BuildPricingRules();
+
+    [Benchmark(Description = "Fluent: interpret pricing rule")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public decimal Fluent_InterpretRule()
+        => Fluent_CreateInterpreter().Interpret(Expression, Context);
+
+    [Benchmark(Description = "Generated: interpret pricing rule")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public decimal Generated_InterpretRule()
+        => GeneratedPricingRules.BuildPricingRules().Interpret(Expression, Context);
+}
+
+public sealed record PricingContext(decimal CartTotal);
+
+[GenerateInterpreter(typeof(PricingContext), typeof(decimal), FactoryMethodName = "BuildPricingRules")]
+public static partial class GeneratedPricingRules
+{
+    [InterpreterTerminal("number")]
+    private static decimal Number(string token) => decimal.Parse(token);
+
+    [InterpreterTerminal("cart")]
+    private static decimal Cart(string token, PricingContext context) => context.CartTotal;
+
+    [InterpreterNonTerminal("add")]
+    private static decimal Add(decimal[] args) => args[0] + args[1];
+
+    [InterpreterNonTerminal("mul")]
+    private static decimal Multiply(decimal[] args) => args[0] * args[1];
+}

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/IteratorBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/IteratorBenchmarks.cs
@@ -1,0 +1,77 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Iterator;
+using PatternKit.Generators.Iterator;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "Iterator")]
+public class IteratorBenchmarks
+{
+    private static readonly RevenueLine[] Lines =
+    [
+        new(120m, true),
+        new(80m, false),
+        new(45m, true),
+        new(20m, true)
+    ];
+
+    [Benchmark(Baseline = true, Description = "Fluent: create iterator flow")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Flow<decimal> Fluent_CreateIterator()
+        => Flow<RevenueLine>.From(Lines)
+            .Filter(static line => line.IsBillable)
+            .Map(static line => line.Amount);
+
+    [Benchmark(Description = "Generated: create iterator")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedRevenueIterator Generated_CreateIterator()
+        => new(Lines);
+
+    [Benchmark(Description = "Fluent: iterate revenue lines")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public decimal Fluent_IterateRevenue()
+        => Fluent_CreateIterator().Fold(0m, static (total, amount) => total + amount);
+
+    [Benchmark(Description = "Generated: iterate revenue lines")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public decimal Generated_IterateRevenue()
+    {
+        var iterator = new GeneratedRevenueIterator(Lines);
+        var total = 0m;
+        while (iterator.TryMoveNext(out var amount))
+            total += amount;
+        return total;
+    }
+}
+
+public readonly record struct RevenueLine(decimal Amount, bool IsBillable);
+
+[Iterator]
+public partial class GeneratedRevenueIterator
+{
+    private readonly RevenueLine[] _lines;
+    private int _index;
+
+    public GeneratedRevenueIterator(RevenueLine[] lines)
+    {
+        _lines = lines;
+        _index = 0;
+    }
+
+    [IteratorStep]
+    private bool Step(out decimal amount)
+    {
+        while (_index < _lines.Length)
+        {
+            var current = _lines[_index++];
+            if (!current.IsBillable)
+                continue;
+
+            amount = current.Amount;
+            return true;
+        }
+
+        amount = 0m;
+        return false;
+    }
+}

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/MediatorBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/MediatorBenchmarks.cs
@@ -1,0 +1,48 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Mediator;
+using PatternKit.Generators.Messaging;
+
+[assembly: GenerateDispatcher(
+    Namespace = "PatternKit.Benchmarks.Behavioral.GeneratedMediator",
+    Name = "BenchmarkDispatcher",
+    IncludeStreaming = false)]
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+using GeneratedMediator;
+
+[BenchmarkCategory("Behavioral", "GoF", "Mediator")]
+public class MediatorBenchmarks
+{
+    private static readonly SubmitInvoice Request = new("INV-100", 125m);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create mediator")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Mediator Fluent_CreateMediator()
+        => Mediator.Create()
+            .Command<SubmitInvoice, InvoiceSubmitted>(static (in SubmitInvoice request) =>
+                new InvoiceSubmitted(request.InvoiceId, request.Amount, true))
+            .Build();
+
+    [Benchmark(Description = "Generated: create dispatcher mediator")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public BenchmarkDispatcher Generated_CreateMediator()
+        => BenchmarkDispatcher.Create()
+            .Command<SubmitInvoice, InvoiceSubmitted>(static (request, _) =>
+                new ValueTask<InvoiceSubmitted>(new InvoiceSubmitted(request.InvoiceId, request.Amount, true)))
+            .Build();
+
+    [Benchmark(Description = "Fluent: send mediator command")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public InvoiceSubmitted? Fluent_SendCommand()
+        => Fluent_CreateMediator().Send<SubmitInvoice, InvoiceSubmitted>(Request).GetAwaiter().GetResult();
+
+    [Benchmark(Description = "Generated: send mediator command")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public InvoiceSubmitted Generated_SendCommand()
+        => Generated_CreateMediator().Send<SubmitInvoice, InvoiceSubmitted>(Request).GetAwaiter().GetResult();
+}
+
+public readonly record struct SubmitInvoice(string InvoiceId, decimal Amount);
+
+public readonly record struct InvoiceSubmitted(string InvoiceId, decimal Amount, bool Accepted);

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/MementoBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/MementoBenchmarks.cs
@@ -1,0 +1,54 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Memento;
+using PatternKit.Generators;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "Memento")]
+public class MementoBenchmarks
+{
+    private static readonly EditableInvoice Invoice = new() { InvoiceId = "INV-100", Total = 125m, Status = "Draft" };
+
+    [Benchmark(Baseline = true, Description = "Fluent: create memento history")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Memento<EditableInvoiceState> Fluent_CreateMemento()
+        => Memento<EditableInvoiceState>.Create()
+            .CloneWith(static (in EditableInvoiceState state) => state)
+            .Capacity(16)
+            .Build();
+
+    [Benchmark(Description = "Generated: create memento history")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public EditableInvoiceHistory Generated_CreateMemento()
+        => new(Invoice);
+
+    [Benchmark(Description = "Fluent: capture and restore state")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public EditableInvoiceState Fluent_CaptureAndRestore()
+    {
+        var history = Fluent_CreateMemento();
+        var state = new EditableInvoiceState("INV-100", 125m, "Draft");
+        history.Save(state, "draft");
+        state = state with { Status = "Approved" };
+        history.Save(state, "approved");
+        history.Undo(ref state);
+        return state;
+    }
+
+    [Benchmark(Description = "Generated: capture and restore state")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public EditableInvoice Generated_CaptureAndRestore()
+        => EditableInvoiceMemento.Capture(in Invoice).RestoreNew();
+}
+
+public readonly record struct EditableInvoiceState(string InvoiceId, decimal Total, string Status);
+
+[Memento(GenerateCaretaker = true, Capacity = 16)]
+public partial class EditableInvoice
+{
+    public string InvoiceId { get; set; } = string.Empty;
+
+    public decimal Total { get; set; }
+
+    public string Status { get; set; } = string.Empty;
+}

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/ObserverBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/ObserverBenchmarks.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Observer;
+using PatternKit.Generators.Observer;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "Observer")]
+public class ObserverBenchmarks
+{
+    private static readonly InventoryChanged Event = new("SKU-100", 4);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create observer")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Observer<InventoryChanged> Fluent_CreateObserver()
+        => Observer<InventoryChanged>.Create()
+            .SwallowErrors()
+            .Build();
+
+    [Benchmark(Description = "Generated: create observer")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public InventoryChangedObserver Generated_CreateObserver()
+        => new();
+
+    [Benchmark(Description = "Fluent: publish inventory event")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public int Fluent_PublishEvent()
+    {
+        var total = 0;
+        var observer = Fluent_CreateObserver();
+        observer.Subscribe((in InventoryChanged evt) => total += evt.Quantity);
+        observer.Publish(Event);
+        return total;
+    }
+
+    [Benchmark(Description = "Generated: publish inventory event")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public int Generated_PublishEvent()
+    {
+        var total = 0;
+        var observer = new InventoryChangedObserver();
+        observer.Subscribe((InventoryChanged evt) => total += evt.Quantity);
+        observer.Publish(Event);
+        return total;
+    }
+}
+
+public sealed record InventoryChanged(string Sku, int Quantity);
+
+[Observer(typeof(InventoryChanged), Threading = ObserverThreadingPolicy.SingleThreadedFast)]
+public partial class InventoryChangedObserver;

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/StateBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/StateBenchmarks.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.State;
+using PatternKit.Generators.State;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "State")]
+public class StateBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create state machine")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public StateMachine<OrderWorkflowState, OrderWorkflowTrigger> Fluent_CreateStateMachine()
+        => StateMachine<OrderWorkflowState, OrderWorkflowTrigger>.Create()
+            .InState(OrderWorkflowState.Draft, state => state
+                .When(static (in OrderWorkflowTrigger trigger) => trigger == OrderWorkflowTrigger.Submit)
+                .Permit(OrderWorkflowState.Submitted)
+                .End())
+            .InState(OrderWorkflowState.Submitted, state => state
+                .When(static (in OrderWorkflowTrigger trigger) => trigger == OrderWorkflowTrigger.Pay)
+                .Permit(OrderWorkflowState.Paid)
+                .End())
+            .Build();
+
+    [Benchmark(Description = "Generated: create state machine")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedOrderWorkflow Generated_CreateStateMachine()
+        => new();
+
+    [Benchmark(Description = "Fluent: transition order state")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public OrderWorkflowState Fluent_TransitionState()
+    {
+        var machine = Fluent_CreateStateMachine();
+        var state = OrderWorkflowState.Draft;
+        var submit = OrderWorkflowTrigger.Submit;
+        machine.Transition(ref state, in submit);
+        return state;
+    }
+
+    [Benchmark(Description = "Generated: transition order state")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public OrderWorkflowState Generated_TransitionState()
+    {
+        var machine = new GeneratedOrderWorkflow();
+        machine.Fire(OrderWorkflowTrigger.Submit);
+        return machine.State;
+    }
+}
+
+public enum OrderWorkflowState { Draft, Submitted, Paid }
+
+public enum OrderWorkflowTrigger { Submit, Pay }
+
+[StateMachine(typeof(OrderWorkflowState), typeof(OrderWorkflowTrigger))]
+public partial class GeneratedOrderWorkflow
+{
+    [StateTransition(From = OrderWorkflowState.Draft, Trigger = OrderWorkflowTrigger.Submit, To = OrderWorkflowState.Submitted)]
+    private void OnSubmit() { }
+
+    [StateTransition(From = OrderWorkflowState.Submitted, Trigger = OrderWorkflowTrigger.Pay, To = OrderWorkflowState.Paid)]
+    private void OnPay() { }
+}

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/StrategyBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/StrategyBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Strategy;
+using PatternKit.Generators;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "Strategy")]
+public class StrategyBenchmarks
+{
+    [Benchmark(Baseline = true, Description = "Fluent: create strategy")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Strategy<CustomerScore, string> Fluent_CreateStrategy()
+        => Strategy<CustomerScore, string>.Create()
+            .When(static (in CustomerScore score) => score.Value >= 750).Then(static (in CustomerScore _) => "prime")
+            .When(static (in CustomerScore score) => score.Value >= 650).Then(static (in CustomerScore _) => "standard")
+            .Default(static (in CustomerScore _) => "review")
+            .Build();
+
+    [Benchmark(Description = "Generated: create strategy")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedScoreStrategy Generated_CreateStrategy()
+        => new GeneratedScoreStrategy.Builder()
+            .When(static (in CustomerScore score) => score.Value >= 750).Then(static (in CustomerScore _) => "prime")
+            .When(static (in CustomerScore score) => score.Value >= 650).Then(static (in CustomerScore _) => "standard")
+            .Default(static (in CustomerScore _) => "review")
+            .Build();
+
+    [Benchmark(Description = "Fluent: execute strategy")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public string Fluent_ExecuteStrategy()
+        => Fluent_CreateStrategy().Execute(new CustomerScore(720));
+
+    [Benchmark(Description = "Generated: execute strategy")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public string Generated_ExecuteStrategy()
+        => Generated_CreateStrategy().Execute(new CustomerScore(720));
+}
+
+public readonly record struct CustomerScore(int Value);
+
+[GenerateStrategy(nameof(GeneratedScoreStrategy), typeof(CustomerScore), typeof(string), StrategyKind.Result)]
+public partial class GeneratedScoreStrategyHost;

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/TemplateMethodBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/TemplateMethodBenchmarks.cs
@@ -1,0 +1,64 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Template;
+using PatternKit.Generators.Template;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "TemplateMethod")]
+public class TemplateMethodBenchmarks
+{
+    private static readonly ImportBatch Batch = new("customers", 42);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create template")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public Template<ImportBatch, ImportResult> Fluent_CreateTemplate()
+        => Template<ImportBatch, ImportResult>.Create(static batch => new ImportResult(batch.Source, batch.Rows, true))
+            .Before(static batch => _ = batch.Rows)
+            .After(static (_, _) => { })
+            .Build();
+
+    [Benchmark(Description = "Generated: create template")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedImportWorkflow Generated_CreateTemplate()
+        => new();
+
+    [Benchmark(Description = "Fluent: execute template")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public ImportResult Fluent_ExecuteTemplate()
+        => Fluent_CreateTemplate().Execute(Batch);
+
+    [Benchmark(Description = "Generated: execute template")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public int Generated_ExecuteTemplate()
+    {
+        var context = new GeneratedImportContext(Batch.Source, Batch.Rows);
+        new GeneratedImportWorkflow().Execute(context);
+        return context.ProcessedRows;
+    }
+}
+
+public readonly record struct ImportBatch(string Source, int Rows);
+
+public readonly record struct ImportResult(string Source, int Rows, bool Persisted);
+
+public sealed class GeneratedImportContext(string source, int rows)
+{
+    public string Source { get; } = source;
+
+    public int Rows { get; } = rows;
+
+    public int ProcessedRows { get; set; }
+}
+
+[Template]
+public partial class GeneratedImportWorkflow
+{
+    [TemplateStep(0)]
+    private void Validate(GeneratedImportContext context) => _ = context.Source;
+
+    [TemplateStep(1)]
+    private void Transform(GeneratedImportContext context) => context.ProcessedRows = context.Rows;
+
+    [TemplateStep(2)]
+    private void Persist(GeneratedImportContext context) => context.ProcessedRows += 0;
+}

--- a/benchmarks/PatternKit.Benchmarks/Behavioral/VisitorBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Behavioral/VisitorBenchmarks.cs
@@ -1,0 +1,81 @@
+using BenchmarkDotNet.Attributes;
+using PatternKit.Behavioral.Visitor;
+using PatternKit.Generators.Visitors;
+
+namespace PatternKit.Benchmarks.Behavioral;
+
+[BenchmarkCategory("Behavioral", "GoF", "Visitor")]
+public class VisitorBenchmarks
+{
+    private static readonly GeneratedNumberNode GeneratedNode = new() { Value = 42 };
+    private static readonly FluentNumberNode FluentNode = new(42);
+
+    [Benchmark(Baseline = true, Description = "Fluent: create visitor")]
+    [BenchmarkCategory("Fluent", "Construction")]
+    public FluentVisitor<FluentDocumentNode, string> Fluent_CreateVisitor()
+        => FluentVisitor<FluentDocumentNode, string>.Create()
+            .When<FluentNumberNode>(static node => $"number:{node.Value}")
+            .When<FluentTextNode>(static node => $"text:{node.Text}")
+            .Default(static _ => "unknown")
+            .Build();
+
+    [Benchmark(Description = "Generated: create visitor")]
+    [BenchmarkCategory("Generated", "Construction")]
+    public GeneratedDocumentNodeVisitorBuilder<string> Generated_CreateVisitorBuilder()
+        => new();
+
+    [Benchmark(Description = "Fluent: visit document node")]
+    [BenchmarkCategory("Fluent", "Execution")]
+    public string Fluent_VisitNode()
+        => Fluent_CreateVisitor().Visit(FluentNode);
+
+    [Benchmark(Description = "Generated: visit document node")]
+    [BenchmarkCategory("Generated", "Execution")]
+    public string Generated_VisitNode()
+    {
+        var visitor = new GeneratedDocumentNodeVisitorBuilder<string>()
+            .When<GeneratedNumberNode>(static node => $"number:{node.Value}")
+            .When<GeneratedTextNode>(static node => $"text:{node.Text}")
+            .Default(static _ => "unknown")
+            .Build();
+        return GeneratedNode.Accept(visitor);
+    }
+}
+
+public abstract class FluentDocumentNode : IVisitable
+{
+    public abstract TResult Accept<TResult>(IVisitor<TResult> visitor);
+}
+
+public sealed class FluentNumberNode(int value) : FluentDocumentNode
+{
+    public int Value { get; } = value;
+
+    public override TResult Accept<TResult>(IVisitor<TResult> visitor)
+        => visitor is FluentVisitor<FluentDocumentNode, TResult> fluent
+            ? fluent.Handle(this)
+            : visitor.VisitDefault(this);
+}
+
+public sealed class FluentTextNode(string text) : FluentDocumentNode
+{
+    public string Text { get; } = text;
+
+    public override TResult Accept<TResult>(IVisitor<TResult> visitor)
+        => visitor is FluentVisitor<FluentDocumentNode, TResult> fluent
+            ? fluent.Handle(this)
+            : visitor.VisitDefault(this);
+}
+
+[GenerateVisitor(GenerateActions = false, GenerateAsync = false)]
+public abstract partial class GeneratedDocumentNode;
+
+public partial class GeneratedNumberNode : GeneratedDocumentNode
+{
+    public int Value { get; init; }
+}
+
+public partial class GeneratedTextNode : GeneratedDocumentNode
+{
+    public string Text { get; init; } = string.Empty;
+}

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -169,6 +169,28 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
 | Wire Tap | Construction | 47.13 ns | 496 B | 40.99 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Wire Tap | Execution | 214.72 ns | 1,232 B | 191.45 ns | 1,064 B | Generated reduced execution time and allocation for the order observability workflow. |
+| Chain of Responsibility | Construction | 58.0959 ns | 656 B | 3.0491 ns | 24 B | Generated chain construction was materially faster and allocated less. |
+| Chain of Responsibility | Execution | 60.2624 ns | 656 B | 4.3664 ns | 0 B | Generated handler dispatch was faster and allocation-free for the approval route. |
+| Command | Construction | 19.6229 ns | 208 B | 3.2500 ns | 24 B | Generated command handler setup was faster and allocated less. |
+| Command | Execution | 23.1740 ns | 232 B | 0.0125 ns | 0 B | Generated static command dispatch removed fluent command allocation overhead in this microbenchmark. |
+| Interpreter | Construction | 149.7429 ns | 1,352 B | 109.6622 ns | 896 B | Generated interpreter factory reduced construction time and allocation. |
+| Interpreter | Execution | 240.8832 ns | 1,464 B | 189.7219 ns | 1,008 B | Generated interpreter rules were faster and allocated less for pricing expressions. |
+| Iterator | Construction | 34.2051 ns | 352 B | 4.8293 ns | 48 B | Generated iterator construction was materially lighter than fluent flow composition. |
+| Iterator | Execution | 84.8700 ns | 480 B | 14.2925 ns | 48 B | Generated iterator execution was faster and allocated less for revenue traversal. |
+| Mediator | Construction | 97.3925 ns | 1,144 B | 37.7610 ns | 416 B | Generated dispatcher mediator construction was faster and allocated less. |
+| Mediator | Execution | 154.8279 ns | 1,320 B | 64.4207 ns | 416 B | Generated dispatcher send path was faster and allocated less for command dispatch. |
+| Memento | Construction | 12.9626 ns | 128 B | 15.7943 ns | 120 B | Fluent construction was slightly faster; generated history allocated slightly less. |
+| Memento | Execution | 116.4308 ns | 376 B | 6.0277 ns | 48 B | Generated memento capture and restore was materially faster and allocated less. |
+| Observer | Construction | 4.9422 ns | 40 B | 6.9757 ns | 56 B | Fluent observer construction was slightly lighter for this small instance. |
+| Observer | Execution | 30.9549 ns | 176 B | 44.3640 ns | 368 B | Fluent publish was lighter for this single-subscriber microbenchmark. |
+| State | Construction | 173.0951 ns | 1,688 B | 3.0356 ns | 24 B | Generated state machine construction was materially faster and allocated less. |
+| State | Execution | 179.4049 ns | 1,688 B | 3.3041 ns | 24 B | Generated transition dispatch was materially faster and allocated less. |
+| Strategy | Construction | 49.6712 ns | 432 B | 49.4027 ns | 432 B | Fluent and generated strategy builders were effectively equivalent. |
+| Strategy | Execution | 51.8884 ns | 432 B | 49.9407 ns | 432 B | Generated strategy execution was slightly faster with the same allocation. |
+| Template Method | Construction | 10.3334 ns | 88 B | 3.0359 ns | 24 B | Generated template construction was faster and allocated less. |
+| Template Method | Execution | 12.9121 ns | 88 B | 0.1900 ns | 0 B | Generated template execution removed fluent delegate overhead in this microbenchmark. |
+| Visitor | Construction | 166.0976 ns | 1,720 B | 9.3177 ns | 112 B | Generated visitor builder construction was materially faster and allocated less. |
+| Visitor | Execution | 197.2918 ns | 1,760 B | 59.6870 ns | 432 B | Generated visitor dispatch was faster and allocated less for document nodes. |
 
 ## Coverage Matrix Summary
 

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -186,6 +186,28 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Unit Of Work | Execution | 121.03 ns | 824 B | 96.91 ns | 520 B | Generated reduced execution time and allocation for the checkout commit workflow. |
 | Wire Tap | Construction | 47.13 ns | 496 B | 40.99 ns | 336 B | Generated reduced construction time and allocation in this microbenchmark. |
 | Wire Tap | Execution | 214.72 ns | 1,232 B | 191.45 ns | 1,064 B | Generated reduced execution time and allocation for the order observability workflow. |
+| Chain of Responsibility | Construction | 58.0959 ns | 656 B | 3.0491 ns | 24 B | Generated chain construction was materially faster and allocated less. |
+| Chain of Responsibility | Execution | 60.2624 ns | 656 B | 4.3664 ns | 0 B | Generated handler dispatch was faster and allocation-free for the approval route. |
+| Command | Construction | 19.6229 ns | 208 B | 3.2500 ns | 24 B | Generated command handler setup was faster and allocated less. |
+| Command | Execution | 23.1740 ns | 232 B | 0.0125 ns | 0 B | Generated static command dispatch removed fluent command allocation overhead in this microbenchmark. |
+| Interpreter | Construction | 149.7429 ns | 1,352 B | 109.6622 ns | 896 B | Generated interpreter factory reduced construction time and allocation. |
+| Interpreter | Execution | 240.8832 ns | 1,464 B | 189.7219 ns | 1,008 B | Generated interpreter rules were faster and allocated less for pricing expressions. |
+| Iterator | Construction | 34.2051 ns | 352 B | 4.8293 ns | 48 B | Generated iterator construction was materially lighter than fluent flow composition. |
+| Iterator | Execution | 84.8700 ns | 480 B | 14.2925 ns | 48 B | Generated iterator execution was faster and allocated less for revenue traversal. |
+| Mediator | Construction | 97.3925 ns | 1,144 B | 37.7610 ns | 416 B | Generated dispatcher mediator construction was faster and allocated less. |
+| Mediator | Execution | 154.8279 ns | 1,320 B | 64.4207 ns | 416 B | Generated dispatcher send path was faster and allocated less for command dispatch. |
+| Memento | Construction | 12.9626 ns | 128 B | 15.7943 ns | 120 B | Fluent construction was slightly faster; generated history allocated slightly less. |
+| Memento | Execution | 116.4308 ns | 376 B | 6.0277 ns | 48 B | Generated memento capture and restore was materially faster and allocated less. |
+| Observer | Construction | 4.9422 ns | 40 B | 6.9757 ns | 56 B | Fluent observer construction was slightly lighter for this small instance. |
+| Observer | Execution | 30.9549 ns | 176 B | 44.3640 ns | 368 B | Fluent publish was lighter for this single-subscriber microbenchmark. |
+| State | Construction | 173.0951 ns | 1,688 B | 3.0356 ns | 24 B | Generated state machine construction was materially faster and allocated less. |
+| State | Execution | 179.4049 ns | 1,688 B | 3.3041 ns | 24 B | Generated transition dispatch was materially faster and allocated less. |
+| Strategy | Construction | 49.6712 ns | 432 B | 49.4027 ns | 432 B | Fluent and generated strategy builders were effectively equivalent. |
+| Strategy | Execution | 51.8884 ns | 432 B | 49.9407 ns | 432 B | Generated strategy execution was slightly faster with the same allocation. |
+| Template Method | Construction | 10.3334 ns | 88 B | 3.0359 ns | 24 B | Generated template construction was faster and allocated less. |
+| Template Method | Execution | 12.9121 ns | 88 B | 0.1900 ns | 0 B | Generated template execution removed fluent delegate overhead in this microbenchmark. |
+| Visitor | Construction | 166.0976 ns | 1,720 B | 9.3177 ns | 112 B | Generated visitor builder construction was materially faster and allocated less. |
+| Visitor | Execution | 197.2918 ns | 1,760 B | 59.6870 ns | 432 B | Generated visitor dispatch was faster and allocated less for document nodes. |
 
 The coverage matrix is separate from the scenario timings. Matrix benchmarks prove every catalog pattern and every generator source file has a reportable BenchmarkDotNet route; pattern-specific scenario benchmarks provide the fluent-vs-generated construction and execution numbers shown above. See [Benchmark Results](benchmark-results.md) for the full pattern and generator matrix.
 

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -166,6 +166,9 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
         if (patternName == "CacheAside")
             return "Cache-Aside";
 
+        if (patternName == "ChainOfResponsibility")
+            return "Chain of Responsibility";
+
         if (patternName == "QueueLoadLeveling")
             return "Queue-Based Load Leveling";
 


### PR DESCRIPTION
## Summary
- add dedicated fluent/generated BenchmarkDotNet scenarios for all remaining GoF behavioral patterns
- publish measured behavioral benchmark results in the README and benchmark docs
- map ChainOfResponsibility to the display name used by benchmark coverage validation

## Verification
- dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-restore
- dotnet run --project benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --framework net10.0 --no-build -- --anyCategories ChainOfResponsibility Command Interpreter Iterator Mediator Memento Observer State Strategy TemplateMethod Visitor
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --filter FullyQualifiedName~PatternKitBenchmarkCoverageTests --no-restore --logger "console;verbosity=minimal"
- dotnet test PatternKit.slnx --configuration Release --no-restore --logger "console;verbosity=minimal"