### PR TITLE
test(generators): cover state transfer and scheduler

### DIFF
--- a/src/PatternKit.Generators/EventCarriedStateTransfer/EventCarriedStateTransferGenerator.cs
+++ b/src/PatternKit.Generators/EventCarriedStateTransfer/EventCarriedStateTransferGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -139,6 +140,57 @@ public sealed class EventCarriedStateTransferGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.EnterpriseIntegration.EventCarriedStateTransfer.EventCarriedStateTransfer<")
+            .Append(eventTypeName).Append(", ").Append(keyTypeName).Append(", ").Append(stateTypeName).Append("> ")
+            .Append(factoryMethodName).AppendLine("()");
+        sb.AppendLine(memberIndent + "{");
+        sb.Append(bodyIndent).Append("return global::PatternKit.EnterpriseIntegration.EventCarriedStateTransfer.EventCarriedStateTransfer<")
+            .Append(eventTypeName).Append(", ").Append(keyTypeName).Append(", ").Append(stateTypeName)
+            .Append(">.Create(\"").Append(Escape(transferName)).AppendLine("\")");
+        sb.Append(bodyIndent).Append("    .WithKey(").Append(keySelectorName).AppendLine(")");
+        sb.Append(bodyIndent).Append("    .WithVersion(").Append(versionSelectorName).AppendLine(")");
+        sb.Append(bodyIndent).Append("    .WithState(").Append(mapperName).AppendLine(")");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(memberIndent + "}");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -146,22 +198,7 @@ public sealed class EventCarriedStateTransferGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.EnterpriseIntegration.EventCarriedStateTransfer.EventCarriedStateTransfer<")
-            .Append(eventTypeName).Append(", ").Append(keyTypeName).Append(", ").Append(stateTypeName).Append("> ")
-            .Append(factoryMethodName).AppendLine("()");
-        sb.AppendLine("    {");
-        sb.Append("        return global::PatternKit.EnterpriseIntegration.EventCarriedStateTransfer.EventCarriedStateTransfer<")
-            .Append(eventTypeName).Append(", ").Append(keyTypeName).Append(", ").Append(stateTypeName)
-            .Append(">.Create(\"").Append(Escape(transferName)).AppendLine("\")");
-        sb.Append("            .WithKey(").Append(keySelectorName).AppendLine(")");
-        sb.Append("            .WithVersion(").Append(versionSelectorName).AppendLine(")");
-        sb.Append("            .WithState(").Append(mapperName).AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static string? GetNamedString(AttributeData attribute, string name)

--- a/src/PatternKit.Generators/SchedulerAgentSupervisor/SchedulerAgentSupervisorGenerator.cs
+++ b/src/PatternKit.Generators/SchedulerAgentSupervisor/SchedulerAgentSupervisorGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -176,6 +177,60 @@ public sealed class SchedulerAgentSupervisorGenerator : IIncrementalGenerator
             sb.AppendLine();
         }
 
