### PR TITLE
test(generators): cover leader election and bff

### DIFF
--- a/src/PatternKit.Generators/BackendsForFrontends/BackendsForFrontendsGenerator.cs
+++ b/src/PatternKit.Generators/BackendsForFrontends/BackendsForFrontendsGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -175,6 +176,56 @@ public sealed class BackendsForFrontendsGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Cloud.BackendsForFrontends.BackendsForFrontends<")
+            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append("> ").Append(factoryMethodName).AppendLine("()");
+        sb.Append(memberIndent).AppendLine("{");
+        sb.Append(bodyIndent).Append("return global::PatternKit.Cloud.BackendsForFrontends.BackendsForFrontends<")
+            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append(">.Create(\"").Append(Escape(gatewayName)).AppendLine("\")");
+        foreach (var route in routes)
+            sb.Append(bodyIndent).Append("    .Frontend(\"").Append(Escape(route.Name)).Append("\", ").Append(route.Selector.Name).Append(", ").Append(route.Handler!.Name).AppendLine(")");
+        if (fallbackName is not null)
+            sb.Append(bodyIndent).Append("    .Fallback(").Append(fallbackName).AppendLine(")");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(memberIndent + "}");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -182,21 +233,7 @@ public sealed class BackendsForFrontendsGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Cloud.BackendsForFrontends.BackendsForFrontends<")
-            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append("> ").Append(factoryMethodName).AppendLine("()");
-        sb.AppendLine("    {");
-        sb.Append("        return global::PatternKit.Cloud.BackendsForFrontends.BackendsForFrontends<")
-            .Append(requestTypeName).Append(", ").Append(responseTypeName).Append(">.Create(\"").Append(Escape(gatewayName)).AppendLine("\")");
-        foreach (var route in routes)
-            sb.Append("            .Frontend(\"").Append(Escape(route.Name)).Append("\", ").Append(route.Selector.Name).Append(", ").Append(route.Handler!.Name).AppendLine(")");
-        if (fallbackName is not null)
-            sb.Append("            .Fallback(").Append(fallbackName).AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static string? GetNamedString(AttributeData attribute, string name)

--- a/src/PatternKit.Generators/LeaderElection/LeaderElectionGenerator.cs
+++ b/src/PatternKit.Generators/LeaderElection/LeaderElectionGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -164,6 +165,63 @@ public sealed class LeaderElectionGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Cloud.LeaderElection.LeaderElection<").Append(contextTypeName).Append("> ").Append(factoryMethodName).AppendLine("Election()");
+        sb.Append(memberIndent).AppendLine("{");
+        sb.Append(bodyIndent).Append("return global::PatternKit.Cloud.LeaderElection.LeaderElection<").Append(contextTypeName).Append(">.Create(\"").Append(Escape(electionName)).AppendLine("\")");
+        sb.Append(bodyIndent).Append("    .LeaseDuration(global::System.TimeSpan.FromMilliseconds(").Append(leaseDurationMilliseconds).AppendLine("))");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(memberIndent + "}");
+        sb.AppendLine();
+        sb.Append(memberIndent).Append("public static global::PatternKit.Cloud.LeaderElection.LeaderElectionCandidate<").Append(contextTypeName).Append("> ").Append(factoryMethodName).Append('(').Append(contextTypeName).AppendLine(" context)");
+        sb.Append(memberIndent).AppendLine("{");
+        sb.Append(bodyIndent).Append("return global::PatternKit.Cloud.LeaderElection.LeaderElectionCandidate.Create(").Append(candidateIdName).AppendLine("(context), context)");
+        if (acquiredName is not null)
+            sb.Append(bodyIndent).Append("    .OnAcquired(").Append(acquiredName).AppendLine(")");
+        if (renewedName is not null)
+            sb.Append(bodyIndent).Append("    .OnRenewed(").Append(renewedName).AppendLine(")");
+        if (releasedName is not null)
+            sb.Append(bodyIndent).Append("    .OnReleased(").Append(releasedName).AppendLine(")");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(memberIndent + "}");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -171,28 +229,7 @@ public sealed class LeaderElectionGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Cloud.LeaderElection.LeaderElection<").Append(contextTypeName).Append("> ").Append(factoryMethodName).AppendLine("Election()");
-        sb.AppendLine("    {");
-        sb.Append("        return global::PatternKit.Cloud.LeaderElection.LeaderElection<").Append(contextTypeName).Append(">.Create(\"").Append(Escape(electionName)).AppendLine("\")");
-        sb.Append("            .LeaseDuration(global::System.TimeSpan.FromMilliseconds(").Append(leaseDurationMilliseconds).AppendLine("))");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("    }");
-        sb.AppendLine();
-        sb.Append("    public static global::PatternKit.Cloud.LeaderElection.LeaderElectionCandidate<").Append(contextTypeName).Append("> ").Append(factoryMethodName).Append('(').Append(contextTypeName).AppendLine(" context)");
-        sb.AppendLine("    {");
-        sb.Append("        return global::PatternKit.Cloud.LeaderElection.LeaderElectionCandidate.Create(").Append(candidateIdName).AppendLine("(context), context)");
-        if (acquiredName is not null)
-            sb.Append("            .OnAcquired(").Append(acquiredName).AppendLine(")");
-        if (renewedName is not null)
-            sb.Append("            .OnRenewed(").Append(renewedName).AppendLine(")");
-        if (releasedName is not null)
-            sb.Append("            .OnReleased(").Append(releasedName).AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static int? GetNamedInt(AttributeData attribute, string name)

