### PR TITLE
ci: normalize maintained source coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             -targetdir:"coverage-report" \
             -reporttypes:"HtmlInline;Cobertura;TextSummary;lcov;Badges" \
             -assemblyfilters:"+PatternKit*;-*Tests*" \
-            -filefilters:"-**/*.Tests/*;-**/*Tests*/**"
+            -filefilters:"-**/*.Tests/*;-**/*Tests*/**;-**/obj/**;-**/bin/**;-**/*.g.cs"
           echo "COVERAGE_SUMMARY<<EOF" >> $GITHUB_ENV
           sed -n '1,60p' coverage-report/Summary.txt >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,19 @@
 ignore:
   - "**/*.Tests/**"
   - "**/*Tests*/**"
+  - "**/bin/**"
+  - "**/obj/**"
+  - "**/*.g.cs"
+
+coverage:
+  status:
+    project:
+      default:
+        target: 95%
+        threshold: 0.1%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 95%
+        threshold: 0.1%
+        if_ci_failed: error

--- a/docs/guides/quality-gates.md
+++ b/docs/guides/quality-gates.md
@@ -12,26 +12,31 @@ dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
 dotnet build PatternKit.slnx --configuration Release --no-restore -m:1
 ```
 
-Run the focused test suite for the area being changed. For broad changes, run the same project-by-project coverage shape used by CI:
+Run the focused test suite for the area being changed. For broad changes, run the same solution-level coverage shape used by CI:
 
 ```bash
-for project in \
-  test/PatternKit.Tests/PatternKit.Tests.csproj \
-  test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj \
-  test/PatternKit.Examples.Tests/PatternKit.Examples.Tests.csproj \
-  test/PatternKit.Hosting.Extensions.Tests/PatternKit.Hosting.Extensions.Tests.csproj
-do
-  dotnet test "$project" \
-    --configuration Release \
-    --no-build \
-    -p:TestTfmsInParallel=false \
-    --collect:"XPlat Code Coverage" \
-    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
-    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[PatternKit*]*" \
-    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests]*" \
-    -- RunConfiguration.TestSessionTimeout=1800000
-done
+dotnet test PatternKit.slnx \
+  --configuration Release \
+  --no-build \
+  -p:TestTfmsInParallel=false \
+  --collect:"XPlat Code Coverage" \
+  --results-directory ./TestResults \
+  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
 ```
+
+Generate the same maintained-source coverage summary that CI publishes:
+
+```bash
+dotnet tool restore
+dotnet tool run reportgenerator \
+  -reports:"TestResults/**/coverage.cobertura.xml" \
+  -targetdir:"coverage-report" \
+  -reporttypes:"TextSummary;Cobertura" \
+  -assemblyfilters:"+PatternKit*;-*Tests*" \
+  -filefilters:"-**/*.Tests/*;-**/*Tests*/**;-**/obj/**;-**/bin/**;-**/*.g.cs"
+```
+
+The Codecov project and patch gates target at least 95% maintained-source coverage. The preferred direction is 99-100%, so coverage work should close real behavior gaps rather than lower thresholds.
 
 Build documentation with warnings treated as failures:
 


### PR DESCRIPTION
Closes #412.

Normalizes repository coverage to maintained source and adds explicit 95% Codecov project/patch targets.

Changes:
- ignores `bin/**`, `obj/**`, and generated `*.g.cs` build output in Codecov
- applies the same maintained-source filters to CI ReportGenerator output
- updates quality-gate docs with the current solution-level coverage command and report generation command

Local validation:
- dotnet test PatternKit.slnx --configuration Release --no-build -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory ./TestResults -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
- dotnet tool run reportgenerator with maintained-source filters: 95.3% line coverage
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- docfx docs\docfx.json --warningsAsErrors