### PR TITLE
test(generators): cover dead letter and mailbox

### DIFF
--- a/src/PatternKit.Generators/Messaging/DeadLetterChannelGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/DeadLetterChannelGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -114,6 +115,57 @@ public sealed class DeadLetterChannelGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Messaging.Reliability.DeadLetterChannel<")
+            .Append(payloadName).Append("> ").Append(factoryName).AppendLine("()");
+        sb.Append(bodyIndent).Append("=> global::PatternKit.Messaging.Reliability.DeadLetterChannel<")
+            .Append(payloadName).Append(">.Create(\"").Append(Escape(channelName)).AppendLine("\")");
+        sb.Append(bodyIndent).Append("    .FromSource(\"").Append(Escape(source)).AppendLine("\")");
+        sb.Append(bodyIndent).Append("    .UseStore(").Append(storeFactory).AppendLine("())");
+        sb.Append(bodyIndent).Append("    .UseIds(static (message, _, _) => \"")
+            .Append(Escape(idPrefix))
+            .Append(":\" + (message.Headers.MessageId ?? global::System.Guid.NewGuid().ToString(\"N\")))")
+            .AppendLine();
+        sb.Append(bodyIndent).Append("    .IncludeExceptionDetails(").Append(includeExceptionDetails ? "true" : "false").AppendLine(")");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -121,22 +173,7 @@ public sealed class DeadLetterChannelGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Messaging.Reliability.DeadLetterChannel<")
-            .Append(payloadName).Append("> ").Append(factoryName).AppendLine("()");
-        sb.Append("        => global::PatternKit.Messaging.Reliability.DeadLetterChannel<")
-            .Append(payloadName).Append(">.Create(\"").Append(Escape(channelName)).AppendLine("\")");
-        sb.Append("            .FromSource(\"").Append(Escape(source)).AppendLine("\")");
-        sb.Append("            .UseStore(").Append(storeFactory).AppendLine("())");
-        sb.Append("            .UseIds(static (message, _, _) => \"")
-            .Append(Escape(idPrefix))
-            .Append(":\" + (message.Headers.MessageId ?? global::System.Guid.NewGuid().ToString(\"N\")))")
-            .AppendLine();
-        sb.Append("            .IncludeExceptionDetails(").Append(includeExceptionDetails ? "true" : "false").AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static bool IsStoreFactory(IMethodSymbol method, ITypeSymbol payloadType)

--- a/src/PatternKit.Generators/Messaging/MailboxGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/MailboxGenerator.cs
@@ -204,20 +204,34 @@ public sealed class MailboxGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Messaging.Mailboxes.Mailbox<")
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Messaging.Mailboxes.Mailbox<")
             .Append(payload)
             .Append("> ")
             .Append(factoryName)
             .AppendLine("()");
-        sb.Append("        => global::PatternKit.Messaging.Mailboxes.Mailbox<")
+        sb.Append(bodyIndent).Append("=> global::PatternKit.Messaging.Mailboxes.Mailbox<")
             .Append(payload)
             .AppendLine(">.Create(" + handlerName + ")");
 
         if (capacity > 0)
         {
-            sb.Append("            .Bounded(")
+            sb.Append(bodyIndent).Append("    .Bounded(")
                 .Append(capacity)
                 .Append(", global::PatternKit.Messaging.Mailboxes.MailboxBackpressurePolicy.")
                 .Append(backpressurePolicy)
@@ -225,22 +239,63 @@ public sealed class MailboxGenerator : IIncrementalGenerator
         }
         else
         {
-            sb.AppendLine("            .Unbounded()");
+            sb.Append(bodyIndent).AppendLine("    .Unbounded()");
         }
 
-        sb.Append("            .OnError(global::PatternKit.Messaging.Mailboxes.MailboxErrorPolicy.")
+        sb.Append(bodyIndent).Append("    .OnError(global::PatternKit.Messaging.Mailboxes.MailboxErrorPolicy.")
             .Append(errorPolicy);
         if (errorHandlerName is not null)
             sb.Append(", ").Append(errorHandlerName);
         sb.AppendLine(")");
 
         if (eventSinkName is not null)
-            sb.Append("            .OnEvent(").Append(eventSinkName).AppendLine(")");
+            sb.Append(bodyIndent).Append("    .OnEvent(").Append(eventSinkName).AppendLine(")");
 
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("}");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
         return sb.ToString();
     }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