+        var containingTypes = GetContainingTypes(type);
+        var indentLevel = 0;
+        foreach (var containingType in containingTypes)
+        {
+            AppendTypeDeclaration(sb, containingType, indentLevel);
+            sb.AppendLine();
+            sb.AppendLine(new string(' ', indentLevel * 4) + "{");
+            indentLevel++;
+        }
+
+        AppendTypeDeclaration(sb, type, indentLevel);
+        sb.AppendLine();
+        var indent = new string(' ', indentLevel * 4);
+        sb.AppendLine(indent + "{");
+        var memberIndent = indent + "    ";
+        var bodyIndent = memberIndent + "    ";
+        sb.Append(memberIndent).Append("public static global::PatternKit.Cloud.SchedulerAgentSupervisor.SchedulerAgentSupervisor<").Append(workTypeName).Append(", ").Append(resultTypeName).Append("> ").Append(factoryMethodName).AppendLine("()");
+        sb.AppendLine(memberIndent + "{");
+        sb.Append(bodyIndent).Append("var policy = global::PatternKit.Cloud.SchedulerAgentSupervisor.SchedulerSupervisionPolicy<").Append(workTypeName).AppendLine(">.Create()");
+        sb.Append(bodyIndent).Append("    .MaxAttempts(").Append(maxAttempts).AppendLine(")");
+        sb.Append(bodyIndent).Append("    .RetryDelay(global::System.TimeSpan.FromMilliseconds(").Append(retryDelayMilliseconds).AppendLine("))");
+        if (retryName is not null)
+            sb.Append(bodyIndent).Append("    .RetryWhen(").Append(retryName).AppendLine(")");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine();
+        sb.Append(bodyIndent).Append("return global::PatternKit.Cloud.SchedulerAgentSupervisor.SchedulerAgentSupervisor<").Append(workTypeName).Append(", ").Append(resultTypeName).Append(">.Create(\"").Append(Escape(supervisorName)).AppendLine("\")");
+        sb.Append(bodyIndent).AppendLine("    .Supervision(policy)");
+        foreach (var agent in agents)
+            sb.Append(bodyIndent).Append("    .Agent(\"").Append(Escape(agent.AgentName)).Append("\", ").Append(agent.MethodName).AppendLine(")");
+        sb.Append(bodyIndent).AppendLine("    .Build();");
+        sb.AppendLine(memberIndent + "}");
+        sb.AppendLine(indent + "}");
+        for (var i = containingTypes.Length - 1; i >= 0; i--)
+        {
+            sb.AppendLine(new string(' ', i * 4) + "}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static INamedTypeSymbol[] GetContainingTypes(INamedTypeSymbol type)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var current = type.ContainingType; current is not null; current = current.ContainingType)
+        {
+            containingTypes.Push(current);
+        }
+
+        return containingTypes.ToArray();
+    }
+
+    private static void AppendTypeDeclaration(StringBuilder sb, INamedTypeSymbol type, int indentLevel)
+    {
+        sb.Append(new string(' ', indentLevel * 4));
         sb.Append(GetAccessibility(type.DeclaredAccessibility)).Append(' ');
         if (type.IsStatic)
             sb.Append("static ");
@@ -183,25 +238,7 @@ public sealed class SchedulerAgentSupervisorGenerator : IIncrementalGenerator
             sb.Append("abstract ");
         else if (type.IsSealed && type.TypeKind == TypeKind.Class)
             sb.Append("sealed ");
-        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name).AppendLine();
-        sb.AppendLine("{");
-        sb.Append("    public static global::PatternKit.Cloud.SchedulerAgentSupervisor.SchedulerAgentSupervisor<").Append(workTypeName).Append(", ").Append(resultTypeName).Append("> ").Append(factoryMethodName).AppendLine("()");
-        sb.AppendLine("    {");
-        sb.Append("        var policy = global::PatternKit.Cloud.SchedulerAgentSupervisor.SchedulerSupervisionPolicy<").Append(workTypeName).AppendLine(">.Create()");
-        sb.Append("            .MaxAttempts(").Append(maxAttempts).AppendLine(")");
-        sb.Append("            .RetryDelay(global::System.TimeSpan.FromMilliseconds(").Append(retryDelayMilliseconds).AppendLine("))");
-        if (retryName is not null)
-            sb.Append("            .RetryWhen(").Append(retryName).AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine();
-        sb.Append("        return global::PatternKit.Cloud.SchedulerAgentSupervisor.SchedulerAgentSupervisor<").Append(workTypeName).Append(", ").Append(resultTypeName).Append(">.Create(\"").Append(Escape(supervisorName)).AppendLine("\")");
-        sb.AppendLine("            .Supervision(policy)");
-        foreach (var agent in agents)
-            sb.Append("            .Agent(\"").Append(Escape(agent.AgentName)).Append("\", ").Append(agent.MethodName).AppendLine(")");
-        sb.AppendLine("            .Build();");
-        sb.AppendLine("    }");
-        sb.AppendLine("}");
-        return sb.ToString();
+        sb.Append("partial ").Append(type.TypeKind == TypeKind.Struct ? "struct" : "class").Append(' ').Append(type.Name);
     }
 
     private static int? GetNamedInt(AttributeData attribute, string name)

