### PR TITLE
test: cover dynamic router and durable subscriber generators

### DIFF
--- a/src/PatternKit.Generators/Messaging/DurableSubscriberGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/DurableSubscriberGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -87,24 +88,79 @@ public sealed class DurableSubscriberGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Messaging.Consumers.DurableSubscriber<")
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var chainIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Messaging.Consumers.DurableSubscriber<")
             .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
             .Append("> ").Append(factoryName).Append("(global::PatternKit.Messaging.Storage.MessageStore<")
             .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
             .AppendLine("> store, global::PatternKit.Messaging.Consumers.IDurableSubscriberCheckpointStore checkpoints)");
-        sb.Append("        => global::PatternKit.Messaging.Consumers.DurableSubscriber<")
+        sb.Append(chainIndent).Append("=> global::PatternKit.Messaging.Consumers.DurableSubscriber<")
             .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
             .Append(">.Create(").Append(ToLiteral(subscriberName)).AppendLine(")");
-        sb.AppendLine("            .From(store)");
-        sb.AppendLine("            .TrackWith(checkpoints)");
+        sb.Append(chainIndent).AppendLine("    .From(store)");
+        sb.Append(chainIndent).AppendLine("    .TrackWith(checkpoints)");
         foreach (var handler in handlers)
-            sb.Append("            .Handle(").Append(ToLiteral(GetHandlerName(handler))).Append(", ").Append(handler.Name).AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("}");
+            sb.Append(chainIndent).Append("    .Handle(").Append(ToLiteral(GetHandlerName(handler))).Append(", ").Append(handler.Name).AppendLine(")");
+        sb.Append(chainIndent).AppendLine("    .Build();");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
         return sb.ToString();
     }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