+        sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
+        if (type.IsStatic)
+            sb.Append("static ");
+        else if (type.IsAbstract && type.TypeKind == TypeKind.Class)
+            sb.Append("abstract ");
+        else if (type.IsSealed && type.TypeKind == TypeKind.Class)
+            sb.Append("sealed ");
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
+    }
+
+    private static string GetAccessibility(Accessibility accessibility)
+        => accessibility switch
+        {
+            Accessibility.Public => "public",
+            Accessibility.Internal => "internal",
+            Accessibility.Private => "private",
+            Accessibility.Protected => "protected",
+            Accessibility.ProtectedAndInternal => "private protected",
+            Accessibility.ProtectedOrInternal => "protected internal",
+            _ => "internal"
+        };
 
     private static string? GetNamedString(AttributeData attribute, string name)
         => attribute.NamedArguments.FirstOrDefault(kv => kv.Key == name).Value.Value as string;

--- a/test/PatternKit.Generators.Tests/DeadLetterChannelGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/DeadLetterChannelGeneratorTests.cs
@@ -3,16 +3,18 @@ using Microsoft.CodeAnalysis.CSharp;
 using PatternKit.Generators.Messaging;
 using PatternKit.Messaging.Reliability;
 using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Generators.Tests;
 
-public sealed class DeadLetterChannelGeneratorTests
+[Feature("Dead Letter Channel generator")]
+public sealed partial class DeadLetterChannelGeneratorTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Scenario("Generates dead letter channel factory")]
     [Fact]
-    public void GeneratesDeadLetterChannelFactory()
-    {
-        var source = """
+    public Task Generates_Dead_Letter_Channel_Factory()
+        => Given("a configured dead letter channel declaration", () => Compile("""
             using PatternKit.Generators.Messaging;
             using PatternKit.Messaging.Reliability;
 
@@ -32,102 +34,172 @@ public sealed class DeadLetterChannelGeneratorTests
                 [DeadLetterStoreFactory]
                 private static IDeadLetterStore<Order> CreateStore() => new InMemoryDeadLetterStore<Order>();
             }
+            """))
+        .Then("generated source creates the configured channel", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            var source = ScenarioExpect.Single(result.GeneratedSources);
+            ScenarioExpect.Equal("CheckoutDeadLetters.DeadLetterChannel.g.cs", source.HintName);
+            ScenarioExpect.Contains("public static partial class CheckoutDeadLetters", source.Source);
+            ScenarioExpect.Contains("BuildChannel", source.Source);
+            ScenarioExpect.Contains(".FromSource(\"checkout.fulfillment\")", source.Source);
+            ScenarioExpect.Contains(".UseStore(CreateStore())", source.Source);
+            ScenarioExpect.Contains("\"checkout-dead:\"", source.Source);
+            ScenarioExpect.Contains(".IncludeExceptionDetails(false)", source.Source);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
 
-            public static class Demo
+    [Scenario("Reports diagnostics for invalid dead letter channel declarations")]
+    [Theory]
+    [InlineData("public static class CheckoutDeadLetters;", "PKDL001")]
+    [InlineData("public static partial class CheckoutDeadLetters;", "PKDL002")]
+    [InlineData("public static partial class CheckoutDeadLetters { [DeadLetterStoreFactory] private static IDeadLetterStore<Order> One() => new InMemoryDeadLetterStore<Order>(); [DeadLetterStoreFactory] private static IDeadLetterStore<Order> Two() => new InMemoryDeadLetterStore<Order>(); }", "PKDL002")]
+    [InlineData("public static partial class CheckoutDeadLetters { [DeadLetterStoreFactory] private static string CreateStore() => \"bad\"; }", "PKDL003")]
+    [InlineData("public static partial class CheckoutDeadLetters { [DeadLetterStoreFactory] private IDeadLetterStore<Order> CreateStore() => new InMemoryDeadLetterStore<Order>(); }", "PKDL003")]
+    [InlineData("public static partial class CheckoutDeadLetters { [DeadLetterStoreFactory] private static IDeadLetterStore<Order> CreateStore(string name) => new InMemoryDeadLetterStore<Order>(); }", "PKDL003")]
+    [InlineData("public static partial class CheckoutDeadLetters { [DeadLetterStoreFactory] private static IDeadLetterStore<string> CreateStore() => new InMemoryDeadLetterStore<string>(); }", "PKDL003")]
+    public Task Reports_Diagnostics_For_Invalid_Dead_Letter_Channel_Declarations(string declaration, string diagnosticId)
+        => Given("an invalid dead letter channel declaration", () => Compile($$"""
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging.Reliability;
+            public sealed record Order(string Id);
+            [GenerateDeadLetterChannel(typeof(Order))]
+            {{declaration}}
+            """))
+        .Then("the expected diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
+        .AssertPassed();
+
+    [Scenario("Generates dead letter channel defaults and host shapes")]
+    [Fact]
+    public Task Generates_Dead_Letter_Channel_Defaults_And_Host_Shapes()
+        => Given("dead letter channel declarations with default names and host shapes", () => Compile("""
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging.Reliability;
+            namespace MyApp;
+            public sealed record Order(string Id);
+
+            [GenerateDeadLetterChannel(typeof(Order))]
+            internal abstract partial class AbstractDeadLetters
             {
-                public static DeadLetterChannel<Order> Run() => CheckoutDeadLetters.BuildChannel();
+                [DeadLetterStoreFactory]
+                private static IDeadLetterStore<Order> Store() => new InMemoryDeadLetterStore<Order>();
             }