--- a/test/PatternKit.Generators.Tests/EventCarriedStateTransferGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/EventCarriedStateTransferGeneratorTests.cs
@@ -43,40 +43,170 @@ public sealed partial class EventCarriedStateTransferGeneratorTests(ITestOutputH
         .AssertPassed();
 
     [Scenario("Reports diagnostics for invalid event-carried state transfer declarations")]
+    [Theory]
+    [InlineData("public static class TransferHost;", "PKECST001")]
+    [InlineData("public static partial class TransferHost;", "PKECST002")]
+    [InlineData("public static partial class TransferHost { [EventCarriedStateKey] private static string Key(ProductStockChanged evt) => evt.Sku; [EventCarriedStateKey] private static string Key2(ProductStockChanged evt) => evt.Sku; [EventCarriedStateVersion] private static long Version(ProductStockChanged evt) => evt.Sequence; [EventCarriedStateMapper] private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand); }", "PKECST002")]
+    [InlineData("public static partial class TransferHost { [EventCarriedStateKey] private string Key(ProductStockChanged evt) => evt.Sku; [EventCarriedStateVersion] private static long Version(ProductStockChanged evt) => evt.Sequence; [EventCarriedStateMapper] private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand); }", "PKECST003")]
+    [InlineData("public static partial class TransferHost { [EventCarriedStateKey] private static int Key(ProductStockChanged evt) => 1; [EventCarriedStateVersion] private static long Version(ProductStockChanged evt) => evt.Sequence; [EventCarriedStateMapper] private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand); }", "PKECST003")]
+    [InlineData("public static partial class TransferHost { [EventCarriedStateKey] private static string Key(string evt) => evt; [EventCarriedStateVersion] private static long Version(ProductStockChanged evt) => evt.Sequence; [EventCarriedStateMapper] private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand); }", "PKECST003")]
+    [InlineData("public static partial class TransferHost { [EventCarriedStateKey] private static string Key(ProductStockChanged evt) => evt.Sku; [EventCarriedStateVersion] private static int Version(ProductStockChanged evt) => 1; [EventCarriedStateMapper] private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand); }", "PKECST003")]
+    [InlineData("public static partial class TransferHost { [EventCarriedStateKey] private static string Key(ProductStockChanged evt) => evt.Sku; [EventCarriedStateVersion] private static long Version(ProductStockChanged evt) => evt.Sequence; [EventCarriedStateMapper] private static string Map(ProductStockChanged evt) => evt.Sku; }", "PKECST003")]
+    public Task Reports_Diagnostics_For_Invalid_Event_Carried_State_Transfer_Declarations(string declaration, string diagnosticId)
+        => Given("an invalid event-carried state transfer declaration", () => Compile($$"""
+            using PatternKit.Generators.EventCarriedStateTransfer;
+            public sealed record ProductStockChanged(string Sku, int QuantityOnHand, long Sequence);
+            public sealed record ProductInventoryState(string Sku, int QuantityOnHand);
+            [GenerateEventCarriedStateTransfer(typeof(ProductStockChanged), typeof(string), typeof(ProductInventoryState))]
+            {{declaration}}
+            """))
+        .Then("the expected diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
+        .AssertPassed();
+
+    [Scenario("Generates event-carried state transfer defaults and host shapes")]
     [Fact]
-    public Task Reports_Diagnostics_For_Invalid_Event_Carried_State_Transfer_Declarations()
-        => Given("invalid event-carried state transfer declarations", () => new[]
+    public Task Generates_Event_Carried_State_Transfer_Defaults_And_Host_Shapes()
+        => Given("event-carried state transfer declarations with default names and host shapes", () => Compile("""
+            using PatternKit.Generators.EventCarriedStateTransfer;
+            namespace Demo;
+            public sealed record ProductStockChanged(string Sku, int QuantityOnHand, long Sequence);
+            public sealed record ProductInventoryState(string Sku, int QuantityOnHand);
+
+            [GenerateEventCarriedStateTransfer(typeof(ProductStockChanged), typeof(string), typeof(ProductInventoryState))]
+            internal abstract partial class AbstractStateTransfer
+            {
+                [EventCarriedStateKey]
+                private static string Key(ProductStockChanged evt) => evt.Sku;
+                [EventCarriedStateVersion]
+                private static long Version(ProductStockChanged evt) => evt.Sequence;
+                [EventCarriedStateMapper]
+                private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand);
+            }
+
+            [GenerateEventCarriedStateTransfer(typeof(ProductStockChanged), typeof(string), typeof(ProductInventoryState), TransferName = "tenant\\\"state")]
+            public sealed partial class SealedStateTransfer
+            {
+                [EventCarriedStateKey]
+                private static string Key(ProductStockChanged evt) => evt.Sku;
+                [EventCarriedStateVersion]
+                private static long Version(ProductStockChanged evt) => evt.Sequence;
+                [EventCarriedStateMapper]
+                private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand);
+            }
+
+            [GenerateEventCarriedStateTransfer(typeof(ProductStockChanged), typeof(string), typeof(ProductInventoryState))]
+            internal partial struct StructStateTransfer
+            {
+                [EventCarriedStateKey]
+                private static string Key(ProductStockChanged evt) => evt.Sku;
+                [EventCarriedStateVersion]
+                private static long Version(ProductStockChanged evt) => evt.Sequence;
+                [EventCarriedStateMapper]
+                private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand);
+            }
+            """))
+        .Then("generated sources preserve host shape and configured defaults", result =>
         {
-            Compile("""
-                using PatternKit.Generators.EventCarriedStateTransfer;
-                [GenerateEventCarriedStateTransfer(typeof(string), typeof(string), typeof(int))]
-                public static class TransferHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.EventCarriedStateTransfer;
-                [GenerateEventCarriedStateTransfer(typeof(string), typeof(string), typeof(int))]
-                public static partial class TransferHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.EventCarriedStateTransfer;
-                [GenerateEventCarriedStateTransfer(typeof(string), typeof(string), typeof(int))]
-                public static partial class TransferHost
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractStateTransfer", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedStateTransfer", combined);
+            ScenarioExpect.Contains("internal partial struct StructStateTransfer", combined);
+            ScenarioExpect.Contains("Create(\"event-carried-state-transfer\")", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"state\")", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
+
+    [Scenario("Generates nested event-carried state transfer host wrappers")]
+    [Fact]
+    public Task Generates_Nested_Event_Carried_State_Transfer_Host_Wrappers()
+        => Given("nested event-carried state transfer declarations", () => Compile("""
+            using PatternKit.Generators.EventCarriedStateTransfer;
+            namespace Demo;
+            public sealed record ProductStockChanged(string Sku, int QuantityOnHand, long Sequence);
+            public sealed record ProductInventoryState(string Sku, int QuantityOnHand);
+
+            public partial class StateTransferContainer
+            {
+                private partial class PrivateHost
                 {
-                    [EventCarriedStateKey]
-                    private static string Key(string value) => value;
-                    [EventCarriedStateVersion]
-                    private static string Version(string value) => value;
-                    [EventCarriedStateMapper]
-                    private static int Map(string value) => value.Length;
+                    [GenerateEventCarriedStateTransfer(typeof(ProductStockChanged), typeof(string), typeof(ProductInventoryState))]
+                    protected partial class ProtectedStateTransfer
+                    {
+                        [EventCarriedStateKey]
+                        private static string Key(ProductStockChanged evt) => evt.Sku;
+                        [EventCarriedStateVersion]
+                        private static long Version(ProductStockChanged evt) => evt.Sequence;
+                        [EventCarriedStateMapper]
+                        private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand);
+                    }
+
+                    [GenerateEventCarriedStateTransfer(typeof(ProductStockChanged), typeof(string), typeof(ProductInventoryState))]
+                    private protected partial class PrivateProtectedStateTransfer
+                    {
+                        [EventCarriedStateKey]
+                        private static string Key(ProductStockChanged evt) => evt.Sku;
+                        [EventCarriedStateVersion]
+                        private static long Version(ProductStockChanged evt) => evt.Sequence;
+                        [EventCarriedStateMapper]
+                        private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand);
+                    }
+
+                    [GenerateEventCarriedStateTransfer(typeof(ProductStockChanged), typeof(string), typeof(ProductInventoryState))]
+                    protected internal partial class ProtectedInternalStateTransfer
+                    {
+                        [EventCarriedStateKey]
+                        private static string Key(ProductStockChanged evt) => evt.Sku;
+                        [EventCarriedStateVersion]
+                        private static long Version(ProductStockChanged evt) => evt.Sequence;
+                        [EventCarriedStateMapper]
+                        private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand);
+                    }
                 }
-                """)
-        })
-        .Then("diagnostics identify invalid declarations", results =>
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
         {
-            ScenarioExpect.Contains(results[0].Diagnostics, diagnostic => diagnostic.Id == "PKECST001");
-            ScenarioExpect.Contains(results[1].Diagnostics, diagnostic => diagnostic.Id == "PKECST002");
-            ScenarioExpect.Contains(results[2].Diagnostics, diagnostic => diagnostic.Id == "PKECST003");
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class StateTransferContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedStateTransfer", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedStateTransfer", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalStateTransfer", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
+        .AssertPassed();
+
+    [Scenario("Skips malformed event-carried state transfer type arguments")]
+    [Theory]
+    [InlineData("null!", "typeof(string)", "typeof(ProductInventoryState)")]
+    [InlineData("typeof(ProductStockChanged)", "null!", "typeof(ProductInventoryState)")]
+    [InlineData("typeof(ProductStockChanged)", "typeof(string)", "null!")]
+    public Task Skips_Malformed_Event_Carried_State_Transfer_Type_Arguments(string eventType, string keyType, string stateType)
+        => Given("an event-carried state transfer declaration with a null type argument", () => Compile($$"""
+            using PatternKit.Generators.EventCarriedStateTransfer;
+            public sealed record ProductStockChanged(string Sku, int QuantityOnHand, long Sequence);
+            public sealed record ProductInventoryState(string Sku, int QuantityOnHand);
+            [GenerateEventCarriedStateTransfer({{eventType}}, {{keyType}}, {{stateType}})]
+            public static partial class ProductInventoryStateTransfer
+            {
+                [EventCarriedStateKey]
+                private static string Key(ProductStockChanged evt) => evt.Sku;
+                [EventCarriedStateVersion]
+                private static long Version(ProductStockChanged evt) => evt.Sequence;
+                [EventCarriedStateMapper]
+                private static ProductInventoryState Map(ProductStockChanged evt) => new(evt.Sku, evt.QuantityOnHand);
+            }
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
         .AssertPassed();
 
     private static GeneratorResult Compile(string source)

--- a/test/PatternKit.Generators.Tests/SchedulerAgentSupervisorGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/SchedulerAgentSupervisorGeneratorTests.cs
@@ -45,60 +45,174 @@ public sealed partial class SchedulerAgentSupervisorGeneratorTests(ITestOutputHe
         .AssertPassed();
 
     [Scenario("Reports diagnostics for invalid scheduler declarations")]
+    [Theory]
+    [InlineData("public static class SchedulerHost;", "PKSAS001")]
+    [InlineData("public static partial class SchedulerHost;", "PKSAS002")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static int Run(SchedulerAgentContext<Work> context) => 1; }", "PKSAS003")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id); }", "PKSAS003")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static Summary Run(string context) => new(context); }", "PKSAS003")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static Summary Run(SchedulerAgentContext<string> context) => new(context.Work); }", "PKSAS003")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id); [SchedulerRetryWhen] private static string Retry(Exception exception, SchedulerAgentContext<Work> context) => exception.Message; }", "PKSAS003")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id); [SchedulerRetryWhen] private bool Retry(Exception exception, SchedulerAgentContext<Work> context) => true; }", "PKSAS003")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id); [SchedulerRetryWhen] private static bool Retry(string exception, SchedulerAgentContext<Work> context) => true; }", "PKSAS003")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id); [SchedulerRetryWhen] private static bool One(Exception exception, SchedulerAgentContext<Work> context) => true; [SchedulerRetryWhen] private static bool Two(Exception exception, SchedulerAgentContext<Work> context) => true; }", "PKSAS002")]
+    [InlineData("public static partial class SchedulerHost { [SchedulerAgent(\"agent\")] private static Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id); [SchedulerAgent(\"agent\")] private static Summary RunAgain(SchedulerAgentContext<Work> context) => new(context.Work.Id); }", "PKSAS005")]
+    public Task Reports_Diagnostics_For_Invalid_Scheduler_Declarations(string declaration, string diagnosticId)
+        => Given("an invalid scheduler agent supervisor declaration", () => Compile($$"""
+            using System;
+            using PatternKit.Cloud.SchedulerAgentSupervisor;
+            using PatternKit.Generators.SchedulerAgentSupervisor;
+            public sealed record Work(string Id);
+            public sealed record Summary(string Id);
+            [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary))]
+            {{declaration}}
+            """))
+        .Then("the expected diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId))
+        .AssertPassed();
+
+    [Scenario("Reports diagnostics for invalid scheduler configuration")]
+    [Theory]
+    [InlineData("MaxAttempts = 0")]
+    [InlineData("RetryDelayMilliseconds = -1")]
+    public Task Reports_Diagnostics_For_Invalid_Scheduler_Configuration(string configuration)
+        => Given("an invalid scheduler agent supervisor configuration", () => Compile($$"""
+            using PatternKit.Cloud.SchedulerAgentSupervisor;
+            using PatternKit.Generators.SchedulerAgentSupervisor;
+            public sealed record Work(string Id);
+            public sealed record Summary(string Id);
+            [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary), {{configuration}})]
+            public static partial class SchedulerHost
+            {
+                [SchedulerAgent("agent")]
+                private static Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+            }
+            """))
+        .Then("the configuration diagnostic is reported", result =>
+            ScenarioExpect.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "PKSAS004"))
+        .AssertPassed();
+
+    [Scenario("Generates scheduler agent supervisor defaults and host shapes")]
     [Fact]
