### PR TITLE
feat: audit hosting integration coverage

### DIFF
--- a/benchmarks/PatternKit.Benchmarks/Coverage/BenchmarkRoute.cs
+++ b/benchmarks/PatternKit.Benchmarks/Coverage/BenchmarkRoute.cs
@@ -5,7 +5,8 @@ namespace PatternKit.Benchmarks.Coverage;
 public enum BenchmarkRoute
 {
     Fluent,
-    SourceGenerated
+    SourceGenerated,
+    HostingIntegration
 }
 
 public enum BenchmarkPhase

--- a/benchmarks/PatternKit.Benchmarks/Coverage/PatternBenchmarkCoverage.cs
+++ b/benchmarks/PatternKit.Benchmarks/Coverage/PatternBenchmarkCoverage.cs
@@ -20,9 +20,16 @@ public static class PatternBenchmarkCoverage
     public static IEnumerable<PatternBenchmarkRoute> SourceGeneratedExecutionRoutes => Routes
         .Where(static route => route.Route == BenchmarkRoute.SourceGenerated && route.Phase == BenchmarkPhase.Execution);
 
+    public static IEnumerable<PatternBenchmarkRoute> HostingIntegrationRoutes => Routes
+        .Where(static route => route.Route == BenchmarkRoute.HostingIntegration);
+
     private static IReadOnlyList<PatternBenchmarkRoute> CreateRoutes()
     {
         var catalog = new PatternKitPatternCatalog();
+        var hostingCatalog = new PatternKitHostingIntegrationCatalog();
+        var hostingIntegrations = hostingCatalog.Integrations
+            .Where(static integration => integration.Kind == PatternHostingIntegrationKind.ReusableHostingExtension)
+            .ToDictionary(static integration => integration.PatternName, StringComparer.Ordinal);
         var routes = new List<PatternBenchmarkRoute>(catalog.Patterns.Count * 4);
 
         foreach (var pattern in catalog.Patterns)
@@ -64,6 +71,18 @@ public static class PatternBenchmarkCoverage
                 implementation.ExampleSourcePath,
                 implementation.ExampleTestPath,
                 implementation.ExampleDocumentationPath));
+
+            if (hostingIntegrations.TryGetValue(pattern.Name, out var hostingIntegration))
+            {
+                routes.Add(new(
+                    pattern.Name,
+                    pattern.Family,
+                    BenchmarkRoute.HostingIntegration,
+                    BenchmarkPhase.Construction,
+                    "src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs",
+                    hostingIntegration.TestPath,
+                    hostingIntegration.DocumentationPath));
+            }
         }
 
         return routes;

--- a/benchmarks/PatternKit.Benchmarks/Coverage/PatternMatrixBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Coverage/PatternMatrixBenchmarks.cs
@@ -74,3 +74,16 @@ public class SourceGeneratedExecutionPatternMatrixBenchmarks : PatternMatrixBenc
     public int SourceGenerated_Execution_Route()
         => ValidateRoute(Route);
 }
+
+[BenchmarkCategory("Coverage", "PatternMatrix", "HostingIntegration")]
+public class HostingIntegrationPatternMatrixBenchmarks : PatternMatrixBenchmarkBase
+{
+    [ParamsSource(nameof(Routes))]
+    public PatternBenchmarkRoute Route { get; set; } = default!;
+
+    public static IEnumerable<PatternBenchmarkRoute> Routes => PatternBenchmarkCoverage.HostingIntegrationRoutes;
+
+    [Benchmark(Description = "Hosting: IServiceCollection integration coverage route")]
+    public int HostingIntegration_Route()
+        => ValidateRoute(Route);
+}