-            """;
 
-        var comp = CreateCompilation(source, nameof(GeneratesDeadLetterChannelFactory));
-        var gen = new DeadLetterChannelGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
-
-        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
-        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
-        ScenarioExpect.Equal("CheckoutDeadLetters.DeadLetterChannel.g.cs", generated.HintName);
-        var text = generated.SourceText.ToString();
-        ScenarioExpect.Contains("BuildChannel", text);
-        ScenarioExpect.Contains(".FromSource(\"checkout.fulfillment\")", text);
-        ScenarioExpect.Contains(".UseStore(CreateStore())", text);
-        ScenarioExpect.Contains("\"checkout-dead:\"", text);
-        ScenarioExpect.Contains(".IncludeExceptionDetails(false)", text);
-
-        var emit = updated.Emit(Stream.Null);
-        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
-    }
-
-    [Scenario("Reports diagnostic for non partial dead letter channel")]
-    [Fact]
-    public void ReportsDiagnosticForNonPartialDeadLetterChannel()
-    {
-        var source = """
-            using PatternKit.Generators.Messaging;
-
-            namespace MyApp;
-
-            public sealed record Order(string Id);
+            [GenerateDeadLetterChannel(typeof(Order), ChannelName = "tenant\\\"dead", Source = "checkout\\\"api", IdPrefix = "tenant\\\"dead")]
+            public sealed partial class SealedDeadLetters
+            {
+                [DeadLetterStoreFactory]
+                private static IDeadLetterStore<Order> Store() => new InMemoryDeadLetterStore<Order>();
+            }
 
             [GenerateDeadLetterChannel(typeof(Order))]