+        sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
+        if (type.IsStatic)
+            sb.Append("static ");
+        else if (type.IsAbstract && type.TypeKind == TypeKind.Class)
+            sb.Append("abstract ");
+        else if (type.IsSealed && type.TypeKind == TypeKind.Class)
+            sb.Append("sealed ");
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
+    }
+
+    private static string GetAccessibility(Accessibility accessibility)
+        => accessibility switch
+        {
+            Accessibility.Public => "public",
+            Accessibility.Internal => "internal",
+            Accessibility.Private => "private",
+            Accessibility.Protected => "protected",
+            Accessibility.ProtectedAndInternal => "private protected",
+            Accessibility.ProtectedOrInternal => "protected internal",
+            _ => "internal"
+        };
 
     private static string GetHandlerName(IMethodSymbol handler)
     {

--- a/src/PatternKit.Generators/Messaging/DynamicRouterGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/DynamicRouterGenerator.cs
@@ -219,34 +219,86 @@ public sealed class DynamicRouterGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
-        sb.Append("partial ").Append(GetKind(type)).Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Messaging.Routing.DynamicRouter<")
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var chainIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Messaging.Routing.DynamicRouter<")
             .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
             .Append(", ")
             .Append(resultType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
             .Append("> ")
             .Append(factoryName)
             .AppendLine("()");
-        sb.Append("        => global::PatternKit.Messaging.Routing.DynamicRouter<")
+        sb.Append(chainIndent).Append("=> global::PatternKit.Messaging.Routing.DynamicRouter<")
             .Append(payloadType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
             .Append(", ")
             .Append(resultType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
             .AppendLine(">.Create()");
 
         foreach (var route in routes)
-            sb.Append("            .When(@\"").Append(route.Name).Append("\", ").Append(route.Order).Append(", ").Append(route.PredicateMethodName).Append(").Then(").Append(route.HandlerMethodName).AppendLine(")");
+            sb.Append(chainIndent).Append("    .When(@\"").Append(route.Name).Append("\", ").Append(route.Order).Append(", ").Append(route.PredicateMethodName).Append(").Then(").Append(route.HandlerMethodName).AppendLine(")");
 
         if (defaultHandler is not null)
-            sb.Append("            .Default(").Append(defaultHandler).AppendLine(")");
+            sb.Append(chainIndent).Append("    .Default(").Append(defaultHandler).AppendLine(")");
 
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("}");
+        sb.Append(chainIndent).AppendLine("    .Build();");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
         return sb.ToString();
     }
 
-    private static string GetKind(INamedTypeSymbol type)
-        => type.TypeKind == TypeKind.Struct ? "struct" : "class";
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
+        sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
+        if (type.IsStatic)
+            sb.Append("static ");
+        else if (type.IsAbstract && type.TypeKind == TypeKind.Class)
+            sb.Append("abstract ");
+        else if (type.IsSealed && type.TypeKind == TypeKind.Class)
+            sb.Append("sealed ");
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
+    }
+
+    private static string GetAccessibility(Accessibility accessibility)
+        => accessibility switch
+        {
+            Accessibility.Public => "public",
+            Accessibility.Internal => "internal",
+            Accessibility.Private => "private",
+            Accessibility.Protected => "protected",
+            Accessibility.ProtectedAndInternal => "private protected",
+            Accessibility.ProtectedOrInternal => "protected internal",
+            _ => "internal"
+        };
 
     private static string? GetNamedString(AttributeData attribute, string name)
         => attribute.NamedArguments.FirstOrDefault(kv => kv.Key == name).Value.Value as string;

--- a/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
+++ b/test/PatternKit.Generators.Tests/AbstractionsAttributeCoverageTests.cs
@@ -1465,6 +1465,17 @@ public sealed class AbstractionsAttributeCoverageTests
         };
         var translatorDrop = new MessageTranslatorDropHeaderAttribute("raw-signature");
         var translatorHeader = new MessageTranslatorHeaderAttribute("content-type", "application/vnd.demo+json");
+        var dynamicRouter = new GenerateDynamicRouterAttribute(typeof(string), typeof(int))
+        {
+            FactoryName = "BuildDynamicRouter"
+        };
+        var dynamicRoute = new DynamicRouteAttribute("vip", 2, "IsVip");
+        var durableSubscriber = new GenerateDurableSubscriberAttribute(typeof(string))
+        {
+            FactoryName = "BuildDurableSubscriber",
+            SubscriberName = "shipment-projection"
+        };
+        var durableHandler = new DurableSubscriberHandlerAttribute("project");
 
         ScenarioExpect.Equal(typeof(string), flyweight.KeyType);
         ScenarioExpect.Equal("SymbolCache", flyweight.CacheTypeName);
@@ -1645,6 +1656,16 @@ public sealed class AbstractionsAttributeCoverageTests
         ScenarioExpect.Equal("raw-signature", translatorDrop.Name);
         ScenarioExpect.Equal("content-type", translatorHeader.Name);
         ScenarioExpect.Equal("application/vnd.demo+json", translatorHeader.Value);
+        ScenarioExpect.Equal(typeof(string), dynamicRouter.PayloadType);
+        ScenarioExpect.Equal(typeof(int), dynamicRouter.ResultType);
+        ScenarioExpect.Equal("BuildDynamicRouter", dynamicRouter.FactoryName);
+        ScenarioExpect.Equal("vip", dynamicRoute.Name);
+        ScenarioExpect.Equal(2, dynamicRoute.Order);
+        ScenarioExpect.Equal("IsVip", dynamicRoute.PredicateMethodName);
+        ScenarioExpect.Equal(typeof(string), durableSubscriber.PayloadType);
+        ScenarioExpect.Equal("BuildDurableSubscriber", durableSubscriber.FactoryName);
+        ScenarioExpect.Equal("shipment-projection", durableSubscriber.SubscriberName);
+        ScenarioExpect.Equal("project", durableHandler.Name);
         ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateMessageChannelAttribute(null!));
         ScenarioExpect.Equal(typeof(string), messageBus.PayloadType);
         ScenarioExpect.Equal("BuildBus", messageBus.FactoryName);