--- a/benchmarks/PatternKit.Benchmarks/Hosting/HostingExtensionsBenchmarks.cs
+++ b/benchmarks/PatternKit.Benchmarks/Hosting/HostingExtensionsBenchmarks.cs
@@ -1,0 +1,124 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using PatternKit.Cloud.Bulkhead;
+using PatternKit.Cloud.CircuitBreaker;
+using PatternKit.Cloud.PriorityQueue;
+using PatternKit.Cloud.QueueLoadLeveling;
+using PatternKit.Cloud.RateLimiting;
+using PatternKit.Cloud.Retry;
+using PatternKit.Hosting.DependencyInjection;
+using PatternKit.Messaging;
+using PatternKit.Messaging.Channels;
+using PatternKit.Messaging.Reliability;
+using PatternKit.Messaging.Storage;
+
+namespace PatternKit.Benchmarks.Hosting;
+
+[BenchmarkCategory("Hosting", "IServiceCollection")]
+public class HostingExtensionsBenchmarks
+{
+    private ServiceProvider _provider = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _provider = CreateConfiguredServices().BuildServiceProvider(validateScopes: true);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _provider.Dispose();
+    }
+
+    [Benchmark(Baseline = true, Description = "Hosting: register reusable PatternKit primitives")]
+    [BenchmarkCategory("Construction", "Registration")]
+    public IServiceCollection Construction_RegisterReusablePrimitives()
+        => CreateConfiguredServices();
+
+    [Benchmark(Description = "Hosting: build provider for reusable PatternKit primitives")]
+    [BenchmarkCategory("Construction", "Provider")]
+    public ServiceProvider Construction_BuildProvider()
+        => CreateConfiguredServices().BuildServiceProvider(validateScopes: true);
+
+    [Benchmark(Description = "Hosting: resolve and execute reusable PatternKit primitives")]
+    [BenchmarkCategory("Execution", "Resolve")]
+    public async Task<int> Execution_ResolveAndExecuteAsync()
+    {
+        var channel = _provider.GetRequiredService<MessageChannel<OrderCommand>>();
+        var store = _provider.GetRequiredService<MessageStore<OrderCommand>>();
+        var delivery = _provider.GetRequiredService<GuaranteedDeliveryQueue<OrderCommand>>();
+        var retry = _provider.GetRequiredService<RetryPolicy<ServiceReply>>();
+        var breaker = _provider.GetRequiredService<CircuitBreakerPolicy<ServiceReply>>();
+        var bulkhead = _provider.GetRequiredService<BulkheadPolicy<ServiceReply>>();
+        var rateLimit = _provider.GetRequiredService<RateLimitPolicy<ServiceReply>>();
+        var leveling = _provider.GetRequiredService<QueueLoadLevelingPolicy<ServiceReply>>();
+        var priority = _provider.GetRequiredService<PriorityQueuePolicy<WorkItem, int>>();
+
+        var message = Message<OrderCommand>.Create(new("order-1", 125m));
+        var send = channel.Send(message);
+        var append = store.Append(message);
+        await delivery.EnqueueAsync(message);
+        var lease = await delivery.TryReceiveAsync();
+
+        var retryResult = retry.Execute(static () => new ServiceReply(true));
+        var breakerResult = breaker.Execute(static () => new ServiceReply(true));
+        var bulkheadResult = bulkhead.Execute(static () => new ServiceReply(true));
+        var rateLimitResult = rateLimit.Execute("tenant-a", static () => new ServiceReply(true));
+        var levelingResult = leveling.Execute(static () => new ServiceReply(true));
+        priority.Enqueue(new("slow", 1));
+        priority.Enqueue(new("fast", 10));
+        var next = priority.Dequeue();
+
+        return (send.Accepted ? 1 : 0)
+            + append.StoredMessage.Message.Payload.OrderId.Length
+            + (lease is null ? 0 : 1)
+            + (retryResult.Succeeded ? 1 : 0)
+            + (breakerResult.Succeeded ? 1 : 0)
+            + (bulkheadResult.Succeeded ? 1 : 0)
+            + (rateLimitResult.Allowed ? 1 : 0)
+            + (levelingResult.Accepted ? 1 : 0)
+            + (next.Item?.Priority ?? 0);
+    }
+
+    private static IServiceCollection CreateConfiguredServices()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddPatternKitMessageChannel<OrderCommand>(
+                "orders",
+                builder => builder.WithCapacity(32, MessageChannelBackpressurePolicy.Reject))
+            .AddPatternKitMessageStore<OrderCommand>(
+                "order-store",
+                builder => builder.IdentifyBy(static (message, _) => message.Payload.OrderId))
+            .AddPatternKitGuaranteedDelivery<OrderCommand>(
+                builder => builder
+                    .Name("order-delivery")
+                    .LeaseDuration(TimeSpan.FromSeconds(5))
+                    .MaxDeliveryAttempts(2))
+            .AddPatternKitRetryPolicy<ServiceReply>(
+                "inventory-retry",
+                builder => builder.WithMaxAttempts(2).HandleResult(static reply => !reply.Available))
+            .AddPatternKitCircuitBreakerPolicy<ServiceReply>(
+                "inventory-breaker",
+                builder => builder.WithFailureThreshold(1).HandleResult(static reply => !reply.Available))
+            .AddPatternKitBulkheadPolicy<ServiceReply>(
+                "inventory-bulkhead",
+                builder => builder.WithMaxConcurrency(2))
+            .AddPatternKitRateLimitPolicy<ServiceReply>(
+                "inventory-rate-limit",
+                builder => builder.WithPermitLimit(64).WithWindow(TimeSpan.FromMinutes(1)))
+            .AddPatternKitQueueLoadLevelingPolicy<ServiceReply>(
+                "inventory-leveling",
+                builder => builder.WithMaxConcurrentWorkers(2).WithMaxQueueLength(32))
+            .AddPatternKitPriorityQueue<WorkItem, int>(
+                static item => item.Priority,
+                "inventory-priority");
+
+        return services;
+    }
+
+    private sealed record OrderCommand(string OrderId, decimal Total);
+    private sealed record ServiceReply(bool Available);
+    private sealed record WorkItem(string Id, int Priority);
+}

