### PR TITLE
docs(benchmarks): publish durable subscriber results

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,8 +512,8 @@ BenchmarkDotNet guidance is documented in [docs/guides/benchmarks.md](docs/guide
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
-| Durable Subscriber | Construction | Pending local rerun | Pending local rerun | Pending local rerun | Pending local rerun | Added benchmark route for checkpointed replay subscriber construction. |
-| Durable Subscriber | Execution | Pending local rerun | Pending local rerun | Pending local rerun | Pending local rerun | Added benchmark route for catch-up projection replay; numbers publish after the next benchmark sweep. |
+| Durable Subscriber | Construction | 98.55 ns | 760 B | 81.45 ns | 616 B | Generated reduced construction time and allocation for checkpointed replay subscriber setup. |
+| Durable Subscriber | Execution | 711.81 ns | 3,912 B | 605.65 ns | 3,128 B | Generated reduced catch-up projection replay time and allocation in this microbenchmark. |
 | Decorator | Construction | 34.293 ns | 264 B | 17.669 ns | 168 B | Generated decorator composition was faster and allocated less. |
 | Decorator | Execution | 60.765 ns | 384 B | 35.551 ns | 304 B | Generated decorator execution was faster and allocated less for decorated storage reads. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -59,8 +59,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
-| Durable Subscriber | Construction | Pending local rerun | Pending local rerun | Pending local rerun | Pending local rerun | Added benchmark route for checkpointed replay subscriber construction. |
-| Durable Subscriber | Execution | Pending local rerun | Pending local rerun | Pending local rerun | Pending local rerun | Added benchmark route for catch-up projection replay; numbers publish after the next benchmark sweep. |
+| Durable Subscriber | Construction | 98.55 ns | 760 B | 81.45 ns | 616 B | Generated reduced construction time and allocation for checkpointed replay subscriber setup. |
+| Durable Subscriber | Execution | 711.81 ns | 3,912 B | 605.65 ns | 3,128 B | Generated reduced catch-up projection replay time and allocation in this microbenchmark. |
 | Decorator | Construction | 34.293 ns | 264 B | 17.669 ns | 168 B | Generated decorator composition was faster and allocated less. |
 | Decorator | Execution | 60.765 ns | 384 B | 35.551 ns | 304 B | Generated decorator execution was faster and allocated less for decorated storage reads. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -76,8 +76,8 @@ The following numbers were captured on Windows 11, Intel Core i9-14900K, .NET SD
 | Data Mapper | Execution | 188.09 ns | 1,104 B | 97.71 ns | 672 B | Generated reduced execution time and allocation for the map-store-load workflow. |
 | Dead Letter Channel | Construction | 12.35 ns | 120 B | 12.50 ns | 120 B | Effectively equivalent for this microbenchmark. |
 | Dead Letter Channel | Execution | 999.95 ns | 7,056 B | 1.023 us | 7,024 B | Generated allocated slightly less, while fluent was slightly faster for capture-and-replay preparation. |
-| Durable Subscriber | Construction | Pending local rerun | Pending local rerun | Pending local rerun | Pending local rerun | Added benchmark route for checkpointed replay subscriber construction. |
-| Durable Subscriber | Execution | Pending local rerun | Pending local rerun | Pending local rerun | Pending local rerun | Added benchmark route for catch-up projection replay; numbers publish after the next benchmark sweep. |
+| Durable Subscriber | Construction | 98.55 ns | 760 B | 81.45 ns | 616 B | Generated reduced construction time and allocation for checkpointed replay subscriber setup. |
+| Durable Subscriber | Execution | 711.81 ns | 3,912 B | 605.65 ns | 3,128 B | Generated reduced catch-up projection replay time and allocation in this microbenchmark. |
 | Decorator | Construction | 34.293 ns | 264 B | 17.669 ns | 168 B | Generated decorator composition was faster and allocated less. |
 | Decorator | Execution | 60.765 ns | 384 B | 35.551 ns | 304 B | Generated decorator execution was faster and allocated less for decorated storage reads. |
 | Domain Event | Construction | 199.5 ns | 1.34 KB | 157.6 ns | 1.04 KB | Generated reduced construction time and allocation in this microbenchmark. |


### PR DESCRIPTION
## Summary
- replace pending Durable Subscriber benchmark rows with measured BenchmarkDotNet current-tfm results
- update README, benchmark guide, and full benchmark-results guide with fluent vs generated timings and allocations

## Benchmark run
- dotnet run --project benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj -c Release --framework net10.0 -- --filter *DurableSubscriberBenchmarks* --artifacts .\BenchmarkDotNet.Artifacts\DurableSubscriberFix --exporters json

## Validation
- dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --no-restore --logger "console;verbosity=minimal" -p:TestTfmsInParallel=false --filter Published_Benchmark_Results
- git diff --check