### PR TITLE
test(generators): cover materialized view and strangler fig

### DIFF
--- a/src/PatternKit.Generators/MaterializedViews/MaterializedViewGenerator.cs
+++ b/src/PatternKit.Generators/MaterializedViews/MaterializedViewGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
@@ -162,6 +163,59 @@ public sealed class MaterializedViewGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Application.MaterializedViews.MaterializedView<")
+            .Append(stateName).Append(", ").Append(eventName).Append("> ").Append(factoryName).AppendLine("()");
+        sb.Append(bodyIndent).Append("=> global::PatternKit.Application.MaterializedViews.MaterializedView<")
+            .Append(stateName).Append(", ").Append(eventName).Append(">.Create(\"").Append(Escape(viewName)).AppendLine("\")");
+
+        foreach (var handler in handlers.OrderBy(static h => h.Order).ThenBy(static h => h.MethodName))
+        {
+            var method = handler.Async ? "WithAsyncHandler" : "WithHandler";
+            sb.Append(bodyIndent).Append("    .").Append(method).Append('<')
+                .Append(handler.EventType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+                .Append(">(").Append(handler.MethodName).Append(", ").Append(handler.Order).AppendLine(")");
+        }
+
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -169,24 +223,7 @@ public sealed class MaterializedViewGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Application.MaterializedViews.MaterializedView<")
-            .Append(stateName).Append(", ").Append(eventName).Append("> ").Append(factoryName).AppendLine("()");
-        sb.Append("        => global::PatternKit.Application.MaterializedViews.MaterializedView<")
-            .Append(stateName).Append(", ").Append(eventName).Append(">.Create(\"").Append(Escape(viewName)).AppendLine("\")");
-
-        foreach (var handler in handlers.OrderBy(static h => h.Order).ThenBy(static h => h.MethodName))
-        {
-            var method = handler.Async ? "WithAsyncHandler" : "WithHandler";
-            sb.Append("            .").Append(method).Append('<')
-                .Append(handler.EventType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
-                .Append(">(").Append(handler.MethodName).Append(", ").Append(handler.Order).AppendLine(")");
-        }
-
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static string? GetNamedString(AttributeData attribute, string name)

--- a/src/PatternKit.Generators/StranglerFig/StranglerFigGenerator.cs
+++ b/src/PatternKit.Generators/StranglerFig/StranglerFigGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -165,6 +166,56 @@ public sealed class StranglerFigGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Cloud.StranglerFig.StranglerFig<")
+            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append("> ").Append(factoryMethodName).AppendLine("()");
+        sb.Append(memberIndent).AppendLine("{");
+        sb.Append(bodyIndent).Append("return global::PatternKit.Cloud.StranglerFig.StranglerFig<")
+            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append(">.Create(\"").Append(Escape(migrationName)).AppendLine("\")");
+        foreach (var route in routes)
+            sb.Append(bodyIndent).Append("    .RouteToModern(\"").Append(Escape(route.Name)).Append("\", ").Append(route.Method.Name).AppendLine(")");
+        sb.Append(bodyIndent).Append("    .Legacy(").Append(legacyName).AppendLine(")");
+        sb.Append(bodyIndent).Append("    .Modern(").Append(modernName).AppendLine(")");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(memberIndent + "}");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -172,21 +223,7 @@ public sealed class StranglerFigGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Cloud.StranglerFig.StranglerFig<")
-            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append("> ").Append(factoryMethodName).AppendLine("()");
-        sb.AppendLine("    {");
-        sb.Append("        return global::PatternKit.Cloud.StranglerFig.StranglerFig<")
-            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append(">.Create(\"").Append(Escape(migrationName)).AppendLine("\")");
-        foreach (var route in routes)
-            sb.Append("            .RouteToModern(\"").Append(Escape(route.Name)).Append("\", ").Append(route.Method.Name).AppendLine(")");
-        sb.Append("            .Legacy(").Append(legacyName).AppendLine(")");
-        sb.Append("            .Modern(").Append(modernName).AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static string? GetNamedString(AttributeData attribute, string name)

--- a/test/PatternKit.Generators.Tests/MaterializedViewGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/MaterializedViewGeneratorTests.cs
@@ -69,50 +69,151 @@ public sealed partial class MaterializedViewGeneratorTests(ITestOutputHelper out
         .AssertPassed();
 
     [Scenario("Generator reports invalid materialized view declarations")]
-    [Fact]
-    public Task Generator_Reports_Invalid_Materialized_View_Declarations()
-        => Given("a non-partial materialized view declaration", () => Compile("""
+    [Theory]
+    [InlineData("public static class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => state; }", "PKMV001")]
+    [InlineData("public static partial class OrderProjection;", "PKMV002")]
+    [InlineData("public partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => state; }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OtherEvent))] private static OrderState ApplyOther(OrderState state, OtherEvent @event) => state; }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static OrderState ApplyPlaced() => new(string.Empty); }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static OrderState ApplyPlaced(OrderState state) => state; }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static OrderState ApplyPlaced(string state, OrderPlaced @event) => new(@event.OrderId); }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static OrderState ApplyPlaced(OrderState state, OrderEvent @event) => state; }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static string ApplyPlaced(OrderState state, OrderPlaced @event) => @event.OrderId; }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static ValueTask<OrderState> ApplyPlaced(OrderState state, OrderPlaced @event, string cancellationToken) => new(state); }", "PKMV003")]
+    [InlineData("public static partial class OrderProjection { [MaterializedViewHandler(typeof(OrderPlaced))] private static ValueTask<string> ApplyPlaced(OrderState state, OrderPlaced @event, CancellationToken cancellationToken) => new(@event.OrderId); }", "PKMV003")]
+    public Task Generator_Reports_Invalid_Materialized_View_Declarations(string declaration, string diagnosticId)
+        => Given("an invalid materialized view declaration", () => Compile($$"""
+            using System.Threading;
+            using System.Threading.Tasks;
             using PatternKit.Generators.MaterializedViews;
             public abstract record OrderEvent(string OrderId);
+            public sealed record OrderPlaced(string OrderId) : OrderEvent(OrderId);
+            public sealed record OtherEvent(string OrderId);
             public sealed record OrderState(string OrderId);
             [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent))]
-            public static class OrderProjection;
+            {{declaration}}
             """))
-        .Then("the partial diagnostic is reported", result =>
-            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "PKMV001"))
+        .Then("the expected diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
         .AssertPassed();
 
-    [Scenario("Generator reports materialized view declarations without handlers")]
+    [Scenario("Generator emits materialized view defaults and host shapes")]
     [Fact]
-    public Task Generator_Reports_Materialized_View_Declarations_Without_Handlers()
-        => Given("a partial materialized view declaration without handlers", () => Compile("""
+    public Task Generator_Emits_Materialized_View_Defaults_And_Host_Shapes()
+        => Given("materialized view declarations with default names and different host shapes", () => Compile("""
             using PatternKit.Generators.MaterializedViews;
+            namespace Demo;
             public abstract record OrderEvent(string OrderId);
+            public sealed record OrderPlaced(string OrderId) : OrderEvent(OrderId);
             public sealed record OrderState(string OrderId);
+
             [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent))]
-            public static partial class OrderProjection;
+            internal abstract partial class AbstractProjection
+            {
+                [MaterializedViewHandler(typeof(OrderPlaced))]
+                private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => new(@event.OrderId);
+            }
+
+            [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent), ViewName = "tenant\\\"projection")]
+            public sealed partial class SealedProjection
+            {
+                [MaterializedViewHandler(typeof(OrderPlaced))]
+                private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => new(@event.OrderId);
+            }
+
+            [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent))]
+            internal partial struct StructProjection
+            {
+                [MaterializedViewHandler(typeof(OrderPlaced))]
+                private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => new(@event.OrderId);
+            }
             """))
-        .Then("the missing handlers diagnostic is reported", result =>
-            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "PKMV002"))
+        .Then("generated sources preserve host shape and configured names", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractProjection", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedProjection", combined);
+            ScenarioExpect.Contains("internal partial struct StructProjection", combined);
+            ScenarioExpect.Contains("Create(\"AbstractProjection\")", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"projection\")", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
         .AssertPassed();
 
-    [Scenario("Generator reports invalid materialized view handlers")]
+    [Scenario("Generator emits nested materialized view host wrappers")]
     [Fact]
-    public Task Generator_Reports_Invalid_Materialized_View_Handlers()
-        => Given("a materialized view with invalid handler signature", () => Compile("""
+    public Task Generator_Emits_Nested_Materialized_View_Host_Wrappers()
+        => Given("nested materialized view declarations", () => Compile("""
+            using PatternKit.Generators.MaterializedViews;
+            namespace Demo;
+            public abstract record OrderEvent(string OrderId);
+            public sealed record OrderPlaced(string OrderId) : OrderEvent(OrderId);
+            public sealed record OrderState(string OrderId);
+
+            public partial class ProjectionContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent))]
+                    protected partial class ProtectedProjection
+                    {
+                        [MaterializedViewHandler(typeof(OrderPlaced))]
+                        private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => new(@event.OrderId);
+                    }
+
+                    [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent))]
+                    private protected partial class PrivateProtectedProjection
+                    {
+                        [MaterializedViewHandler(typeof(OrderPlaced))]
+                        private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => new(@event.OrderId);
+                    }
+
+                    [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent))]
+                    protected internal partial class ProtectedInternalProjection
+                    {
+                        [MaterializedViewHandler(typeof(OrderPlaced))]
+                        private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => new(@event.OrderId);
+                    }
+                }
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class ProjectionContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedProjection", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedProjection", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalProjection", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
+
+    [Scenario("Generator skips malformed materialized view type arguments")]
+    [Theory]
+    [InlineData("null!", "typeof(OrderEvent)")]
+    [InlineData("typeof(OrderState)", "null!")]
+    public Task Generator_Skips_Malformed_Materialized_View_Type_Arguments(string stateType, string eventType)
+        => Given("a materialized view declaration with a null type argument", () => Compile($$"""
             using PatternKit.Generators.MaterializedViews;
             public abstract record OrderEvent(string OrderId);
             public sealed record OrderPlaced(string OrderId) : OrderEvent(OrderId);
             public sealed record OrderState(string OrderId);
-            [GenerateMaterializedView(typeof(OrderState), typeof(OrderEvent))]
+            [GenerateMaterializedView({{stateType}}, {{eventType}})]
             public static partial class OrderProjection
             {
                 [MaterializedViewHandler(typeof(OrderPlaced))]
-                private static string ApplyPlaced(OrderState state, OrderPlaced @event) => @event.OrderId;
+                private static OrderState ApplyPlaced(OrderState state, OrderPlaced @event) => state;
             }
             """))