-            public static class CheckoutDeadLetters;
-            """;
+            internal partial struct StructDeadLetters
+            {
+                [DeadLetterStoreFactory]
+                private static IDeadLetterStore<Order> Store() => new InMemoryDeadLetterStore<Order>();
+            }
+            """))
+        .Then("generated sources preserve host shape and configured defaults", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
 
-        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForNonPartialDeadLetterChannel));
-        var gen = new DeadLetterChannelGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+            var combined = string.Join("\n", result.GeneratedSources.Select(static source => source.Source));
+            ScenarioExpect.Contains("internal abstract partial class AbstractDeadLetters", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedDeadLetters", combined);
+            ScenarioExpect.Contains("internal partial struct StructDeadLetters", combined);
+            ScenarioExpect.Contains("Create(\"dead-letter-channel\")", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"dead\")", combined);
+            ScenarioExpect.Contains(".FromSource(\"application\")", combined);
+            ScenarioExpect.Contains(".FromSource(\"checkout\\\\\\\"api\")", combined);
+            ScenarioExpect.Contains(".IncludeExceptionDetails(true)", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
 
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKDL001", diagnostic.Id);
-    }
-
-    [Scenario("Reports diagnostic for missing dead letter store factory")]
+    [Scenario("Generates nested dead letter channel host wrappers")]
     [Fact]
-    public void ReportsDiagnosticForMissingDeadLetterStoreFactory()
-    {
-        var source = """
+    public Task Generates_Nested_Dead_Letter_Channel_Host_Wrappers()
+        => Given("nested dead letter channel declarations", () => Compile("""
             using PatternKit.Generators.Messaging;
-
+            using PatternKit.Messaging.Reliability;
             namespace MyApp;
-
             public sealed record Order(string Id);
 
-            [GenerateDeadLetterChannel(typeof(Order))]
-            public static partial class CheckoutDeadLetters;
-            """;
+            public partial class DeadLetterContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateDeadLetterChannel(typeof(Order))]
+                    protected partial class ProtectedDeadLetters
+                    {
+                        [DeadLetterStoreFactory]
+                        private static IDeadLetterStore<Order> Store() => new InMemoryDeadLetterStore<Order>();
+                    }
 
-        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForMissingDeadLetterStoreFactory));
-        var gen = new DeadLetterChannelGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+                    [GenerateDeadLetterChannel(typeof(Order))]
+                    private protected partial class PrivateProtectedDeadLetters
+                    {
+                        [DeadLetterStoreFactory]
+                        private static IDeadLetterStore<Order> Store() => new InMemoryDeadLetterStore<Order>();
+                    }
 
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKDL002", diagnostic.Id);
-    }
+                    [GenerateDeadLetterChannel(typeof(Order))]
+                    protected internal partial class ProtectedInternalDeadLetters
+                    {
+                        [DeadLetterStoreFactory]
+                        private static IDeadLetterStore<Order> Store() => new InMemoryDeadLetterStore<Order>();
+                    }
+                }
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
 
-    [Scenario("Reports diagnostic for invalid dead letter store factory")]
+            var combined = string.Join("\n", result.GeneratedSources.Select(static source => source.Source));
+            ScenarioExpect.Contains("public partial class DeadLetterContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedDeadLetters", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedDeadLetters", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalDeadLetters", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
+
+    [Scenario("Skips malformed dead letter channel payload type")]
     [Fact]
-    public void ReportsDiagnosticForInvalidDeadLetterStoreFactory()
-    {
-        var source = """
+    public Task Skips_Malformed_Dead_Letter_Channel_Payload_Type()
+        => Given("a dead letter channel declaration with a null payload type", () => Compile("""
             using PatternKit.Generators.Messaging;
-
-            namespace MyApp;
-
-            public sealed record Order(string Id);
-
-            [GenerateDeadLetterChannel(typeof(Order))]
+            using PatternKit.Messaging.Reliability;
+            [GenerateDeadLetterChannel(null!)]
             public static partial class CheckoutDeadLetters
             {
                 [DeadLetterStoreFactory]
-                private static string CreateStore() => "bad";
+                private static IDeadLetterStore<string> Store() => new InMemoryDeadLetterStore<string>();
             }
-            """;
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidDeadLetterStoreFactory));
-        var gen = new DeadLetterChannelGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKDL003", diagnostic.Id);
+    private static GeneratorResult Compile(string source)
+    {
+        var compilation = CreateCompilation(source, "DeadLetterChannelGeneratorTests");
+        _ = RoslynTestHelpers.Run(compilation, new DeadLetterChannelGenerator(), out var run, out var updated);
+        var result = run.Results.Single();
+        var emit = updated.Emit(Stream.Null);
+        return new GeneratorResult(
+            result.Diagnostics.ToArray(),
+            result.GeneratedSources
+                .Select(static source => new GeneratedSource(source.HintName, source.SourceText.ToString()))
+                .ToArray(),
+            emit.Success,
+            emit.Diagnostics.Select(static diagnostic => diagnostic.ToString()).ToArray());
     }
 
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)
@@ -135,4 +207,12 @@ public sealed class DeadLetterChannelGeneratorTests
             source,
             assemblyName,
             extra: MetadataReference.CreateFromFile(typeof(DeadLetterChannel<>).Assembly.Location));
+
+    private sealed record GeneratorResult(
+        IReadOnlyList<Diagnostic> Diagnostics,
+        IReadOnlyList<GeneratedSource> GeneratedSources,
+        bool EmitSuccess,
+        IReadOnlyList<string> EmitDiagnostics);
+
+    private sealed record GeneratedSource(string HintName, string Source);
 }

--- a/test/PatternKit.Generators.Tests/MailboxGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/MailboxGeneratorTests.cs
@@ -1,17 +1,20 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using PatternKit.Generators.Messaging;
+using PatternKit.Messaging.Mailboxes;
 using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
 
 namespace PatternKit.Generators.Tests;
 
