### PR TITLE
fix(examples): isolate generated control bus state

### DIFF
--- a/src/PatternKit.Examples/Messaging/FulfillmentControlBusExample.cs
+++ b/src/PatternKit.Examples/Messaging/FulfillmentControlBusExample.cs
@@ -120,7 +120,14 @@ public static class FulfillmentControlBuses
 /// <summary>Bridge from generated static handlers to container-owned fulfillment state.</summary>
 public static class FulfillmentProcessorControlRegistry
 {
-    public static FulfillmentProcessorControlState Current { get; set; } = new();
+    private static readonly AsyncLocal<FulfillmentProcessorControlState?> CurrentState = new();
+    private static readonly FulfillmentProcessorControlState DefaultState = new();
+
+    public static FulfillmentProcessorControlState Current
+    {
+        get => CurrentState.Value ?? DefaultState;
+        set => CurrentState.Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
 }
 
 /// <summary>Source-generated control bus for fulfillment operations.</summary>


### PR DESCRIPTION
## Summary
- isolate generated Fulfillment Control Bus handler state with AsyncLocal so parallel tests and request contexts do not share the static registry value

## Validation
- dotnet test test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj --configuration Release --no-restore --logger "console;verbosity=minimal" -p:TestTfmsInParallel=false --filter FulfillmentControlBusExample