@@ -1745,6 +1766,13 @@ public sealed class AbstractionsAttributeCoverageTests
         ScenarioExpect.Throws<ArgumentException>(() => new MessageTranslatorDropHeaderAttribute(""));
         ScenarioExpect.Throws<ArgumentException>(() => new MessageTranslatorHeaderAttribute("", "value"));
         ScenarioExpect.Throws<ArgumentNullException>(() => new MessageTranslatorHeaderAttribute("content-type", null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateDynamicRouterAttribute(null!, typeof(int)));
+        ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateDynamicRouterAttribute(typeof(string), null!));
+        ScenarioExpect.Throws<ArgumentException>(() => new DynamicRouteAttribute("", 1, "Predicate"));
+        ScenarioExpect.Throws<ArgumentException>(() => new DynamicRouteAttribute("route", 1, ""));
+        ScenarioExpect.IsType<DynamicRouteDefaultAttribute>(new DynamicRouteDefaultAttribute());
+        ScenarioExpect.Throws<ArgumentNullException>(() => new GenerateDurableSubscriberAttribute(null!));
+        ScenarioExpect.Throws<ArgumentException>(() => new DurableSubscriberHandlerAttribute(""));
         ScenarioExpect.IsType<MessageTranslatorHandlerAttribute>(new MessageTranslatorHandlerAttribute());
         ScenarioExpect.IsType<SagaCompleteWhenAttribute>(new SagaCompleteWhenAttribute());
         ScenarioExpect.IsType<ContentRouteDefaultAttribute>(new ContentRouteDefaultAttribute());

--- a/test/PatternKit.Generators.Tests/DurableSubscriberGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/DurableSubscriberGeneratorTests.cs
@@ -1,23 +1,25 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using PatternKit.Generators.Messaging;
+using PatternKit.Messaging.Consumers;
 using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Generators.Tests;
 
-public sealed class DurableSubscriberGeneratorTests
+[Feature("Durable Subscriber generator")]
+public sealed partial class DurableSubscriberGeneratorTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
-    [Scenario("GeneratesDurableSubscriberFactory")]
+    [Scenario("Generator emits durable subscriber factory")]
     [Fact]
-    public void GeneratesDurableSubscriberFactory()
-    {
-        var source = """
+    public Task Generator_Emits_Durable_Subscriber_Factory()
+        => Given("a valid durable subscriber declaration", () => Compile("""
             using PatternKit.Generators.Messaging;
             using PatternKit.Messaging;
             using PatternKit.Messaging.Consumers;
             using PatternKit.Messaging.Storage;
 
-            namespace MyApp;
+            namespace Demo;
 
             public sealed record Order(string Id);
 
@@ -28,73 +30,196 @@ public sealed class DurableSubscriberGeneratorTests
                 private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
                     => DurableSubscriberHandlerResult.Success("project");
             }
-            """;
+            """))
+        .Then("generated source creates the subscriber", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            var source = ScenarioExpect.Single(result.GeneratedSources);
+            ScenarioExpect.Contains("public static partial class ShippingSubscriber", source);
+            ScenarioExpect.Contains("DurableSubscriber<global::Demo.Order>", source);
+            ScenarioExpect.Contains(".From(store)", source);
+            ScenarioExpect.Contains(".TrackWith(checkpoints)", source);
+            ScenarioExpect.Contains(".Handle(@\"project\", Project)", source);
+            ScenarioExpect.True(result.EmitSuccess, result.EmitDiagnostics);
+        })
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(GeneratesDurableSubscriberFactory));
-        _ = RoslynTestHelpers.Run(comp, new DurableSubscriberGenerator(), out var run, out var updated);
-
-        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
-        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
-        ScenarioExpect.Equal("ShippingSubscriber.DurableSubscriber.g.cs", generated.HintName);
-        var text = generated.SourceText.ToString();
-        ScenarioExpect.Contains("DurableSubscriber<global::MyApp.Order>", text);
-        ScenarioExpect.Contains(".From(store)", text);
-        ScenarioExpect.Contains(".TrackWith(checkpoints)", text);
-        ScenarioExpect.Contains(".Handle(@\"project\", Project)", text);
-
-        var emit = updated.Emit(Stream.Null);
-        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
-    }
-
-    [Scenario("ReportsDurableSubscriberDiagnostics")]
+    [Scenario("Generator reports invalid durable subscriber declarations")]
     [Theory]
     [InlineData("public static class ShippingSubscriber { }", "PKDS001")]
     [InlineData("public static partial class ShippingSubscriber { }", "PKDS002")]