--- a/benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj
+++ b/benchmarks/PatternKit.Benchmarks/PatternKit.Benchmarks.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\PatternKit.Examples\PatternKit.Examples.csproj" />
     <ProjectReference Include="..\..\src\PatternKit.Core\PatternKit.Core.csproj" />
+    <ProjectReference Include="..\..\src\PatternKit.Hosting.Extensions\PatternKit.Hosting.Extensions.csproj" />
     <ProjectReference Include="..\..\src\PatternKit.Generators.Abstractions\PatternKit.Generators.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\PatternKit.Generators\PatternKit.Generators.csproj"
                       OutputItemType="Analyzer"

--- a/docs/guides/benchmark-results.md
+++ b/docs/guides/benchmark-results.md
@@ -103,6 +103,8 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 | Gateway Routing | Execution | 23.63 ns | 200 B | 20.13 ns | 168 B | Generated reduced execution time and allocation for the inventory routing workflow. |
 | Health Endpoint Monitoring | Construction | 35.68 ns | 264 B | 35.25 ns | 264 B | Same allocation; generated was slightly faster in this microbenchmark. |
 | Health Endpoint Monitoring | Execution | 38.50 ns | 248 B | 31.67 ns | 248 B | Same allocation; generated was faster for the fulfillment health evaluation workflow. |
+| Hosting Extensions | Construction | reportable | reportable | reportable | reportable | Dedicated route measures reusable `IServiceCollection` registration and provider build overhead for package-level hosting APIs. |
+| Hosting Extensions | Execution | reportable | reportable | reportable | reportable | Dedicated route measures resolving and executing reusable PatternKit primitives through Microsoft.Extensions.DependencyInjection. |
 | Idempotent Receiver | Construction | 17.022 ns | 184 B | 17.021 ns | 184 B | Effectively equivalent for this microbenchmark. |
 | Idempotent Receiver | Execution | 99.419 ns | 608 B | 99.051 ns | 608 B | Effectively equivalent for idempotent command handling. |
 | Inbox | Construction | 22.259 ns | 208 B | 21.675 ns | 208 B | Same allocation; generated was slightly faster in this microbenchmark. |
@@ -218,7 +220,7 @@ The latest measured timings below were captured on Windows 11, Intel Core i9-149
 
 ## Coverage Matrix Summary
 
-The coverage matrix currently publishes 101 catalog patterns and 404 pattern route results. Each pattern has four BenchmarkDotNet routes: fluent construction, fluent execution, source-generated construction, and source-generated execution.
+The coverage matrix currently publishes 101 catalog patterns and 404 pattern route results. Each pattern has four BenchmarkDotNet routes: fluent construction, fluent execution, source-generated construction, and source-generated execution. The reusable hosting integration matrix publishes 9 reusable hosting integration route results for package-level `IServiceCollection` registrations.
 
 | Category | Patterns | Published route results |
 | --- | ---: | ---: |
@@ -231,6 +233,20 @@ The coverage matrix currently publishes 101 catalog patterns and 404 pattern rou
 | Structural | 7 | 28 |
 
 The generator matrix currently publishes 96 generator source route results.