-        .Then("the handler diagnostic is reported", result =>
-            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "PKMV003"))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
         .AssertPassed();
 
     private static GeneratorResult Compile(string source)

--- a/test/PatternKit.Generators.Tests/StranglerFigGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/StranglerFigGeneratorTests.cs
@@ -43,56 +43,177 @@ public sealed partial class StranglerFigGeneratorTests(ITestOutputHelper output)
         .AssertPassed();
 
     [Scenario("Reports diagnostics for invalid Strangler Fig declarations")]
+    [Theory]
+    [InlineData("public static class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF001")]
+    [InlineData("public static partial class MigrationHost;", "PKSF002")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF002")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF002")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; }", "PKSF002")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int One(string value) => 1; [StranglerFigLegacy] private static int Two(string value) => 2; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF002")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int One(string value) => 1; [StranglerFigModern] private static int Two(string value) => 2; }", "PKSF002")]
+    [InlineData("public partial class MigrationHost { [StranglerFigRoute(\"modern\")] private bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static string Route(string value) => value; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route() => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(int value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static string Legacy(string value) => value; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(int value) => value; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private int Modern(string value) => 2; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static string Modern(string value) => value; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(int value) => value; }", "PKSF003")]
+    [InlineData("public static partial class MigrationHost { [StranglerFigRoute(\"modern\")] private static bool Route1(string value) => true; [StranglerFigRoute(\"MODERN\")] private static bool Route2(string value) => true; [StranglerFigLegacy] private static int Legacy(string value) => 1; [StranglerFigModern] private static int Modern(string value) => 2; }", "PKSF004")]
+    public Task Reports_Diagnostics_For_Invalid_Strangler_Fig_Declarations(string declaration, string diagnosticId)
+        => Given("an invalid Strangler Fig declaration", () => Compile($$"""
+            using PatternKit.Generators.StranglerFig;
+            [GenerateStranglerFig(typeof(string), typeof(int))]
+            {{declaration}}
+            """))
+        .Then("diagnostics identify invalid declarations", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
+        .AssertPassed();
+
+    [Scenario("Generates Strangler Fig defaults and host shapes")]
     [Fact]
-    public Task Reports_Diagnostics_For_Invalid_Strangler_Fig_Declarations()
-        => Given("invalid Strangler Fig declarations", () => new[]
+    public Task Generates_Strangler_Fig_Defaults_And_Host_Shapes()
+        => Given("Strangler Fig declarations with default names and different host shapes", () => Compile("""
+            using PatternKit.Generators.StranglerFig;
+            namespace Demo;
+            public sealed record CheckoutRequest(string Tenant);
+            public sealed record CheckoutResponse(string Confirmation);
+
+            [GenerateStranglerFig(typeof(CheckoutRequest), typeof(CheckoutResponse))]
+            internal abstract partial class AbstractMigration
+            {
+                [StranglerFigRoute("default")]
+                private static bool Route(CheckoutRequest request) => true;
+                [StranglerFigLegacy]
+                private static CheckoutResponse Legacy(CheckoutRequest request) => new("legacy");
+                [StranglerFigModern]
+                private static CheckoutResponse Modern(CheckoutRequest request) => new("modern");
+            }
+
+            [GenerateStranglerFig(typeof(CheckoutRequest), typeof(CheckoutResponse), MigrationName = "tenant\\\"migration")]
+            public sealed partial class SealedMigration
+            {
+                [StranglerFigRoute("tenant")]
+                private static bool Route(CheckoutRequest request) => true;
+                [StranglerFigLegacy]
+                private static CheckoutResponse Legacy(CheckoutRequest request) => new("legacy");
+                [StranglerFigModern]
+                private static CheckoutResponse Modern(CheckoutRequest request) => new("modern");
+            }
+
+            [GenerateStranglerFig(typeof(CheckoutRequest), typeof(CheckoutResponse))]
+            internal partial struct StructMigration
+            {
+                [StranglerFigRoute("struct")]
+                private static bool Route(CheckoutRequest request) => true;
+                [StranglerFigLegacy]
+                private static CheckoutResponse Legacy(CheckoutRequest request) => new("legacy");
+                [StranglerFigModern]
+                private static CheckoutResponse Modern(CheckoutRequest request) => new("modern");
+            }
+            """))
+        .Then("generated sources preserve host shape and configured names", result =>
         {
-            Compile("""
-                using PatternKit.Generators.StranglerFig;
-                [GenerateStranglerFig(typeof(string), typeof(int))]
-                public static class MigrationHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.StranglerFig;
-                [GenerateStranglerFig(typeof(string), typeof(int))]
-                public static partial class MigrationHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.StranglerFig;
-                [GenerateStranglerFig(typeof(string), typeof(int))]
-                public static partial class MigrationHost
-                {
-                    [StranglerFigRoute("modern")]
-                    private static string ModernRoute(string value) => value;
-                    [StranglerFigLegacy]
-                    private static int Legacy(string value) => 1;
-                    [StranglerFigModern]
-                    private static int Modern(string value) => 2;
-                }
-                """),
-            Compile("""
-                using PatternKit.Generators.StranglerFig;
-                [GenerateStranglerFig(typeof(string), typeof(int))]
-                public static partial class MigrationHost
-                {
-                    [StranglerFigRoute("modern")]
-                    private static bool Route1(string value) => true;
-                    [StranglerFigRoute("MODERN")]
-                    private static bool Route2(string value) => true;
-                    [StranglerFigLegacy]
-                    private static int Legacy(string value) => 1;
-                    [StranglerFigModern]
-                    private static int Modern(string value) => 2;
-                }
-                """)
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractMigration", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedMigration", combined);
+            ScenarioExpect.Contains("internal partial struct StructMigration", combined);
+            ScenarioExpect.Contains("Create(\"strangler-fig\")", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"migration\")", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
-        .Then("diagnostics identify invalid declarations", results =>
+        .AssertPassed();
+
+    [Scenario("Generates nested Strangler Fig host wrappers")]
+    [Fact]
+    public Task Generates_Nested_Strangler_Fig_Host_Wrappers()
+        => Given("nested Strangler Fig declarations", () => Compile("""
+            using PatternKit.Generators.StranglerFig;
+            namespace Demo;
+            public sealed record CheckoutRequest(string Tenant);
+            public sealed record CheckoutResponse(string Confirmation);
+
+            public partial class MigrationContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateStranglerFig(typeof(CheckoutRequest), typeof(CheckoutResponse))]
+                    protected partial class ProtectedMigration
+                    {
+                        [StranglerFigRoute("protected")]
+                        private static bool Route(CheckoutRequest request) => true;
+                        [StranglerFigLegacy]
+                        private static CheckoutResponse Legacy(CheckoutRequest request) => new("legacy");
+                        [StranglerFigModern]
+                        private static CheckoutResponse Modern(CheckoutRequest request) => new("modern");
+                    }
+
+                    [GenerateStranglerFig(typeof(CheckoutRequest), typeof(CheckoutResponse))]
+                    private protected partial class PrivateProtectedMigration
+                    {
+                        [StranglerFigRoute("private-protected")]
+                        private static bool Route(CheckoutRequest request) => true;
+                        [StranglerFigLegacy]
+                        private static CheckoutResponse Legacy(CheckoutRequest request) => new("legacy");
+                        [StranglerFigModern]
+                        private static CheckoutResponse Modern(CheckoutRequest request) => new("modern");
+                    }
+
+                    [GenerateStranglerFig(typeof(CheckoutRequest), typeof(CheckoutResponse))]
+                    protected internal partial class ProtectedInternalMigration
+                    {
+                        [StranglerFigRoute("protected-internal")]
+                        private static bool Route(CheckoutRequest request) => true;
+                        [StranglerFigLegacy]
+                        private static CheckoutResponse Legacy(CheckoutRequest request) => new("legacy");
+                        [StranglerFigModern]
+                        private static CheckoutResponse Modern(CheckoutRequest request) => new("modern");
+                    }
+                }
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
         {
-            ScenarioExpect.Contains(results[0].Diagnostics, diagnostic => diagnostic.Id == "PKSF001");
-            ScenarioExpect.Contains(results[1].Diagnostics, diagnostic => diagnostic.Id == "PKSF002");
-            ScenarioExpect.Contains(results[2].Diagnostics, diagnostic => diagnostic.Id == "PKSF003");
-            ScenarioExpect.Contains(results[3].Diagnostics, diagnostic => diagnostic.Id == "PKSF004");
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class MigrationContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedMigration", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedMigration", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalMigration", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
+        .AssertPassed();
+
+    [Scenario("Skips malformed Strangler Fig type arguments")]
+    [Theory]
+    [InlineData("null!", "typeof(CheckoutResponse)")]
+    [InlineData("typeof(CheckoutRequest)", "null!")]
+    public Task Skips_Malformed_Strangler_Fig_Type_Arguments(string requestType, string responseType)
+        => Given("a Strangler Fig declaration with a null type argument", () => Compile($$"""
+            using PatternKit.Generators.StranglerFig;
+            public sealed record CheckoutRequest(string Tenant);
+            public sealed record CheckoutResponse(string Confirmation);
+            [GenerateStranglerFig({{requestType}}, {{responseType}})]
+            public static partial class CheckoutMigration
+            {
+                [StranglerFigRoute("modern")]
+                private static bool Route(CheckoutRequest request) => true;
+                [StranglerFigLegacy]
+                private static CheckoutResponse Legacy(CheckoutRequest request) => new("legacy");
+                [StranglerFigModern]
+                private static CheckoutResponse Modern(CheckoutRequest request) => new("modern");
+            }
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
         .AssertPassed();
 
     private static GeneratorResult Compile(string source)


### PR DESCRIPTION
## Summary
- add nested host wrapper generation for Materialized View and Strangler Fig source generators
- expand TinyBDD generator coverage for invalid signatures, defaults, host shapes, escaped names, malformed type args, and nested hosts
- raise local generator coverage for MaterializedViewGenerator and StranglerFigGenerator to 99.3% each

## Validation
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --framework net10.0 --filter "FullyQualifiedName~MaterializedViewGeneratorTests|FullyQualifiedName~StranglerFigGeneratorTests" --logger "console;verbosity=minimal"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory .\TestResults --logger "console;verbosity=minimal" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
- reportgenerator -reports:TestResults\**\coverage.cobertura.xml -targetdir:coverage-report-generators -reporttypes:TextSummary
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore --no-build -p:TestTfmsInParallel=false --logger "console;verbosity=minimal"

## Coverage
- PatternKit.Generators: 95.9% local line coverage
- MaterializedViewGenerator: 99.3%
- StranglerFigGenerator: 99.3%

Refs #413