### PR TITLE
ci: enforce dotnet format baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           dotnet restore --use-lock-file
           dotnet tool restore
 
+      - name: Verify formatting
+        run: dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
+
       - name: Build (Release)
         run: dotnet build PatternKit.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true
 
@@ -133,6 +136,9 @@ jobs:
         run: |
           dotnet restore --use-lock-file
           dotnet tool restore
+
+      - name: Verify formatting
+        run: dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
 
       - name: Fetch tags
         run: git fetch --prune --tags

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -64,6 +64,9 @@ jobs:
           dotnet restore --use-lock-file
           dotnet tool restore
 
+      - name: Verify formatting
+        run: dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
+
       - name: Build solution
         run: |
           dotnet build PatternKit.slnx \

--- a/docs/guides/quality-gates.md
+++ b/docs/guides/quality-gates.md
@@ -8,6 +8,7 @@ Restore and build the full solution:
 
 ```bash
 dotnet restore PatternKit.slnx --use-lock-file
+dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
 dotnet build PatternKit.slnx --configuration Release --no-restore -m:1
 ```
 
@@ -68,6 +69,6 @@ Every production pattern should have:
 
 ## Formatting and static analysis
 
-The repository includes a root `.editorconfig` so editors and `dotnet format` agree on basic C# layout and style. The current source tree still has historical whitespace that makes a full solution `dotnet format --verify-no-changes` fail with a very large formatting-only diff. Treat that as a dedicated cleanup task, not a drive-by change inside feature work.
+The repository includes a root `.editorconfig` so editors, `dotnet format`, and CI agree on basic C# layout and style. Run `dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal` before opening a PR; CI enforces the same gate for pull requests and `main` releases.
 
 The same rule applies to analyzer hardening. Built-in .NET analyzers currently surface many intentional API-shape warnings for fluent generic factories, benchmark method names, and netstandard-compatible guard code. Enable stricter analyzers by project and rule family with explicit baselines rather than turning on solution-wide warning enforcement in one step.


### PR DESCRIPTION
## Summary
- add a dotnet format --verify-no-changes gate to PR CI and main release CI
- document the enforced format gate in the quality guide
- keep formatting checks before build/test so drift fails quickly

## Validation
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- git diff --check
- dotnet build PatternKit.slnx --configuration Release --no-restore -m:1