### PR TITLE
ci: count cobertura partials as covered lines

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,10 @@ ignore:
   - "**/obj/**"
   - "**/*.g.cs"
 
+parsers:
+  cobertura:
+    partials_as_hits: true
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary
- Configure Codecov's Cobertura parser to count partial line hits as hits.
- Keeps the project status target at 95% while aligning Codecov's project status with the line coverage produced by the combined Cobertura reports.

## Validation
- Codecov YAML validation endpoint returned `Valid!`.
- Full local solution coverage before this config-only change: 96.6% line coverage, 43,463 covered lines / 44,988 coverable lines.