-    public void ReportsDurableSubscriberDiagnostics(string declaration, string expected)
-    {
-        var source = $$"""
+    [InlineData("public static partial class ShippingSubscriber { [DurableSubscriberHandler(\"project\")] private static int Project(Order order) => 1; }", "PKDS003")]
+    [InlineData("public partial class ShippingSubscriber { [DurableSubscriberHandler(\"project\")] private DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context) => DurableSubscriberHandlerResult.Success(\"project\"); }", "PKDS003")]
+    [InlineData("public static partial class ShippingSubscriber { [DurableSubscriberHandler(\"project\")] private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message) => DurableSubscriberHandlerResult.Success(\"project\"); }", "PKDS003")]
+    [InlineData("public static partial class ShippingSubscriber { [DurableSubscriberHandler(\"project\")] private static DurableSubscriberHandlerResult Project(StoredMessage<string> message, MessageContext context) => DurableSubscriberHandlerResult.Success(\"project\"); }", "PKDS003")]
+    [InlineData("public static partial class ShippingSubscriber { [DurableSubscriberHandler(\"project\")] private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, string context) => DurableSubscriberHandlerResult.Success(\"project\"); }", "PKDS003")]
+    public Task Generator_Reports_Invalid_Durable_Subscriber_Declarations(string declaration, string expected)
+        => Given("an invalid durable subscriber declaration", () => Compile($$"""
             using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+            using PatternKit.Messaging.Consumers;
+            using PatternKit.Messaging.Storage;
 
-            namespace MyApp;
+            namespace Demo;
             public sealed record Order(string Id);
             [GenerateDurableSubscriber(typeof(Order))]
             {{declaration}}
-            """;
+            """))
+        .Then("the expected diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == expected))
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(ReportsDurableSubscriberDiagnostics) + expected);
-        _ = RoslynTestHelpers.Run(comp, new DurableSubscriberGenerator(), out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal(expected, diagnostic.Id);
-    }
-
-    [Scenario("ReportsInvalidDurableSubscriberHandler")]
+    [Scenario("Generator emits durable subscriber defaults and host shapes")]
     [Fact]
-    public void ReportsInvalidDurableSubscriberHandler()
-    {
-        var source = """
+    public Task Generator_Emits_Durable_Subscriber_Defaults_And_Host_Shapes()
+        => Given("durable subscriber declarations using default names and different host shapes", () => Compile("""
             using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+            using PatternKit.Messaging.Consumers;
+            using PatternKit.Messaging.Storage;
 
-            namespace MyApp;
+            namespace Demo;
+
             public sealed record Order(string Id);
+
             [GenerateDurableSubscriber(typeof(Order))]
+            internal abstract partial class AbstractSubscriber
+            {
+                [DurableSubscriberHandler("project")]
+                private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
+                    => DurableSubscriberHandlerResult.Success("project");
+            }
+
+            [GenerateDurableSubscriber(typeof(Order))]
+            public sealed partial class SealedSubscriber
+            {
+                [DurableSubscriberHandler("project")]
+                private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
+                    => DurableSubscriberHandlerResult.Success("project");
+            }
+
+            [GenerateDurableSubscriber(typeof(Order))]
+            internal partial struct StructSubscriber
+            {
+                [DurableSubscriberHandler("project")]
+                private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
+                    => DurableSubscriberHandlerResult.Success("project");
+            }
+            """))
+        .Then("generated sources preserve host shape and default names", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractSubscriber", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedSubscriber", combined);
+            ScenarioExpect.Contains("internal partial struct StructSubscriber", combined);
+            ScenarioExpect.Contains("Create(@\"durable-subscriber\")", combined);
+            ScenarioExpect.True(result.EmitSuccess, result.EmitDiagnostics);
+        })
+        .AssertPassed();
+
+    [Scenario("Generator emits nested durable subscriber host wrappers")]
+    [Fact]
+    public Task Generator_Emits_Nested_Durable_Subscriber_Host_Wrappers()
+        => Given("a nested durable subscriber declaration", () => Compile("""
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+            using PatternKit.Messaging.Consumers;
+            using PatternKit.Messaging.Storage;
+
+            namespace Demo;
+
+            public sealed record Order(string Id);
+
+            public partial class SubscriberContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateDurableSubscriber(typeof(Order))]
+                    protected partial class ProtectedSubscriber
+                    {
+                        [DurableSubscriberHandler("protected")]
+                        private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
+                            => DurableSubscriberHandlerResult.Success("protected");
+                    }
+
+                    [GenerateDurableSubscriber(typeof(Order))]
+                    private protected partial class PrivateProtectedSubscriber
+                    {
+                        [DurableSubscriberHandler("private-protected")]
+                        private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
+                            => DurableSubscriberHandlerResult.Success("private-protected");
+                    }
+
+                    [GenerateDurableSubscriber(typeof(Order))]
+                    protected internal partial class ProtectedInternalSubscriber
+                    {
+                        [DurableSubscriberHandler("protected-internal")]
+                        private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
+                            => DurableSubscriberHandlerResult.Success("protected-internal");
+                    }
+                }
+            }
+            """))
+        .Then("generated source preserves containing partial type wrappers", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var source = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class SubscriberContainer", source);
+            ScenarioExpect.Contains("private partial class PrivateHost", source);
+            ScenarioExpect.Contains("protected partial class ProtectedSubscriber", source);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedSubscriber", source);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalSubscriber", source);
+            ScenarioExpect.True(result.EmitSuccess, result.EmitDiagnostics);
+        })
+        .AssertPassed();
+
+    [Scenario("Generator skips malformed durable subscriber type arguments")]
+    [Fact]
+    public Task Generator_Skips_Malformed_Durable_Subscriber_Type_Arguments()
+        => Given("a durable subscriber declaration with a null type argument", () => Compile("""
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+            using PatternKit.Messaging.Consumers;
+            using PatternKit.Messaging.Storage;
+
+            public sealed record Order(string Id);
+
+            [GenerateDurableSubscriber(null!)]
             public static partial class ShippingSubscriber
             {
                 [DurableSubscriberHandler("project")]
-                private static int Project(Order order) => 1;
+                private static DurableSubscriberHandlerResult Project(StoredMessage<Order> message, MessageContext context)
+                    => DurableSubscriberHandlerResult.Success("project");
             }
