### PR TITLE
test: cover event store generator hosts

### DIFF
--- a/src/PatternKit.Generators/EventSourcing/EventStoreGenerator.cs
+++ b/src/PatternKit.Generators/EventSourcing/EventStoreGenerator.cs
@@ -68,6 +68,48 @@ public sealed class EventStoreGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine();
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var continuationIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Application.EventSourcing.InMemoryEventStore<")
+            .Append(eventName).Append(", ").Append(streamIdName).Append("> ").Append(factoryName).AppendLine("()");
+        sb.Append(continuationIndent).Append("=> global::PatternKit.Application.EventSourcing.InMemoryEventStore<")
+            .Append(eventName).Append(", ").Append(streamIdName).Append(">.Create(\"").Append(Escape(storeName)).AppendLine("\").Build();");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -75,14 +117,7 @@ public sealed class EventStoreGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Application.EventSourcing.InMemoryEventStore<")
-            .Append(eventName).Append(", ").Append(streamIdName).Append("> ").Append(factoryName).AppendLine("()");
-        sb.Append("        => global::PatternKit.Application.EventSourcing.InMemoryEventStore<")
-            .Append(eventName).Append(", ").Append(streamIdName).Append(">.Create(\"").Append(Escape(storeName)).AppendLine("\").Build();");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static string? GetNamedString(AttributeData attribute, string name)

--- a/test/PatternKit.Generators.Tests/EventStoreGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/EventStoreGeneratorTests.cs
@@ -42,6 +42,97 @@ public sealed partial class EventStoreGeneratorTests(ITestOutputHelper output) :
             ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "PKES001"))
         .AssertPassed();
 
+    [Scenario("Generator emits store defaults and host shapes")]
+    [Fact]
+    public Task Generator_Emits_Store_Defaults_And_Host_Shapes()
+        => Given("event store declarations using default names and different host shapes", () => Compile("""
+            using PatternKit.Generators.EventSourcing;
+
+            namespace Demo;
+
+            public abstract record OrderEvent(string OrderId);
+
+            [GenerateEventStore(typeof(OrderEvent), typeof(string))]
+            internal abstract partial class AbstractEventStore;
+
+            [GenerateEventStore(typeof(OrderEvent), typeof(string), StoreName = "tenant\\\"events")]
+            public sealed partial class SealedEventStore;
+
+            [GenerateEventStore(typeof(OrderEvent), typeof(System.Guid))]
+            internal partial struct StructEventStore;
+            """))
+        .Then("generated sources preserve shape and defaults", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractEventStore", combined);
+            ScenarioExpect.Contains("Create(\"AbstractEventStore\")", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedEventStore", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"events\")", combined);
+            ScenarioExpect.Contains("internal partial struct StructEventStore", combined);
+            ScenarioExpect.Contains("InMemoryEventStore<global::Demo.OrderEvent, global::System.Guid>", combined);
+        })
+        .AssertPassed();
+
+    [Scenario("Generator skips malformed event store type arguments")]
+    [Fact]
+    public Task Generator_Skips_Malformed_Event_Store_Type_Arguments()
+        => Given("an event store declaration with a null event type argument", () => Compile("""
+            using PatternKit.Generators.EventSourcing;
+
+            public abstract record OrderEvent(string OrderId);
+
+            [GenerateEventStore(null!, typeof(string))]
+            public static partial class BrokenEventStore;
+            """))
+        .Then("no event store source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
+        .AssertPassed();
+
+    [Scenario("Generator emits nested event store hosts")]
+    [Fact]
+    public Task Generator_Emits_Nested_Event_Store_Hosts()
+        => Given("nested event store declarations with non-public accessibility", () => CompileWithUpdated("""
+            using PatternKit.Generators.EventSourcing;
+
+            namespace Demo;
+
+            public abstract record OrderEvent(string OrderId);
+
+            public partial class StoreContainer
+            {
+                private partial class PrivateStore
+                {
+                    [GenerateEventStore(typeof(OrderEvent), typeof(string))]
+                    protected partial class ProtectedStore;
+
+                    [GenerateEventStore(typeof(OrderEvent), typeof(string))]
+                    private protected partial class PrivateProtectedStore;
+
+                    [GenerateEventStore(typeof(OrderEvent), typeof(string))]
+                    protected internal partial class ProtectedInternalStore;
+                }
+            }
+            """))
+        .Then("generated sources preserve containing type wrappers", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class StoreContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateStore", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedStore", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedStore", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalStore", combined);
+
+            var emit = result.Updated.Emit(Stream.Null);
+            ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        })
+        .AssertPassed();
+
     private static GeneratorResult Compile(string source)
     {
         var compilation = RoslynTestHelpers.CreateCompilation(
@@ -53,5 +144,24 @@ public sealed partial class EventStoreGeneratorTests(ITestOutputHelper output) :
         return new GeneratorResult(result.Diagnostics.ToArray(), result.GeneratedSources.Select(static source => source.SourceText.ToString()).ToArray());
     }
 
+    private static GeneratorCompilationResult CompileWithUpdated(string source)
+    {
+        var compilation = RoslynTestHelpers.CreateCompilation(
+            source,
+            "EventStoreGeneratorTests",
+            extra: MetadataReference.CreateFromFile(typeof(InMemoryEventStore<,>).Assembly.Location));
+        _ = RoslynTestHelpers.Run(compilation, new EventStoreGenerator(), out var run, out var updated);
+        var result = run.Results.Single();
+        return new GeneratorCompilationResult(
+            result.Diagnostics.ToArray(),
+            result.GeneratedSources.Select(static source => source.SourceText.ToString()).ToArray(),
+            updated);
+    }
+
     private sealed record GeneratorResult(IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<string> GeneratedSources);
+
+    private sealed record GeneratorCompilationResult(
+        IReadOnlyList<Diagnostic> Diagnostics,
+        IReadOnlyList<string> GeneratedSources,
+        Compilation Updated);
 }


### PR DESCRIPTION
## Summary
- add TinyBDD coverage for EventStore default store names, escaped names, abstract/sealed/internal/struct hosts, and malformed type arguments
- fix nested event-store hosts by generating containing partial type wrappers instead of invalid top-level nested type declarations
- add emit-validated nested host coverage for private/protected/private protected/protected internal event-store declarations
- raise EventStoreGenerator source coverage from 81.8% to 98.8% in the generator-only report

Part of #413.

## Validation
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --framework net10.0 --filter "FullyQualifiedName~EventStoreGeneratorTests" --logger "console;verbosity=minimal"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory .\TestResults --logger "console;verbosity=minimal" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
- dotnet tool run reportgenerator -reports:"TestResults\**\coverage.cobertura.xml" -targetdir:"coverage-report-generators" -reporttypes:"TextSummary;Cobertura" -assemblyfilters:"+PatternKit.Generators" -filefilters:"-**/*.Tests/*;-**/*Tests*/**;-**/obj/**;-**/bin/**;-**/*.g.cs"
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore --no-build -p:TestTfmsInParallel=false --logger "console;verbosity=minimal"