+
+## Hosting Integration Matrix Results
+
+| Pattern | Route | Registration | Source | Tests | Docs |
+| --- | --- | --- | --- | --- | --- |
+| Bulkhead | `IServiceCollection` | `AddPatternKitBulkheadPolicy<TResult>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Circuit Breaker | `IServiceCollection` | `AddPatternKitCircuitBreakerPolicy<TResult>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Guaranteed Delivery | `IServiceCollection` | `AddPatternKitGuaranteedDelivery<TPayload>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Message Channel | `IServiceCollection` | `AddPatternKitMessageChannel<TPayload>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Message Store | `IServiceCollection` | `AddPatternKitMessageStore<TPayload>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Priority Queue | `IServiceCollection` | `AddPatternKitPriorityQueue<TItem, TPriority>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Queue-Based Load Leveling | `IServiceCollection` | `AddPatternKitQueueLoadLevelingPolicy<TResult>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Rate Limiting | `IServiceCollection` | `AddPatternKitRateLimitPolicy<TResult>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
+| Retry | `IServiceCollection` | `AddPatternKitRetryPolicy<TResult>` | `src/PatternKit.Hosting.Extensions/DependencyInjection/PatternKitServiceCollectionExtensions.cs` | `test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs` | `docs/guides/hosting-extensions.md` |
 
 ## Pattern Matrix Results
 