-            """;
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(ReportsInvalidDurableSubscriberHandler));
-        _ = RoslynTestHelpers.Run(comp, new DurableSubscriberGenerator(), out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKDS003", diagnostic.Id);
+    private static GeneratorResult Compile(string source)
+    {
+        var compilation = RoslynTestHelpers.CreateCompilation(
+            source,
+            "DurableSubscriberGeneratorTests",
+            extra: MetadataReference.CreateFromFile(typeof(DurableSubscriber<>).Assembly.Location));
+        _ = RoslynTestHelpers.Run(compilation, new DurableSubscriberGenerator(), out var run, out var updated);
+        var result = run.Results.Single();
+        var emit = updated.Emit(Stream.Null);
+        return new GeneratorResult(
+            result.Diagnostics.ToArray(),
+            result.GeneratedSources.Select(static source => source.SourceText.ToString()).ToArray(),
+            emit.Success,
+            string.Join("\n", emit.Diagnostics));
     }
 
-    private static CSharpCompilation CreateCompilation(string source, string assemblyName)
-        => RoslynTestHelpers.CreateCompilation(
-            source,
-            assemblyName,
-            extra: MetadataReference.CreateFromFile(typeof(PatternKit.Messaging.Consumers.DurableSubscriber<>).Assembly.Location));
+    private sealed record GeneratorResult(
+        IReadOnlyList<Diagnostic> Diagnostics,
+        IReadOnlyList<string> GeneratedSources,
+        bool EmitSuccess,
+        string EmitDiagnostics);
 }

--- a/test/PatternKit.Generators.Tests/DynamicRouterGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/DynamicRouterGeneratorTests.cs
@@ -1,21 +1,23 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using PatternKit.Generators.Messaging;
+using PatternKit.Messaging.Routing;
 using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Generators.Tests;
 
-public sealed class DynamicRouterGeneratorTests
+[Feature("Dynamic Router generator")]
+public sealed partial class DynamicRouterGeneratorTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
-    [Scenario("GeneratesDynamicRouterFactory")]
+    [Scenario("Generator emits dynamic router factory")]
     [Fact]
-    public void GeneratesDynamicRouterFactory()
-    {
-        var source = """
+    public Task Generator_Emits_Dynamic_Router_Factory()
+        => Given("a valid dynamic router declaration", () => Compile("""
             using PatternKit.Generators.Messaging;
             using PatternKit.Messaging;
 
-            namespace MyApp;
+            namespace Demo;
 
             public sealed record Order(string Channel);
 
@@ -33,72 +35,193 @@ public sealed class DynamicRouterGeneratorTests
                 private static string Default(Message<Order> message, MessageContext context)
                     => "default";
             }
-            """;
+            """))
+        .Then("generated source creates the router", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            var source = ScenarioExpect.Single(result.GeneratedSources);
+            ScenarioExpect.Contains("public static partial class OrderRouter", source);
+            ScenarioExpect.Contains("DynamicRouter<global::Demo.Order, string>", source);
+            ScenarioExpect.Contains(".When(@\"wholesale\", 10, IsWholesale).Then(Wholesale)", source);
+            ScenarioExpect.Contains(".Default(Default)", source);
+            ScenarioExpect.True(result.EmitSuccess, result.EmitDiagnostics);
+        })
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(GeneratesDynamicRouterFactory));
-        _ = RoslynTestHelpers.Run(comp, new DynamicRouterGenerator(), out var run, out var updated);
-
-        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
-        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
-        ScenarioExpect.Equal("OrderRouter.DynamicRouter.g.cs", generated.HintName);
-        var text = generated.SourceText.ToString();
-        ScenarioExpect.Contains("DynamicRouter<global::MyApp.Order, string>", text);
-        ScenarioExpect.Contains(".When(@\"wholesale\", 10, IsWholesale).Then(Wholesale)", text);
-        ScenarioExpect.Contains(".Default(Default)", text);
-
-        var emit = updated.Emit(Stream.Null);
-        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
-    }
-
-    [Scenario("ReportsDynamicRouterDiagnostics")]
+    [Scenario("Generator reports invalid dynamic router declarations")]
     [Theory]
     [InlineData("public static class OrderRouter { }", "PKDR001")]
     [InlineData("public static partial class OrderRouter { }", "PKDR002")]
-    public void ReportsDynamicRouterDiagnostics(string declaration, string expected)
-    {
-        var source = $$"""
+    [InlineData("public static partial class OrderRouter { [DynamicRoute(\"bad\", 10, \"Missing\")] private static int Bad(Order order) => 1; }", "PKDR003")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message, MessageContext context) => true; [DynamicRoute(\" \", 10, nameof(IsWholesale))] private static string Wholesale(Message<Order> message, MessageContext context) => \"wholesale\"; }", "PKDR003")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message, MessageContext context) => true; [DynamicRoute(\"wholesale\", 10, \" \")] private static string Wholesale(Message<Order> message, MessageContext context) => \"wholesale\"; }", "PKDR003")]
+    [InlineData("public static partial class OrderRouter { private static string IsWholesale(Message<Order> message, MessageContext context) => \"yes\"; [DynamicRoute(\"wholesale\", 10, nameof(IsWholesale))] private static string Wholesale(Message<Order> message, MessageContext context) => \"wholesale\"; }", "PKDR003")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message) => true; [DynamicRoute(\"wholesale\", 10, nameof(IsWholesale))] private static string Wholesale(Message<Order> message, MessageContext context) => \"wholesale\"; }", "PKDR003")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message, MessageContext context) => true; [DynamicRoute(\"wholesale\", 10, nameof(IsWholesale))] private string Wholesale(Message<Order> message, MessageContext context) => \"wholesale\"; }", "PKDR003")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message, MessageContext context) => true; [DynamicRoute(\"wholesale\", 10, nameof(IsWholesale))] private static int Wholesale(Message<Order> message, MessageContext context) => 1; }", "PKDR003")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message, MessageContext context) => true; [DynamicRoute(\"wholesale\", 10, nameof(IsWholesale))] private static string Wholesale(Message<Order> message, MessageContext context) => \"wholesale\"; [DynamicRouteDefault] private static int Default(Message<Order> message, MessageContext context) => 1; }", "PKDR004")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message, MessageContext context) => true; [DynamicRoute(\"one\", 10, nameof(IsWholesale))] private static string One(Message<Order> message, MessageContext context) => \"one\"; [DynamicRoute(\"one\", 20, nameof(IsWholesale))] private static string Two(Message<Order> message, MessageContext context) => \"two\"; }", "PKDR005")]
+    [InlineData("public static partial class OrderRouter { private static bool IsWholesale(Message<Order> message, MessageContext context) => true; [DynamicRoute(\"one\", 10, nameof(IsWholesale))] private static string One(Message<Order> message, MessageContext context) => \"one\"; [DynamicRoute(\"two\", 10, nameof(IsWholesale))] private static string Two(Message<Order> message, MessageContext context) => \"two\"; }", "PKDR005")]
+    public Task Generator_Reports_Invalid_Dynamic_Router_Declarations(string declaration, string expected)
+        => Given("an invalid dynamic router declaration", () => Compile($$"""
             using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
 
-            namespace MyApp;
+            namespace Demo;
             public sealed record Order(string Channel);
             [GenerateDynamicRouter(typeof(Order), typeof(string))]
             {{declaration}}
-            """;
+            """))
+        .Then("the expected diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == expected))
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(ReportsDynamicRouterDiagnostics) + expected);
-        _ = RoslynTestHelpers.Run(comp, new DynamicRouterGenerator(), out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal(expected, diagnostic.Id);
-    }
-
-    [Scenario("ReportsInvalidDynamicRoute")]
+    [Scenario("Generator emits dynamic router host shapes")]
     [Fact]
-    public void ReportsInvalidDynamicRoute()
-    {
-        var source = """
+    public Task Generator_Emits_Dynamic_Router_Host_Shapes()
+        => Given("dynamic router declarations using different host shapes", () => Compile("""
             using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
 
-            namespace MyApp;
+            namespace Demo;
+
             public sealed record Order(string Channel);
+
             [GenerateDynamicRouter(typeof(Order), typeof(string))]
+            internal abstract partial class AbstractRouter
+            {
+                private static bool Matches(Message<Order> message, MessageContext context) => true;
+                [DynamicRoute("all", 1, nameof(Matches))]
+                private static string Route(Message<Order> message, MessageContext context) => "all";
+            }
+
+            [GenerateDynamicRouter(typeof(Order), typeof(string))]
+            public sealed partial class SealedRouter
+            {
+                private static bool Matches(Message<Order> message, MessageContext context) => true;
+                [DynamicRoute("all", 1, nameof(Matches))]
+                private static string Route(Message<Order> message, MessageContext context) => "all";
+            }
+
+            [GenerateDynamicRouter(typeof(Order), typeof(string))]
+            internal partial struct StructRouter
+            {
+                private static bool Matches(Message<Order> message, MessageContext context) => true;
+                [DynamicRoute("all", 1, nameof(Matches))]
+                private static string Route(Message<Order> message, MessageContext context) => "all";
+            }
+            """))
+        .Then("generated sources preserve host shape and compile", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractRouter", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedRouter", combined);
+            ScenarioExpect.Contains("internal partial struct StructRouter", combined);
+            ScenarioExpect.True(result.EmitSuccess, result.EmitDiagnostics);
+        })
+        .AssertPassed();
+
+    [Scenario("Generator emits nested dynamic router host wrappers")]
+    [Fact]
+    public Task Generator_Emits_Nested_Dynamic_Router_Host_Wrappers()
+        => Given("a nested dynamic router declaration", () => Compile("""
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace Demo;
+
+            public sealed record Order(string Channel);
+
+            public partial class RouterContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateDynamicRouter(typeof(Order), typeof(string))]
+                    protected partial class ProtectedRouter
+                    {
+                        private static bool Matches(Message<Order> message, MessageContext context) => true;
+                        [DynamicRoute("protected", 1, nameof(Matches))]
+                        private static string Route(Message<Order> message, MessageContext context) => "protected";
+                    }
+
+                    [GenerateDynamicRouter(typeof(Order), typeof(string))]
+                    private protected partial class PrivateProtectedRouter
+                    {
+                        private static bool Matches(Message<Order> message, MessageContext context) => true;
+                        [DynamicRoute("private-protected", 1, nameof(Matches))]
+                        private static string Route(Message<Order> message, MessageContext context) => "private-protected";
+                    }
+
+                    [GenerateDynamicRouter(typeof(Order), typeof(string))]
+                    protected internal partial class ProtectedInternalRouter
+                    {
+                        private static bool Matches(Message<Order> message, MessageContext context) => true;
+                        [DynamicRoute("protected-internal", 1, nameof(Matches))]
+                        private static string Route(Message<Order> message, MessageContext context) => "protected-internal";
+                    }
+                }
+            }
+            """))
+        .Then("generated source preserves containing partial type wrappers", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var source = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class RouterContainer", source);
+            ScenarioExpect.Contains("private partial class PrivateHost", source);
+            ScenarioExpect.Contains("protected partial class ProtectedRouter", source);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedRouter", source);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalRouter", source);
+            ScenarioExpect.True(result.EmitSuccess, result.EmitDiagnostics);
+        })
+        .AssertPassed();
+
+    [Scenario("Generator skips malformed dynamic router type arguments")]
+    [Theory]
+    [InlineData("null!", "typeof(string)")]
+    [InlineData("typeof(Order)", "null!")]
+    public Task Generator_Skips_Malformed_Dynamic_Router_Type_Arguments(string payloadType, string resultType)
+        => Given("a dynamic router declaration with a null type argument", () => Compile($$"""
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            public sealed record Order(string Channel);
+
+            [GenerateDynamicRouter({{payloadType}}, {{resultType}})]
             public static partial class OrderRouter
             {
-                [DynamicRoute("bad", 10, "Missing")]
-                private static int Bad(Order order) => 1;
+                private static bool Matches(Message<Order> message, MessageContext context) => true;
+                [DynamicRoute("all", 1, nameof(Matches))]
+                private static string Route(Message<Order> message, MessageContext context) => "all";
             }
-            """;
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(ReportsInvalidDynamicRoute));
-        _ = RoslynTestHelpers.Run(comp, new DynamicRouterGenerator(), out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKDR003", diagnostic.Id);
+    private static GeneratorResult Compile(string source)
+    {
+        var compilation = RoslynTestHelpers.CreateCompilation(
+            source,
+            "DynamicRouterGeneratorTests",
+            extra: MetadataReference.CreateFromFile(typeof(DynamicRouter<,>).Assembly.Location));
+        _ = RoslynTestHelpers.Run(compilation, new DynamicRouterGenerator(), out var run, out var updated);
+        var result = run.Results.Single();
+        var emit = updated.Emit(Stream.Null);
+        return new GeneratorResult(
+            result.Diagnostics.ToArray(),
+            result.GeneratedSources.Select(static source => source.SourceText.ToString()).ToArray(),
+            emit.Success,
+            string.Join("\n", emit.Diagnostics));
     }
 
-    private static CSharpCompilation CreateCompilation(string source, string assemblyName)
-        => RoslynTestHelpers.CreateCompilation(
-            source,
-            assemblyName,
-            extra: MetadataReference.CreateFromFile(typeof(PatternKit.Messaging.Routing.DynamicRouter<,>).Assembly.Location));
+    private sealed record GeneratorResult(
+        IReadOnlyList<Diagnostic> Diagnostics,
+        IReadOnlyList<string> GeneratedSources,
+        bool EmitSuccess,
+        string EmitDiagnostics);
 }


### PR DESCRIPTION
## Summary
- emit containing partial type wrappers for nested Dynamic Router and Durable Subscriber generator hosts
- convert Dynamic Router and Durable Subscriber generator tests to TinyBDD xUnit scenarios
- cover invalid signatures, duplicate routes, malformed type arguments, host shape preservation, emitted compilation, and missing messaging attribute constructors

## Validation
- dotnet test test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj --configuration Release --framework net10.0 --filter "FullyQualifiedName~DynamicRouterGeneratorTests|FullyQualifiedName~DurableSubscriberGeneratorTests|FullyQualifiedName~AbstractionsAttributeCoverageTests" --logger "console;verbosity=minimal"
- dotnet test test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory ./TestResults --logger "console;verbosity=minimal" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
- reportgenerator -reports:TestResults/**/coverage.cobertura.xml -targetdir:coverage-report-generators -reporttypes:TextSummary
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- dotnet test test/PatternKit.Generators.Tests/PatternKit.Generators.Tests.csproj --configuration Release --no-restore --no-build -p:TestTfmsInParallel=false --logger "console;verbosity=minimal"

Coverage: DynamicRouterGenerator 97.9%; DurableSubscriberGenerator 97.1%; GenerateDynamicRouterAttribute/DynamicRouteAttribute/GenerateDurableSubscriberAttribute/DurableSubscriberHandlerAttribute 100%; PatternKit.Generators 95.6% locally.