-public sealed class MailboxGeneratorTests
+[Feature("Mailbox generator")]
+public sealed partial class MailboxGeneratorTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
     [Scenario("Generates typed mailbox factory")]
     [Fact]
-    public void GeneratesTypedMailboxFactory()
-    {
-        var source = """
+    public Task Generates_Typed_Mailbox_Factory()
+        => Given("a configured mailbox declaration", () => Compile("""
             using System;
             using System.Collections.Generic;
             using System.Threading;
@@ -48,140 +51,220 @@ public sealed class MailboxGeneratorTests
                 [MailboxEventSink]
                 private static void Observe(MailboxEvent evt) => Events.Add(evt.Kind);
             }
+            """))
+        .Then("generated source creates the configured mailbox", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            var source = ScenarioExpect.Single(result.GeneratedSources);
+            ScenarioExpect.Equal("WorkMailbox.Mailbox.g.cs", source.HintName);
+            ScenarioExpect.Contains("public static partial class WorkMailbox", source.Source);
+            ScenarioExpect.Contains("CreateWorker()", source.Source);
+            ScenarioExpect.Contains(".Bounded(8, global::PatternKit.Messaging.Mailboxes.MailboxBackpressurePolicy.Reject)", source.Source);
+            ScenarioExpect.Contains(".OnError(global::PatternKit.Messaging.Mailboxes.MailboxErrorPolicy.Continue, HandleError)", source.Source);
+            ScenarioExpect.Contains(".OnEvent(Observe)", source.Source);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
 
-            public static class Demo
-            {
-                public static int Capacity()
-                {
-                    using var mailbox = WorkMailbox.CreateWorker();
-                    return mailbox.Capacity ?? 0;
-                }
-            }
-            """;
-
-        var comp = CreateCompilation(source, nameof(GeneratesTypedMailboxFactory));
-        var gen = new MailboxGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
-
-        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
-        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
-        ScenarioExpect.Equal("WorkMailbox.Mailbox.g.cs", generated.HintName);
-        var text = generated.SourceText.ToString();
-        ScenarioExpect.Contains("CreateWorker()", text);
-        ScenarioExpect.Contains(".Bounded(8, global::PatternKit.Messaging.Mailboxes.MailboxBackpressurePolicy.Reject)", text);
-        ScenarioExpect.Contains(".OnError(global::PatternKit.Messaging.Mailboxes.MailboxErrorPolicy.Continue, HandleError)", text);
-        ScenarioExpect.Contains(".OnEvent(Observe)", text);
-
-        var emit = updated.Emit(Stream.Null);
-        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
-    }
-
-    [Scenario("Reports diagnostic for non-partial mailbox")]
-    [Fact]
-    public void ReportsDiagnosticForNonPartialMailbox()
-    {
-        var source = """
+    [Scenario("Reports diagnostics for invalid mailbox declarations")]
+    [Theory]
+    [InlineData("public static class WorkMailbox;", "PKMB001")]
+    [InlineData("public static partial class WorkMailbox;", "PKMB002")]
+    [InlineData("public static partial class WorkMailbox { [MailboxHandler] private static ValueTask One(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default; [MailboxHandler] private static ValueTask Two(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default; }", "PKMB002")]
+    [InlineData("public static partial class WorkMailbox { [MailboxHandler] private static void Handle(WorkItem item) { } }", "PKMB003")]
+    [InlineData("public static partial class WorkMailbox { [MailboxHandler] private ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default; }", "PKMB003")]
+    [InlineData("public static partial class WorkMailbox { [MailboxHandler] private static ValueTask Handle(Message<string> message, MessageContext context, CancellationToken cancellationToken) => default; }", "PKMB003")]
+    [InlineData("public static partial class WorkMailbox { [MailboxHandler] private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default; [MailboxErrorHandler] private static void HandleError(Exception exception) { } }", "PKMB004")]
+    [InlineData("public static partial class WorkMailbox { [MailboxHandler] private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default; [MailboxEventSink] private static ValueTask Observe(MailboxEvent evt) => default; }", "PKMB004")]
+    [InlineData("public static partial class WorkMailbox { [MailboxHandler] private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default; [MailboxEventSink] private static void One(MailboxEvent evt) { } [MailboxEventSink] private static void Two(MailboxEvent evt) { } }", "PKMB004")]
+    public Task Reports_Diagnostics_For_Invalid_Mailbox_Declarations(string declaration, string diagnosticId)
+        => Given("an invalid mailbox declaration", () => Compile($$"""
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
             using PatternKit.Generators.Messaging;
-
-            namespace MyApp;
-
+            using PatternKit.Messaging;
+            using PatternKit.Messaging.Mailboxes;
             public sealed record WorkItem(string Id);
-
             [GenerateMailbox(typeof(WorkItem))]
-            public static class WorkMailbox;
-            """;
+            {{declaration}}
+            """))
+        .Then("the expected diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForNonPartialMailbox));
-        var gen = new MailboxGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKMB001", diagnostic.Id);
-    }
-
-    [Scenario("Reports diagnostic for missing mailbox handler")]
-    [Fact]
-    public void ReportsDiagnosticForMissingMailboxHandler()
-    {
-        var source = """
+    [Scenario("Reports diagnostics for invalid mailbox configuration")]
+    [Theory]
+    [InlineData("Capacity = -1")]
+    [InlineData("BackpressurePolicy = \"Overflow\"")]
+    [InlineData("ErrorPolicy = \"Ignore\"")]
+    public Task Reports_Diagnostics_For_Invalid_Mailbox_Configuration(string configuration)
+        => Given("a mailbox declaration with invalid configuration", () => Compile($$"""
+            using System.Threading;
+            using System.Threading.Tasks;
             using PatternKit.Generators.Messaging;
-
-            namespace MyApp;
-
+            using PatternKit.Messaging;
             public sealed record WorkItem(string Id);
-
-            [GenerateMailbox(typeof(WorkItem))]
-            public static partial class WorkMailbox;
-            """;
-
-        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForMissingMailboxHandler));
-        var gen = new MailboxGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKMB002", diagnostic.Id);
-    }
-
-    [Scenario("Reports diagnostic for invalid mailbox handler")]
-    [Fact]
-    public void ReportsDiagnosticForInvalidMailboxHandler()
-    {
-        var source = """
-            using PatternKit.Generators.Messaging;
-
-            namespace MyApp;
-
-            public sealed record WorkItem(string Id);
-
-            [GenerateMailbox(typeof(WorkItem))]
+            [GenerateMailbox(typeof(WorkItem), {{configuration}})]
             public static partial class WorkMailbox
             {
                 [MailboxHandler]
-                private static void Handle(WorkItem item) { }
+                private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default;
             }
-            """;
+            """))
+        .Then("the configuration diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "PKMB005"))
+        .AssertPassed();
 
-        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidMailboxHandler));
-        var gen = new MailboxGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
-
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKMB003", diagnostic.Id);
-    }
-
-    [Scenario("Reports diagnostic for invalid mailbox policy")]
+    [Scenario("Generates mailbox defaults, policies, and host shapes")]
     [Fact]