-    public Task Reports_Diagnostics_For_Invalid_Scheduler_Declarations()
-        => Given("invalid scheduler declarations", () => new[]
+    public Task Generates_Scheduler_Agent_Supervisor_Defaults_And_Host_Shapes()
+        => Given("scheduler declarations with default names and host shapes", () => Compile("""
+            using PatternKit.Cloud.SchedulerAgentSupervisor;
+            using PatternKit.Generators.SchedulerAgentSupervisor;
+            namespace Demo;
+            public sealed record Work(string Id);
+            public sealed record Summary(string Id);
+
+            [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary))]
+            internal abstract partial class AbstractScheduler
+            {
+                [SchedulerAgent("release-agent")]
+                private static Summary Release(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+            }
+
+            [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary), SupervisorName = "tenant\\\"scheduler")]
+            public sealed partial class SealedScheduler
+            {
+                [SchedulerAgent("release-agent")]
+                private static Summary Release(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+            }
+
+            [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary), MaxAttempts = 2, RetryDelayMilliseconds = 0)]
+            internal partial struct StructScheduler
+            {
+                [SchedulerAgent("release-agent")]
+                private static Summary Release(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+            }
+            """))
+        .Then("generated sources preserve host shape and configured defaults", result =>
         {
-            Compile("""
-                using PatternKit.Generators.SchedulerAgentSupervisor;
-                [GenerateSchedulerAgentSupervisor(typeof(string), typeof(string))]
-                public static class SchedulerHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.SchedulerAgentSupervisor;
-                [GenerateSchedulerAgentSupervisor(typeof(string), typeof(string))]
-                public static partial class SchedulerHost;
-                """),
-            Compile("""
-                using PatternKit.Generators.SchedulerAgentSupervisor;
-                [GenerateSchedulerAgentSupervisor(typeof(string), typeof(string))]
-                public static partial class SchedulerHost
-                {
-                    [SchedulerAgent("agent")]
-                    private static int Run(string value) => 1;
-                }
-                """),
-            Compile("""
-                using PatternKit.Cloud.SchedulerAgentSupervisor;
-                using PatternKit.Generators.SchedulerAgentSupervisor;
-                [GenerateSchedulerAgentSupervisor(typeof(string), typeof(string), MaxAttempts = 0)]
-                public static partial class SchedulerHost
-                {
-                    [SchedulerAgent("agent")]
-                    private static string Run(SchedulerAgentContext<string> context) => context.Work;
-                }
-                """),
-            Compile("""
-                using PatternKit.Cloud.SchedulerAgentSupervisor;
-                using PatternKit.Generators.SchedulerAgentSupervisor;
-                [GenerateSchedulerAgentSupervisor(typeof(string), typeof(string))]
-                public static partial class SchedulerHost
-                {
-                    [SchedulerAgent("agent")]
-                    private static string Run(SchedulerAgentContext<string> context) => context.Work;
-                    [SchedulerAgent("agent")]
-                    private static string RunAgain(SchedulerAgentContext<string> context) => context.Work;
-                }
-                """)
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("internal abstract partial class AbstractScheduler", combined);
+            ScenarioExpect.Contains("public sealed partial class SealedScheduler", combined);
+            ScenarioExpect.Contains("internal partial struct StructScheduler", combined);
+            ScenarioExpect.Contains("Create(\"scheduler-agent-supervisor\")", combined);
+            ScenarioExpect.Contains("Create(\"tenant\\\\\\\"scheduler\")", combined);
+            ScenarioExpect.Contains(".MaxAttempts(3)", combined);
+            ScenarioExpect.Contains("FromMilliseconds(1000)", combined);
+            ScenarioExpect.Contains(".MaxAttempts(2)", combined);
+            ScenarioExpect.Contains("FromMilliseconds(0)", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
-        .Then("diagnostics identify invalid declarations", results =>
+        .AssertPassed();
+
+    [Scenario("Generates nested scheduler agent supervisor host wrappers")]
+    [Fact]
+    public Task Generates_Nested_Scheduler_Agent_Supervisor_Host_Wrappers()
+        => Given("nested scheduler agent supervisor declarations", () => Compile("""
+            using PatternKit.Cloud.SchedulerAgentSupervisor;
+            using PatternKit.Generators.SchedulerAgentSupervisor;
+            namespace Demo;
+            public sealed record Work(string Id);
+            public sealed record Summary(string Id);
+
+            public partial class SchedulerContainer
+            {
+                private partial class PrivateHost
+                {
+                    [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary))]
+                    protected partial class ProtectedScheduler
+                    {
+                        [SchedulerAgent("release-agent")]
+                        private static Summary Release(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+                    }
+
+                    [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary))]
+                    private protected partial class PrivateProtectedScheduler
+                    {
+                        [SchedulerAgent("release-agent")]
+                        private static Summary Release(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+                    }
+
+                    [GenerateSchedulerAgentSupervisor(typeof(Work), typeof(Summary))]
+                    protected internal partial class ProtectedInternalScheduler
+                    {
+                        [SchedulerAgent("release-agent")]
+                        private static Summary Release(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+                    }
+                }
+            }
+            """))
+        .Then("generated sources preserve containing partial type wrappers", result =>
         {
-            ScenarioExpect.Contains(results[0].Diagnostics, diagnostic => diagnostic.Id == "PKSAS001");
-            ScenarioExpect.Contains(results[1].Diagnostics, diagnostic => diagnostic.Id == "PKSAS002");
-            ScenarioExpect.Contains(results[2].Diagnostics, diagnostic => diagnostic.Id == "PKSAS003");
-            ScenarioExpect.Contains(results[3].Diagnostics, diagnostic => diagnostic.Id == "PKSAS004");
-            ScenarioExpect.Contains(results[4].Diagnostics, diagnostic => diagnostic.Id == "PKSAS005");
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(3, result.GeneratedSources.Count);
+
+            var combined = string.Join("\n", result.GeneratedSources);
+            ScenarioExpect.Contains("public partial class SchedulerContainer", combined);
+            ScenarioExpect.Contains("private partial class PrivateHost", combined);
+            ScenarioExpect.Contains("protected partial class ProtectedScheduler", combined);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedScheduler", combined);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalScheduler", combined);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
         })
+        .AssertPassed();
+
+    [Scenario("Skips malformed scheduler agent supervisor type arguments")]
+    [Theory]
+    [InlineData("null!", "typeof(Summary)")]
+    [InlineData("typeof(Work)", "null!")]
+    public Task Skips_Malformed_Scheduler_Agent_Supervisor_Type_Arguments(string workType, string resultType)
+        => Given("a scheduler declaration with a null type argument", () => Compile($$"""
+            using PatternKit.Cloud.SchedulerAgentSupervisor;
+            using PatternKit.Generators.SchedulerAgentSupervisor;
+            public sealed record Work(string Id);
+            public sealed record Summary(string Id);
+            [GenerateSchedulerAgentSupervisor({{workType}}, {{resultType}})]
+            public static partial class SchedulerHost
+            {
+                [SchedulerAgent("agent")]
+                private static Summary Run(SchedulerAgentContext<Work> context) => new(context.Work.Id);
+            }
+            """))
+        .Then("no source is generated", result =>
+            ScenarioExpect.Empty(result.GeneratedSources))
         .AssertPassed();
 
     private static GeneratorResult Compile(string source)


### PR DESCRIPTION
## Summary
- harden Event-Carried State Transfer and Scheduler Agent Supervisor generation for nested/typed host shapes
- expand TinyBDD scenarios for defaults, escaped names, malformed type arguments, invalid signatures/configuration, and nested hosts
- preserve containing partial wrappers for nested generator hosts

## Validation
- dotnet format PatternKit.slnx --verify-no-changes --verbosity minimal
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release --no-restore --no-build -p:TestTfmsInParallel=false --logger "console;verbosity=minimal"
- local coverage pass: PatternKit.Generators 97.0%, EventCarriedStateTransferGenerator 99.2%, SchedulerAgentSupervisorGenerator 99.3%

Refs #413