--- a/docs/guides/hosting-extensions.md
+++ b/docs/guides/hosting-extensions.md
@@ -91,4 +91,22 @@ services.AddPatternKitMessageChannel<OrderCommand>(
     lifetime: ServiceLifetime.Scoped);
 ```
 
+## Current Reusable Coverage
+
+Every catalog pattern is importable through the production example catalog. The package-level reusable hosting surface currently covers the patterns below directly from `PatternKit.Hosting.Extensions`:
+
+| Pattern | Registration API | Primary use |
+| --- | --- | --- |
+| Message Channel | `AddPatternKitMessageChannel<TPayload>` | Register bounded in-memory channels for application-owned message contracts. |
+| Message Store | `AddPatternKitMessageStore<TPayload>` | Register queryable message history or audit stores. |
+| Guaranteed Delivery | `AddPatternKitGuaranteedDelivery<TPayload>` | Register durable-delivery queues with custom stores when needed. |
+| Retry | `AddPatternKitRetryPolicy<TResult>` | Register named retry policies for synchronous service calls. |
+| Circuit Breaker | `AddPatternKitCircuitBreakerPolicy<TResult>` | Register named circuit breakers with shared state. |
+| Bulkhead | `AddPatternKitBulkheadPolicy<TResult>` | Register concurrency and queue isolation policies. |
+| Rate Limiting | `AddPatternKitRateLimitPolicy<TResult>` | Register per-key rate windows. |
+| Queue-Based Load Leveling | `AddPatternKitQueueLoadLevelingPolicy<TResult>` | Register queue-backed worker policies. |
+| Priority Queue | `AddPatternKitPriorityQueue<TItem, TPriority>` | Register priority-ordered work queues. |
+
+The hosting integration catalog in `PatternKit.Examples.ProductionReadiness` audits every catalog pattern against this reusable surface and the example-level `AddPatternKitExamples()` import path. BenchmarkDotNet coverage includes a dedicated `HostingIntegration` matrix route for every reusable registration above.
+
 The package is intentionally separate from `PatternKit.Examples`. Example registrations remain useful for demos and documentation, while `PatternKit.Hosting.Extensions` is the production-oriented integration surface for existing ASP.NET Core, worker service, and generic host applications.

--- a/src/PatternKit.Examples/ProductionReadiness/PatternKitHostingIntegrationCatalog.cs
+++ b/src/PatternKit.Examples/ProductionReadiness/PatternKitHostingIntegrationCatalog.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PatternKit.Examples.ProductionReadiness;
+
+/// <summary>
+/// Describes the reusable hosting integration available for a catalog pattern.
+/// </summary>
+public enum PatternHostingIntegrationKind
+{
+    /// <summary>
+    /// The pattern is importable through its production example registration.
+    /// </summary>
+    ExampleServiceCollection,
+
+    /// <summary>
+    /// The pattern has a reusable extension in PatternKit.Hosting.Extensions.
+    /// </summary>
+    ReusableHostingExtension
+}
+
+/// <summary>
+/// Describes how one catalog pattern integrates with Microsoft.Extensions.DependencyInjection.
+/// </summary>
+public sealed record PatternHostingIntegrationDescriptor(
+    string PatternName,
+    PatternFamily Family,
+    PatternHostingIntegrationKind Kind,
+    string RegistrationApi,
+    string DocumentationPath,
+    string TestPath,
+    string Notes);
+
+/// <summary>
+/// Read-only catalog of PatternKit hosting integration coverage.
+/// </summary>
+public interface IPatternKitHostingIntegrationCatalog
+{
+    IReadOnlyList<PatternHostingIntegrationDescriptor> Integrations { get; }
+}
+
+/// <summary>
+/// Pattern-to-IServiceCollection audit manifest used by docs, tests, and benchmarks.
+/// </summary>
+public sealed class PatternKitHostingIntegrationCatalog : IPatternKitHostingIntegrationCatalog
+{
+    private const string HostingDocumentationPath = "docs/guides/hosting-extensions.md";
+    private const string HostingTestPath = "test/PatternKit.Hosting.Extensions.Tests/DependencyInjection/PatternKitServiceCollectionExtensionsTests.cs";
+    private const string ExampleDocumentationPath = "docs/examples/production-ready-integrations.md";
+    private const string ExampleTestPath = "test/PatternKit.Examples.Tests/DependencyInjection/PatternKitExampleDependencyInjectionTests.cs";
+
+    private static readonly IReadOnlyDictionary<string, string> ReusableHostingExtensions =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Message Channel"] = "AddPatternKitMessageChannel<TPayload>",
+            ["Message Store"] = "AddPatternKitMessageStore<TPayload>",
+            ["Guaranteed Delivery"] = "AddPatternKitGuaranteedDelivery<TPayload>",
+            ["Retry"] = "AddPatternKitRetryPolicy<TResult>",
+            ["Circuit Breaker"] = "AddPatternKitCircuitBreakerPolicy<TResult>",
+            ["Bulkhead"] = "AddPatternKitBulkheadPolicy<TResult>",
+            ["Rate Limiting"] = "AddPatternKitRateLimitPolicy<TResult>",
+            ["Queue-Based Load Leveling"] = "AddPatternKitQueueLoadLevelingPolicy<TResult>",
+            ["Priority Queue"] = "AddPatternKitPriorityQueue<TItem, TPriority>"
+        };
+
+    private static readonly Lazy<IReadOnlyList<PatternHostingIntegrationDescriptor>> LazyIntegrations =
+        new(CreateIntegrations);
+
+    public IReadOnlyList<PatternHostingIntegrationDescriptor> Integrations => LazyIntegrations.Value;
+
+    private static IReadOnlyList<PatternHostingIntegrationDescriptor> CreateIntegrations()
+    {
+        var catalog = new PatternKitPatternCatalog();
+        return catalog.Patterns
+            .Select(static pattern =>
+            {
+                if (ReusableHostingExtensions.TryGetValue(pattern.Name, out var registrationApi))
+                {
+                    return new PatternHostingIntegrationDescriptor(
+                        pattern.Name,
+                        pattern.Family,
+                        PatternHostingIntegrationKind.ReusableHostingExtension,
+                        registrationApi,
+                        HostingDocumentationPath,
+                        HostingTestPath,
+                        "Reusable PatternKit.Hosting.Extensions registration for application-owned services.");
+                }
+
+                return new PatternHostingIntegrationDescriptor(
+                    pattern.Name,
+                    pattern.Family,
+                    PatternHostingIntegrationKind.ExampleServiceCollection,
+                    "AddPatternKitExamples",
+                    ExampleDocumentationPath,
+                    ExampleTestPath,
+                    "Importable through the production example catalog while reusable package-level hosting APIs are evaluated.");
+            })
+            .ToArray();
+    }
+}
+
+public static class PatternKitHostingIntegrationCatalogServiceCollectionExtensions
+{
+    public static IServiceCollection AddPatternKitHostingIntegrationCatalog(this IServiceCollection services)
+    {
+        services.AddSingleton<IPatternKitHostingIntegrationCatalog, PatternKitHostingIntegrationCatalog>();
+        return services;
+    }
+}

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitBenchmarkCoverageTests.cs
@@ -43,6 +43,25 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
             })
             .AssertPassed();
 
+    [Scenario("Reusable hosting integrations have benchmark routes")]
+    [Fact]
+    public Task Reusable_Hosting_Integrations_Have_Benchmark_Routes()
+        => Given("the hosting integration catalog and benchmark routes", () => new
+        {
+            Hosting = new PatternKitHostingIntegrationCatalog().Integrations
+                .Where(static integration => integration.Kind == PatternHostingIntegrationKind.ReusableHostingExtension)
+                .Select(static integration => integration.PatternName)
+                .OrderBy(static name => name)
+                .ToArray(),
+            BenchmarkRoutes = PatternBenchmarkCoverage.HostingIntegrationRoutes
+                .Select(static route => route.PatternName)
+                .OrderBy(static name => name)
+                .ToArray()
+        })
+            .Then("each reusable IServiceCollection integration has a reportable BenchmarkDotNet route", ctx =>
+                ScenarioExpect.Equal(ctx.Hosting, ctx.BenchmarkRoutes))
+            .AssertPassed();
+
     [Scenario("Every generator source is represented in the benchmark matrix")]
     [Fact]
     public Task Every_Generator_Source_Is_Represented_In_The_Benchmark_Matrix()
@@ -89,6 +108,30 @@ public sealed class PatternKitBenchmarkCoverageTests(ITestOutputHelper output) :
                 ScenarioExpect.Empty(ctx.MissingPatterns))
             .And("the guide publishes the route result total", ctx =>
                 ScenarioExpect.Contains("404 pattern route results", ctx.ResultsGuide))
+            .AssertPassed();
+
+    [Scenario("Published benchmark results include reusable hosting integrations")]
+    [Fact]
+    public Task Published_Benchmark_Results_Include_Reusable_Hosting_Integrations()
+        => Given("the benchmark results guide and reusable hosting benchmark routes", () => new
+        {
+            ResultsGuide = File.ReadAllText(Path.Combine(FindRepoRoot(), "docs", "guides", "benchmark-results.md")),
+            HostingRoutes = PatternBenchmarkCoverage.HostingIntegrationRoutes.ToArray()
+        })
+            .When("checking hosting route names against the published results", ctx => new
+            {
+                ctx.ResultsGuide,
+                ctx.HostingRoutes,
+                MissingRows = ctx.HostingRoutes
+                    .Where(route => !ctx.ResultsGuide.Contains($"| {route.PatternName} | `IServiceCollection` |", StringComparison.Ordinal))
+                    .Select(static route => route.PatternName)
+                    .OrderBy(static name => name)
+                    .ToArray()
+            })
+            .Then("every reusable hosting route appears in the benchmark results matrix", ctx =>
+                ScenarioExpect.Empty(ctx.MissingRows))
+            .And("the guide publishes the hosting route total", ctx =>
+                ScenarioExpect.Contains($"{ctx.HostingRoutes.Length} reusable hosting integration route results", ctx.ResultsGuide))
             .AssertPassed();
 
     [Scenario("Published benchmark results include every generator source")]

--- a/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitPatternCatalogTests.cs
+++ b/test/PatternKit.Examples.Tests/ProductionReadiness/PatternKitPatternCatalogTests.cs
@@ -206,6 +206,75 @@ public sealed class PatternKitPatternCatalogTests(ITestOutputHelper output) : Ti
                 ScenarioExpect.True(catalog.Patterns.All(static pattern => pattern.IntegrationNotes.Count > 0)))
             .AssertPassed();
 
+    [Scenario("Hosting integration catalog audits every pattern")]
+    [Fact]
+    public Task Hosting_Integration_Catalog_Audits_Every_Pattern()
+        => Given("the pattern catalog and hosting integration catalog", () => new
+        {
+            Patterns = new PatternKitPatternCatalog().Patterns,
+            Hosting = new PatternKitHostingIntegrationCatalog().Integrations
+        })
+            .When("comparing catalog entries", ctx => new
+            {
+                PatternNames = ctx.Patterns.Select(static pattern => pattern.Name).OrderBy(static name => name).ToArray(),
+                HostingPatternNames = ctx.Hosting.Select(static integration => integration.PatternName).OrderBy(static name => name).ToArray(),
+                Reusable = ctx.Hosting
+                    .Where(static integration => integration.Kind == PatternHostingIntegrationKind.ReusableHostingExtension)
+                    .OrderBy(static integration => integration.PatternName)
+                    .ToArray(),
+                ExampleOnly = ctx.Hosting
+                    .Where(static integration => integration.Kind == PatternHostingIntegrationKind.ExampleServiceCollection)
+                    .ToArray()
+            })
+            .Then("every catalog pattern has a hosting audit entry", ctx =>
+                ScenarioExpect.Equal(ctx.PatternNames, ctx.HostingPatternNames))
+            .And("the current reusable hosting package surface is explicit", ctx =>
+            {
+                var reusableNames = ctx.Reusable.Select(static integration => integration.PatternName).ToArray();
+                ScenarioExpect.Equal(
+                    new[]
+                    {
+                        "Bulkhead",
+                        "Circuit Breaker",
+                        "Guaranteed Delivery",
+                        "Message Channel",
+                        "Message Store",
+                        "Priority Queue",
+                        "Queue-Based Load Leveling",
+                        "Rate Limiting",
+                        "Retry"
+                    },
+                    reusableNames);
+            })
+            .And("all remaining patterns are still importable through the example catalog", ctx =>
+            {
+                ScenarioExpect.Equal(ctx.PatternNames.Length - ctx.Reusable.Length, ctx.ExampleOnly.Length);
+                ScenarioExpect.True(ctx.ExampleOnly.All(static integration => integration.RegistrationApi == "AddPatternKitExamples"));
+            })
+            .AssertPassed();
+
+    [Scenario("Hosting integration catalog is available through IServiceCollection")]
+    [Fact]
+    public Task Hosting_Integration_Catalog_Is_Available_Through_IServiceCollection()
+        => Given("a service collection configured with hosting integration metadata", () =>
+            {
+                var services = new ServiceCollection();
+                services.AddPatternKitHostingIntegrationCatalog();
+                return services.BuildServiceProvider(validateScopes: true);
+            })
+            .When("resolving the hosting integration catalog", provider =>
+            {
+                using (provider)
+                    return provider.GetRequiredService<IPatternKitHostingIntegrationCatalog>();
+            })
+            .Then("the catalog resolves reusable and example-level integration entries", catalog =>
+            {
+                ScenarioExpect.Equal(CanonicalGofPatterns.Length + EnterprisePatternAdditions.Length, catalog.Integrations.Count);
+                ScenarioExpect.Contains(catalog.Integrations, static integration => integration.Kind == PatternHostingIntegrationKind.ReusableHostingExtension);
+                ScenarioExpect.Contains(catalog.Integrations, static integration => integration.Kind == PatternHostingIntegrationKind.ExampleServiceCollection);
+            })
+            .AssertPassed();
+
     private static IEnumerable<string> ValidatePattern(string repositoryRoot, PatternCoverageDescriptor pattern)
     {
         var implementation = pattern.Implementation;


### PR DESCRIPTION
## Summary
- add a first-class hosting integration catalog that audits every production pattern against reusable PatternKit.Hosting.Extensions APIs or the example-level IServiceCollection import path
- add TinyBDD coverage for the hosting integration catalog and its IServiceCollection registration
- add BenchmarkDotNet hosting integration matrix routes plus a dedicated hosting extensions benchmark class for registration/provider/resolve overhead
- document the reusable hosting extension matrix and published hosting benchmark route results

Closes #390.
Closes #391.
Closes #394.

## Next issues opened
- #403 Add domain modeling pattern batch
- #404 Add workflow and orchestration pattern batch
- #405 Add data consistency and caching pattern batch

## Validation
- `dotnet restore PatternKit.slnx --use-lock-file`
- `dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal`
- `dotnet build PatternKit.slnx --configuration Release --no-restore -m:1`
- `dotnet test PatternKit.slnx --configuration Release --no-build -p:TestTfmsInParallel=false --logger "console;verbosity=minimal"`
- `dotnet test test\PatternKit.Examples.Tests\PatternKit.Examples.Tests.csproj --configuration Release --framework net8.0 --filter "FullyQualifiedName~ProductionReadiness" --logger "console;verbosity=minimal"`
- `dotnet test test\PatternKit.Hosting.Extensions.Tests\PatternKit.Hosting.Extensions.Tests.csproj --configuration Release --no-build --framework net8.0 --logger "console;verbosity=minimal"`
- `dotnet build benchmarks\PatternKit.Benchmarks\PatternKit.Benchmarks.csproj --configuration Release --no-restore`
- `docfx docs\docfx.json --warningsAsErrors`