-    public void ReportsDiagnosticForInvalidMailboxPolicy()
-    {
-        var source = """
+    public Task Generates_Mailbox_Defaults_Policies_And_Host_Shapes()
+        => Given("mailbox declarations with default names and host shapes", () => Compile("""
             using System.Threading;
             using System.Threading.Tasks;
             using PatternKit.Generators.Messaging;
             using PatternKit.Messaging;
 
             namespace MyApp;
-
             public sealed record WorkItem(string Id);
 
-            [GenerateMailbox(typeof(WorkItem), BackpressurePolicy = "Overflow")]
-            public static partial class WorkMailbox
+            [GenerateMailbox(typeof(WorkItem))]
+            internal abstract partial class AbstractMailbox
             {
                 [MailboxHandler]
                 private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default;
             }
-            """;
 
-        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidMailboxPolicy));
-        var gen = new MailboxGenerator();
-        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+            [GenerateMailbox(typeof(WorkItem), Capacity = 4, BackpressurePolicy = "dropnewest", ErrorPolicy = "continue")]
+            public sealed partial class SealedMailbox
+            {
+                [MailboxHandler]
+                private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default;
+            }
 
-        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
-        ScenarioExpect.Equal("PKMB005", diagnostic.Id);
+            [GenerateMailbox(typeof(WorkItem), Capacity = 3, BackpressurePolicy = "DropOldest")]
+            internal partial struct StructMailbox
+            {
+                [MailboxHandler]
+                private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default;
+            }
+            """))
+        .Then("generated sources preserve host shape and normalize policy names", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources.Select(static source => source.Source));
+            ScenarioExpect.Contains("internal abstract partial class AbstractMailbox", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedMailbox", combined);
+            ScenarioExpect.Contains("internal partial struct StructMailbox", combined);
+            ScenarioExpect.Contains(".Unbounded()", combined);
+            ScenarioExpect.Contains("MailboxBackpressurePolicy.DropNewest", combined);
+            ScenarioExpect.Contains("MailboxBackpressurePolicy.DropOldest", combined);
+            ScenarioExpect.Contains("MailboxErrorPolicy.Stop", combined);
+            ScenarioExpect.Contains("MailboxErrorPolicy.Continue", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
+
+    [Scenario("Generates nested mailbox host wrappers")]
+    [Fact]
+    public Task Generates_Nested_Mailbox_Host_Wrappers()
+        => Given("nested mailbox declarations", () => Compile("""
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+            namespace MyApp;
+            public sealed record WorkItem(string Id);
+
+            public partial class MailboxContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateMailbox(typeof(WorkItem))]
+                    protected partial class ProtectedMailbox
+                    {
+                        [MailboxHandler]
+                        private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default;
+                    }
+
+                    [GenerateMailbox(typeof(WorkItem))]
+                    private protected partial class PrivateProtectedMailbox
+                    {
+                        [MailboxHandler]
+                        private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default;
+                    }
+
+                    [GenerateMailbox(typeof(WorkItem))]
+                    protected internal partial class ProtectedInternalMailbox
+                    {
+                        [MailboxHandler]
+                        private static ValueTask Handle(Message<WorkItem> message, MessageContext context, CancellationToken cancellationToken) => default;
+                    }
+                }
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources.Select(static source => source.Source));
+            ScenarioExpect.Contains("public partial class MailboxContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedMailbox", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedMailbox", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalMailbox", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
+
+    [Scenario("Skips malformed mailbox payload type")]
+    [Fact]
+    public Task Skips_Malformed_Mailbox_Payload_Type()
+        => Given("a mailbox declaration with a null payload type", () => Compile("""
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+            [GenerateMailbox(null!)]
+            public static partial class WorkMailbox
+            {
+                [MailboxHandler]
+                private static ValueTask Handle(Message<string> message, MessageContext context, CancellationToken cancellationToken) => default;
+            }
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
+        .AssertPassed();
+
+    private static GeneratorResult Compile(string source)
+    {
+        var compilation = CreateCompilation(source, "MailboxGeneratorTests");
+        _ = RoslynTestHelpers.Run(compilation, new MailboxGenerator(), out var run, out var updated);
+        var result = run.Results.Single();
+        var emit = updated.Emit(Stream.Null);
+        return new GeneratorResult(
+            result.Diagnostics.ToArray(),
+            result.GeneratedSources
+                .Select(static source => new GeneratedSource(source.HintName, source.SourceText.ToString()))
+                .ToArray(),
+            emit.Success,
+            emit.Diagnostics.Select(static diagnostic => diagnostic.ToString()).ToArray());
     }
 
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)
         => RoslynTestHelpers.CreateCompilation(
             source,
             assemblyName,
-            extra: MetadataReference.CreateFromFile(typeof(PatternKit.Messaging.Mailboxes.Mailbox<>).Assembly.Location));
+            extra: MetadataReference.CreateFromFile(typeof(Mailbox<>).Assembly.Location));
+
+    private sealed record GeneratorResult(
+        IReadOnlyList<Diagnostic> Diagnostics,
+        IReadOnlyList<GeneratedSource> GeneratedSources,
+        bool EmitSuccess,
+        IReadOnlyList<string> EmitDiagnostics);
+
+    private sealed record GeneratedSource(string HintName, string Source);
 }


### PR DESCRIPTION
## Summary
- harden Dead Letter Channel and Mailbox source generation for nested/typed host shapes
- convert both generator test files onto TinyBDD xUnit scenario chains
- expand diagnostics, defaults, policy normalization, malformed argument, and nested host coverage

## Validation
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore --no-build -p:TestTfmsInParallel=false --logger "console;verbosity=minimal"
- local coverage pass: PatternKit.Generators 96.8%, DeadLetterChannelGenerator 99.2%, MailboxGenerator 99.5%

Refs #413