--- a/test/PatternKit.Generators.Tests/BackendsForFrontendsGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/BackendsForFrontendsGeneratorTests.cs
@@ -43,71 +43,165 @@ public sealed partial class BackendsForFrontendsGeneratorTests(ITestOutputHelper
         .AssertPassed();
 
     [Scenario("Reports diagnostics for invalid Backends for Frontends declarations")]
+    [Theory]
+    [InlineData("public static class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF001")]
+    [InlineData("public static partial class BffHost;", "PKBFF002")]
+    [InlineData("public static partial class BffHost { [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF002")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; }", "PKBFF002")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"mobile\")] private static int Mobile(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF002")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; [FrontendFallback] private static int One(BackendsForFrontendsContext<string> ctx) => 1; [FrontendFallback] private static int Two(BackendsForFrontendsContext<string> ctx) => 2; }", "PKBFF002")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool One(string value) => true; [FrontendSelector(\"WEB\")] private static bool Two(string value) => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; [FrontendHandler(\"WEB\")] private static int Web2(BackendsForFrontendsContext<string> ctx) => 2; }", "PKBFF004")]
+    [InlineData("public partial class BffHost { [FrontendSelector(\"web\")] private bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF003")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static string IsWeb(string value) => value; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF003")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb() => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF003")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(int value) => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF003")]
+    [InlineData("public partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private int Web(BackendsForFrontendsContext<string> ctx) => 1; }", "PKBFF003")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private static string Web(BackendsForFrontendsContext<string> ctx) => string.Empty; }", "PKBFF003")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private static int Web(string ctx) => 1; }", "PKBFF003")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<int> ctx) => 1; }", "PKBFF003")]
+    [InlineData("public static partial class BffHost { [FrontendSelector(\"web\")] private static bool IsWeb(string value) => true; [FrontendHandler(\"web\")] private static int Web(BackendsForFrontendsContext<string> ctx) => 1; [FrontendFallback] private static string Fallback(BackendsForFrontendsContext<string> ctx) => string.Empty; }", "PKBFF003")]
+    public Task Reports_Diagnostics_For_Invalid_Backends_For_Frontends_Declarations(string declaration, string diagnosticId)
+        => Given("an invalid BFF declaration", () => Compile($$"""
+            using PatternKit.Cloud.BackendsForFrontends;
+            using PatternKit.Generators.BackendsForFrontends;
+            [GenerateBackendsForFrontends(typeof(string), typeof(int))]
+            {{declaration}}
+            """))
+        .Then("diagnostics identify invalid declarations", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
+        .AssertPassed();
+
+    [Scenario("Generates Backends for Frontends defaults and host shapes")]
     [Fact]
-    public Task Reports_Diagnostics_For_Invalid_Backends_For_Frontends_Declarations()
-        => Given("invalid BFF declarations", () => new[]
+    public Task Generates_Backends_For_Frontends_Defaults_And_Host_Shapes()
+        => Given("BFF declarations with default names and different host shapes", () => Compile("""
+            using PatternKit.Cloud.BackendsForFrontends;
+            using PatternKit.Generators.BackendsForFrontends;
+            namespace Demo;
+            public sealed record ClientRequest(string Client, string CustomerId);
+            public sealed record ClientResponse(string CustomerId, string Shape);
+
+            [GenerateBackendsForFrontends(typeof(ClientRequest), typeof(ClientResponse))]
+            internal abstract partial class AbstractBff
+            {
+                [FrontendSelector("web")]
+                private static bool IsWeb(ClientRequest request) => true;
+                [FrontendHandler("web")]
+                private static ClientResponse Web(BackendsForFrontendsContext<ClientRequest> ctx) => new(ctx.Request.CustomerId, "web");
+            }
+
+            [GenerateBackendsForFrontends(typeof(ClientRequest), typeof(ClientResponse), GatewayName = "tenant\\\"bff")]
+            public sealed partial class SealedBff
+            {
+                [FrontendSelector("web")]
+                private static bool IsWeb(ClientRequest request) => true;
+                [FrontendHandler("web")]
+                private static ClientResponse Web(BackendsForFrontendsContext<ClientRequest> ctx) => new(ctx.Request.CustomerId, "web");
+            }
+
+            [GenerateBackendsForFrontends(typeof(ClientRequest), typeof(ClientResponse))]
+            internal partial struct StructBff
+            {
+                [FrontendSelector("web")]
+                private static bool IsWeb(ClientRequest request) => true;
+                [FrontendHandler("web")]
+                private static ClientResponse Web(BackendsForFrontendsContext<ClientRequest> ctx) => new(ctx.Request.CustomerId, "web");
+            }
+            """))
+        .Then("generated sources preserve host shape and configured names", result =>
         {
-            Compile("""
-                using PatternKit.Generators.BackendsForFrontends;
-                [GenerateBackendsForFrontends(typeof(string), typeof(int))]
-                public static class BffHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.BackendsForFrontends;
-                [GenerateBackendsForFrontends(typeof(string), typeof(int))]
-                public static partial class BffHost;
-                """),
-            Compile("""
-                using PatternKit.Cloud.BackendsForFrontends;
-                using PatternKit.Generators.BackendsForFrontends;
-                [GenerateBackendsForFrontends(typeof(string), typeof(int))]
-                public static partial class BffHost
-                {
-                    [FrontendSelector("web")]
-                    private static string Web(string value) => value;
-                    [FrontendHandler("web")]
-                    private static int Handle(BackendsForFrontendsContext<string> ctx) => 1;
-                }
-                """),
-            Compile("""
-                using PatternKit.Cloud.BackendsForFrontends;
-                using PatternKit.Generators.BackendsForFrontends;
-                [GenerateBackendsForFrontends(typeof(string), typeof(int))]
-                public static partial class BffHost
-                {
-                    [FrontendSelector("web")]
-                    private static bool Web(string value) => true;
-                    [FrontendSelector("WEB")]
-                    private static bool Web2(string value) => true;
-                    [FrontendHandler("web")]
-                    private static int Handle(BackendsForFrontendsContext<string> ctx) => 1;
-                    [FrontendHandler("WEB")]
-                    private static int Handle2(BackendsForFrontendsContext<string> ctx) => 1;
-                }
-                """),
-            Compile("""
-                using PatternKit.Cloud.BackendsForFrontends;
-                using PatternKit.Generators.BackendsForFrontends;
-                [GenerateBackendsForFrontends(typeof(string), typeof(int))]
-                public static partial class BffHost
-                {
-                    [FrontendSelector("web")]
-                    private static bool Web(string value) => true;
-                    [FrontendHandler("web")]
-                    private static int Handle(BackendsForFrontendsContext<string> ctx) => 1;
-                    [FrontendFallback]
-                    private static string Fallback(BackendsForFrontendsContext<string> ctx) => "";
-                }
-                """)
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractBff", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedBff", combined);
+            ScenarioExpect.Contains("internal partial struct StructBff", combined);
+            ScenarioExpect.Contains("Create(\"backends-for-frontends\")", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"bff\")", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
-        .Then("diagnostics identify invalid declarations", results =>
+        .AssertPassed();
+
+    [Scenario("Generates nested Backends for Frontends host wrappers")]
+    [Fact]
+    public Task Generates_Nested_Backends_For_Frontends_Host_Wrappers()
+        => Given("nested BFF declarations", () => Compile("""
+            using PatternKit.Cloud.BackendsForFrontends;
+            using PatternKit.Generators.BackendsForFrontends;
+            namespace Demo;
+            public sealed record ClientRequest(string Client, string CustomerId);
+            public sealed record ClientResponse(string CustomerId, string Shape);
+
+            public partial class BffContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateBackendsForFrontends(typeof(ClientRequest), typeof(ClientResponse))]
+                    protected partial class ProtectedBff
+                    {
+                        [FrontendSelector("web")]
+                        private static bool IsWeb(ClientRequest request) => true;
+                        [FrontendHandler("web")]
+                        private static ClientResponse Web(BackendsForFrontendsContext<ClientRequest> ctx) => new(ctx.Request.CustomerId, "web");
+                    }
+
+                    [GenerateBackendsForFrontends(typeof(ClientRequest), typeof(ClientResponse))]
+                    private protected partial class PrivateProtectedBff
+                    {
+                        [FrontendSelector("web")]
+                        private static bool IsWeb(ClientRequest request) => true;
+                        [FrontendHandler("web")]
+                        private static ClientResponse Web(BackendsForFrontendsContext<ClientRequest> ctx) => new(ctx.Request.CustomerId, "web");
+                    }
+
+                    [GenerateBackendsForFrontends(typeof(ClientRequest), typeof(ClientResponse))]
+                    protected internal partial class ProtectedInternalBff
+                    {
+                        [FrontendSelector("web")]
+                        private static bool IsWeb(ClientRequest request) => true;
+                        [FrontendHandler("web")]
+                        private static ClientResponse Web(BackendsForFrontendsContext<ClientRequest> ctx) => new(ctx.Request.CustomerId, "web");
+                    }
+                }
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
         {
-            ScenarioExpect.Contains(results[0].Diagnostics, diagnostic => diagnostic.Id == "PKBFF001");
-            ScenarioExpect.Contains(results[1].Diagnostics, diagnostic => diagnostic.Id == "PKBFF002");
-            ScenarioExpect.Contains(results[2].Diagnostics, diagnostic => diagnostic.Id == "PKBFF003");
-            ScenarioExpect.Contains(results[3].Diagnostics, diagnostic => diagnostic.Id == "PKBFF004");
-            ScenarioExpect.Contains(results[4].Diagnostics, diagnostic => diagnostic.Id == "PKBFF003");
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class BffContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedBff", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedBff", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalBff", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
+        .AssertPassed();
+
+    [Scenario("Skips malformed Backends for Frontends type arguments")]
+    [Theory]
+    [InlineData("null!", "typeof(ClientResponse)")]
+    [InlineData("typeof(ClientRequest)", "null!")]
+    public Task Skips_Malformed_Backends_For_Frontends_Type_Arguments(string requestType, string responseType)
+        => Given("a BFF declaration with a null type argument", () => Compile($$"""
+            using PatternKit.Cloud.BackendsForFrontends;
+            using PatternKit.Generators.BackendsForFrontends;
+            public sealed record ClientRequest(string Client, string CustomerId);
+            public sealed record ClientResponse(string CustomerId, string Shape);
+            [GenerateBackendsForFrontends({{requestType}}, {{responseType}})]
+            public static partial class CommerceBff
+            {
+                [FrontendSelector("web")]
+                private static bool IsWeb(ClientRequest request) => true;
+                [FrontendHandler("web")]
+                private static ClientResponse Web(BackendsForFrontendsContext<ClientRequest> ctx) => new(ctx.Request.CustomerId, "web");
+            }
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
         .AssertPassed();
 
     private static GeneratorResult Compile(string source)

--- a/test/PatternKit.Generators.Tests/LeaderElectionGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/LeaderElectionGeneratorTests.cs
@@ -48,46 +48,148 @@ public sealed partial class LeaderElectionGeneratorTests(ITestOutputHelper outpu
         .AssertPassed();
 
     [Scenario("Reports diagnostics for invalid leader election declarations")]
+    [Theory]
+    [InlineData("public static class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; }", "PKLE001")]
+    [InlineData("public static partial class LeaderHost;", "PKLE002")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string One(string value) => value; [LeaderCandidateId] private static string Two(string value) => value; }", "PKLE002")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderAcquired] private static void One(LeaderLease lease, string value) { } [LeaderAcquired] private static void Two(LeaderLease lease, string value) { } }", "PKLE002")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderRenewed] private static void One(LeaderLease lease, string value) { } [LeaderRenewed] private static void Two(LeaderLease lease, string value) { } }", "PKLE002")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderReleased] private static void One(string value) { } [LeaderReleased] private static void Two(string value) { } }", "PKLE002")]
+    [InlineData("public partial class LeaderHost { [LeaderCandidateId] private string CandidateId(string value) => value; }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static int CandidateId(string value) => 1; }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId() => string.Empty; }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(int value) => value.ToString(); }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderAcquired] private static int Acquired(LeaderLease lease, string context) => 1; }", "PKLE003")]
+    [InlineData("public partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderAcquired] private void Acquired(LeaderLease lease, string context) { } }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderAcquired] private static void Acquired(string lease, string context) { } }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderAcquired] private static void Acquired(LeaderLease lease, int context) { } }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderRenewed] private static void Renewed(LeaderLease lease) { } }", "PKLE003")]
+    [InlineData("public partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderReleased] private void Released(string context) { } }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; [LeaderReleased] private static void Released(int context) { } }", "PKLE003")]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; }", "PKLE004", 0)]
+    [InlineData("public static partial class LeaderHost { [LeaderCandidateId] private static string CandidateId(string value) => value; }", "PKLE004", -1)]
+    public Task Reports_Diagnostics_For_Invalid_Leader_Election_Declarations(string declaration, string diagnosticId, int leaseDurationMilliseconds = 30000)
+        => Given("an invalid leader election declaration", () => Compile($$"""
+            using PatternKit.Cloud.LeaderElection;
+            using PatternKit.Generators.LeaderElection;
+            [GenerateLeaderElection(typeof(string), LeaseDurationMilliseconds = {{leaseDurationMilliseconds}})]
+            {{declaration}}
+            """))
+        .Then("diagnostics identify invalid declarations", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
+        .AssertPassed();
+
+    [Scenario("Generates leader election defaults and host shapes")]
     [Fact]
-    public Task Reports_Diagnostics_For_Invalid_Leader_Election_Declarations()
-        => Given("invalid leader election declarations", () => new[]
+    public Task Generates_Leader_Election_Defaults_And_Host_Shapes()
+        => Given("leader election declarations with default names and different host shapes", () => Compile("""
+            using PatternKit.Cloud.LeaderElection;
+            using PatternKit.Generators.LeaderElection;
+            namespace Demo;
+            public sealed record WorkerContext(string NodeId);
+
+            [GenerateLeaderElection(typeof(WorkerContext))]
+            internal abstract partial class AbstractLeader
+            {
+                [LeaderCandidateId]
+                private static string CandidateId(WorkerContext context) => context.NodeId;
+            }
+
+            [GenerateLeaderElection(typeof(WorkerContext), ElectionName = "tenant\\\"leader")]
+            public sealed partial class SealedLeader
+            {
+                [LeaderCandidateId]
+                private static string CandidateId(WorkerContext context) => context.NodeId;
+            }
+
+            [GenerateLeaderElection(typeof(WorkerContext))]
+            internal partial struct StructLeader
+            {
+                [LeaderCandidateId]
+                private static string CandidateId(WorkerContext context) => context.NodeId;
+            }
+            """))
+        .Then("generated sources preserve host shape and configured names", result =>
         {
-            Compile("""
-                using PatternKit.Generators.LeaderElection;
-                [GenerateLeaderElection(typeof(string))]
-                public static class LeaderHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.LeaderElection;
-                [GenerateLeaderElection(typeof(string))]
-                public static partial class LeaderHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.LeaderElection;
-                [GenerateLeaderElection(typeof(string))]
-                public static partial class LeaderHost
-                {
-                    [LeaderCandidateId]
-                    private static int CandidateId(string value) => 1;
-                }
-                """),
-            Compile("""
-                using PatternKit.Generators.LeaderElection;
-                [GenerateLeaderElection(typeof(string), LeaseDurationMilliseconds = 0)]
-                public static partial class LeaderHost
-                {
-                    [LeaderCandidateId]
-                    private static string CandidateId(string value) => value;
-                }
-                """)
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractLeader", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedLeader", combined);
+            ScenarioExpect.Contains("internal partial struct StructLeader", combined);
+            ScenarioExpect.Contains("CreateElection()", combined);
+            ScenarioExpect.Contains("Create(\"leader-election\")", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"leader\")", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
-        .Then("diagnostics identify invalid declarations", results =>
+        .AssertPassed();
+
+    [Scenario("Generates nested leader election host wrappers")]
+    [Fact]
+    public Task Generates_Nested_Leader_Election_Host_Wrappers()
+        => Given("nested leader election declarations", () => Compile("""
+            using PatternKit.Cloud.LeaderElection;
+            using PatternKit.Generators.LeaderElection;
+            namespace Demo;
+            public sealed record WorkerContext(string NodeId);
+
+            public partial class LeaderContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateLeaderElection(typeof(WorkerContext))]
+                    protected partial class ProtectedLeader
+                    {
+                        [LeaderCandidateId]
+                        private static string CandidateId(WorkerContext context) => context.NodeId;
+                    }
+
+                    [GenerateLeaderElection(typeof(WorkerContext))]
+                    private protected partial class PrivateProtectedLeader
+                    {
+                        [LeaderCandidateId]
+                        private static string CandidateId(WorkerContext context) => context.NodeId;
+                    }
+
+                    [GenerateLeaderElection(typeof(WorkerContext))]
+                    protected internal partial class ProtectedInternalLeader
+                    {
+                        [LeaderCandidateId]
+                        private static string CandidateId(WorkerContext context) => context.NodeId;
+                    }
+                }
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
         {
-            ScenarioExpect.Contains(results[0].Diagnostics, diagnostic => diagnostic.Id == "PKLE001");
-            ScenarioExpect.Contains(results[1].Diagnostics, diagnostic => diagnostic.Id == "PKLE002");
-            ScenarioExpect.Contains(results[2].Diagnostics, diagnostic => diagnostic.Id == "PKLE003");
-            ScenarioExpect.Contains(results[3].Diagnostics, diagnostic => diagnostic.Id == "PKLE004");
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class LeaderContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedLeader", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedLeader", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalLeader", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
+        .AssertPassed();
+
+    [Scenario("Skips malformed leader election type arguments")]
+    [Fact]
+    public Task Skips_Malformed_Leader_Election_Type_Arguments()
+        => Given("a leader election declaration with a null type argument", () => Compile("""
+            using PatternKit.Generators.LeaderElection;
+            [GenerateLeaderElection(null!)]
+            public static partial class LeaderHost
+            {
+                [LeaderCandidateId]
+                private static string CandidateId(string value) => value;
+            }
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
         .AssertPassed();
 
     private static GeneratorResult Compile(string source)


### PR DESCRIPTION
## Summary
- add nested host wrapper generation for Leader Election and Backends for Frontends source generators
- expand TinyBDD generator coverage for invalid signatures, defaults, host shapes, escaped names, malformed type args, and nested hosts
- raise local generator coverage for LeaderElectionGenerator and BackendsForFrontendsGenerator to 99.3% each

## Validation
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --framework net10.0 --filter "FullyQualifiedName~LeaderElectionGeneratorTests|FullyQualifiedName~BackendsForFrontendsGeneratorTests" --logger "console;verbosity=minimal"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory .\TestResults --logger "console;verbosity=minimal" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
- reportgenerator -reports:TestResults\**\coverage.cobertura.xml -targetdir:coverage-report-generators -reporttypes:TextSummary
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore --no-build -p:TestTfmsInParallel=false --logger "console;verbosity=minimal"

## Coverage
- PatternKit.Generators: 96.1% local line coverage
- BackendsForFrontendsGenerator: 99.3%
- LeaderElectionGenerator: 99.3%

Refs #413