### PR TITLE
test: harden core runtime coverage gaps

### DIFF
--- a/test/PatternKit.Tests/Application/TableDataGateway/TableDataGatewayTests.cs
+++ b/test/PatternKit.Tests/Application/TableDataGateway/TableDataGatewayTests.cs
@@ -46,8 +46,77 @@ public sealed partial class TableDataGatewayTests(ITestOutputHelper output) : Ti
             ScenarioExpect.Throws<ArgumentNullException>(() => gateway.InsertAsync(null!).AsTask().GetAwaiter().GetResult());
             ScenarioExpect.Throws<ArgumentNullException>(() => gateway.GetAsync(null!).AsTask().GetAwaiter().GetResult());
             ScenarioExpect.Throws<ArgumentNullException>(() => gateway.QueryAsync(null!).AsTask().GetAwaiter().GetResult());
+            ScenarioExpect.Throws<ArgumentNullException>(() => gateway.UpdateAsync(null!).AsTask().GetAwaiter().GetResult());
+            ScenarioExpect.Throws<ArgumentNullException>(() => gateway.DeleteAsync(null!).AsTask().GetAwaiter().GetResult());
             ScenarioExpect.Throws<ArgumentException>(() => TableGatewayResult<OrderRow>.Conflict(new OrderRow("order-1", "Pending", 10m), ""));
             ScenarioExpect.Throws<ArgumentException>(() => TableGatewayResult<OrderRow>.Missing(null, ""));
+        })
+        .AssertPassed();
+
+    [Scenario("Table Data Gateway reports missing mutations")]
+    [Fact]
+    public Task Table_Data_Gateway_Reports_Missing_Mutations()
+        => Given("an empty orders table gateway", () => InMemoryTableDataGateway<OrderRow, string>.Create("orders", static row => row.OrderId).Build())
+        .When("missing rows are updated and deleted", (Func<InMemoryTableDataGateway<OrderRow, string>, ValueTask<MissingMutationScenario>>)(async gateway =>
+        {
+            var update = await gateway.UpdateAsync(new OrderRow("order-404", "Closed", 12m));
+            var delete = await gateway.DeleteAsync("order-404");
+            return new(update, delete);
+        }))
+        .Then("missing mutations include failure status and reasons", result =>
+        {
+            ScenarioExpect.False(result.Update.Succeeded);
+            ScenarioExpect.False(result.Delete.Succeeded);
+            ScenarioExpect.Equal(TableGatewayStatus.Missing, result.Update.Status);
+            ScenarioExpect.Equal(TableGatewayStatus.Missing, result.Delete.Status);
+            ScenarioExpect.Equal("order-404", result.Update.Row!.OrderId);
+            ScenarioExpect.Null(result.Delete.Row);
+            ScenarioExpect.Contains("order-404", result.Update.Reason!);
+            ScenarioExpect.Contains("orders", result.Delete.Reason!);
+        })
+        .AssertPassed();
+
+    [Scenario("Table Data Gateway lists rows with configured comparer")]
+    [Fact]
+    public Task Table_Data_Gateway_Lists_Rows_With_Configured_Comparer()
+        => Given("a case insensitive orders table gateway", () => InMemoryTableDataGateway<OrderRow, string>
+            .Create("orders", static row => row.OrderId)
+            .UseComparer(StringComparer.OrdinalIgnoreCase)
+            .Build())
+        .When("rows are inserted listed and duplicated with different key casing", (Func<InMemoryTableDataGateway<OrderRow, string>, ValueTask<ListScenario>>)(async gateway =>
+        {
+            var insert = await gateway.InsertAsync(new OrderRow("ORDER-1", "Pending", 25m));
+            var duplicate = await gateway.InsertAsync(new OrderRow("order-1", "Pending", 25m));
+            var rows = await gateway.ListAsync();
+            return new(insert, duplicate, rows);
+        }))
+        .Then("the custom comparer controls key identity", result =>
+        {
+            ScenarioExpect.True(result.Insert.Succeeded);
+            ScenarioExpect.False(result.Duplicate.Succeeded);
+            ScenarioExpect.Equal(TableGatewayStatus.Conflict, result.Duplicate.Status);
+            ScenarioExpect.Equal("ORDER-1", ScenarioExpect.Single(result.Rows).OrderId);
+        })
+        .AssertPassed();
+
+    [Scenario("Table Data Gateway honors cancellation")]
+    [Fact]
+    public Task Table_Data_Gateway_Honors_Cancellation()
+        => Given("a canceled token and orders table gateway", () =>
+        {
+            var source = new CancellationTokenSource();
+            source.Cancel();
+            var gateway = InMemoryTableDataGateway<OrderRow, string>.Create("orders", static row => row.OrderId).Build();
+            return new CanceledGatewayScenario(gateway, source.Token);
+        })
+        .Then("operations throw cancellation before mutating rows", scenario =>
+        {
+            ScenarioExpect.Throws<OperationCanceledException>(() => scenario.Gateway.InsertAsync(new OrderRow("order-1", "Pending", 10m), scenario.Token).AsTask().GetAwaiter().GetResult());
+            ScenarioExpect.Throws<OperationCanceledException>(() => scenario.Gateway.GetAsync("order-1", scenario.Token).AsTask().GetAwaiter().GetResult());
+            ScenarioExpect.Throws<OperationCanceledException>(() => scenario.Gateway.ListAsync(scenario.Token).AsTask().GetAwaiter().GetResult());
+            ScenarioExpect.Throws<OperationCanceledException>(() => scenario.Gateway.QueryAsync(static row => row.Status == "Pending", scenario.Token).AsTask().GetAwaiter().GetResult());
+            ScenarioExpect.Throws<OperationCanceledException>(() => scenario.Gateway.UpdateAsync(new OrderRow("order-1", "Closed", 10m), scenario.Token).AsTask().GetAwaiter().GetResult());
+            ScenarioExpect.Throws<OperationCanceledException>(() => scenario.Gateway.DeleteAsync("order-1", scenario.Token).AsTask().GetAwaiter().GetResult());
         })
         .AssertPassed();
 
@@ -60,4 +129,10 @@ public sealed partial class TableDataGatewayTests(ITestOutputHelper output) : Ti
         IReadOnlyList<OrderRow> ClosedRows,
         TableGatewayResult<OrderRow> Delete,
         OrderRow? Missing);
+
+    private sealed record MissingMutationScenario(TableGatewayResult<OrderRow> Update, TableGatewayResult<OrderRow> Delete);
+
+    private sealed record ListScenario(TableGatewayResult<OrderRow> Insert, TableGatewayResult<OrderRow> Duplicate, IReadOnlyList<OrderRow> Rows);
+
+    private sealed record CanceledGatewayScenario(InMemoryTableDataGateway<OrderRow, string> Gateway, CancellationToken Token);
 }

--- a/test/PatternKit.Tests/Cloud/Bulkhead/BulkheadPolicyTests.cs
+++ b/test/PatternKit.Tests/Cloud/Bulkhead/BulkheadPolicyTests.cs
@@ -113,6 +113,108 @@ public sealed class BulkheadPolicyTests
         ScenarioExpect.Equal(1, policy.AvailableSlots);
     }
 
+    [Scenario("Synchronous bulkhead rejects calls when concurrency and queue are full")]
+    [Fact]
+    public async Task Synchronous_Bulkhead_Rejects_Calls_When_Concurrency_And_Queue_Are_Full()
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var policy = BulkheadPolicy<string>.Create("sync-reject")
+            .WithMaxConcurrency(1)
+            .WithMaxQueueLength(0)
+            .Build();
+
+        var first = Task.Run(() => policy.Execute(() =>
+        {
+            entered.SetResult();
+            release.Task.GetAwaiter().GetResult();
+            return "accepted";
+        }));
+        await entered.Task;
+
+        var rejected = policy.Execute(static () => "overflow");
+        release.SetResult();
+        var completed = await first;
+
+        ScenarioExpect.Equal("sync-reject", policy.Name);
+        ScenarioExpect.Equal(1, policy.MaxConcurrency);
+        ScenarioExpect.Equal(0, policy.MaxQueueLength);
+        ScenarioExpect.Equal(TimeSpan.Zero, policy.QueueTimeout);
+        ScenarioExpect.True(completed.Succeeded);
+        ScenarioExpect.True(rejected.Rejected);
+        ScenarioExpect.False(rejected.Succeeded);
+        ScenarioExpect.False(rejected.TimedOut);
+        ScenarioExpect.False(rejected.Queued);
+        ScenarioExpect.Equal(0, rejected.AvailableSlots);
+    }
+
+    [Scenario("Synchronous bulkhead queues calls inside the configured queue length")]
+    [Fact]
+    public async Task Synchronous_Bulkhead_Queues_Calls_Inside_Configured_Queue_Length()
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var policy = BulkheadPolicy<int>.Create("sync-queue")
+            .WithMaxConcurrency(1)
+            .WithMaxQueueLength(1)
+            .WithQueueTimeout(TimeSpan.FromSeconds(5))
+            .Build();
+
+        var first = Task.Run(() => policy.Execute(() =>
+        {
+            entered.SetResult();
+            release.Task.GetAwaiter().GetResult();
+            return 1;
+        }));
+        await entered.Task;
+
+        var second = Task.Run(() => policy.Execute(static () => 2));
+        SpinWait.SpinUntil(() => policy.QueuedCount == 1, TimeSpan.FromSeconds(2));
+        release.SetResult();
+
+        var firstResult = await first;
+        var secondResult = await second;
+
+        ScenarioExpect.True(firstResult.Succeeded);
+        ScenarioExpect.True(secondResult.Succeeded);
+        ScenarioExpect.True(secondResult.Queued);
+        ScenarioExpect.Equal(2, secondResult.Value);
+        ScenarioExpect.Equal(0, secondResult.AvailableSlots);
+        ScenarioExpect.Equal(0, policy.QueuedCount);
+    }
+
+    [Scenario("Synchronous bulkhead times out queued calls")]
+    [Fact]
+    public async Task Synchronous_Bulkhead_Times_Out_Queued_Calls()
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var policy = BulkheadPolicy<string>.Create("sync-timeout")
+            .WithMaxConcurrency(1)
+            .WithMaxQueueLength(1)
+            .WithQueueTimeout(TimeSpan.FromMilliseconds(10))
+            .Build();
+
+        var first = Task.Run(() => policy.Execute(() =>
+        {
+            entered.SetResult();
+            release.Task.GetAwaiter().GetResult();
+            return "accepted";
+        }));
+        await entered.Task;
+
+        var timedOut = policy.Execute(static () => "late");
+        release.SetResult();
+        _ = await first;
+
+        ScenarioExpect.False(timedOut.Succeeded);
+        ScenarioExpect.False(timedOut.Rejected);
+        ScenarioExpect.True(timedOut.TimedOut);
+        ScenarioExpect.True(timedOut.Queued);
+        ScenarioExpect.Equal(0, timedOut.AvailableSlots);
+        ScenarioExpect.Equal(0, policy.QueuedCount);
+    }
+
     [Scenario("Async bulkhead preserves cancellation")]
     [Fact]
     public async Task AsyncBulkhead_Preserves_Cancellation()

--- a/test/PatternKit.Tests/Messaging/Consumers/EventDrivenConsumerTests.cs
+++ b/test/PatternKit.Tests/Messaging/Consumers/EventDrivenConsumerTests.cs
@@ -46,6 +46,29 @@ public sealed class EventDrivenConsumerTests
         ScenarioExpect.Same(context, captured);
     }
 
+    [Scenario("Accept UsesMessageContextWhenContextIsNotProvided")]
+    [Fact]
+    public void Accept_UsesMessageContextWhenContextIsNotProvided()
+    {
+        MessageContext? captured = null;
+        var message = Message<Command>.Create(new("sku-1", 3))
+            .WithMessageId("message-1")
+            .WithCorrelationId("correlation-1");
+        var consumer = EventDrivenConsumer<Command>.Create()
+            .Handle("capture", (handledMessage, context) =>
+            {
+                captured = context;
+                ScenarioExpect.Same(message, handledMessage);
+            })
+            .Build();
+
+        var result = consumer.Accept(message);
+
+        ScenarioExpect.True(result.Accepted);
+        ScenarioExpect.Same(message, result.Message);
+        ScenarioExpect.Same(message.Headers, captured!.Headers);
+    }
+
     [Scenario("Accept ReportsFailuresAndHonorsErrorPolicy")]
     [Fact]
     public void Accept_ReportsFailuresAndHonorsErrorPolicy()
@@ -80,6 +103,25 @@ public sealed class EventDrivenConsumerTests
         ScenarioExpect.Equal("sku-2", ScenarioExpect.Single(handled));
     }
 
+    [Scenario("Accept ConvertsThrownHandlersToFailures")]
+    [Fact]
+    public void Accept_ConvertsThrownHandlersToFailures()
+    {
+        var exception = new InvalidOperationException("handler failed");
+        var consumer = EventDrivenConsumer<Command>.Create()
+            .Handle("throwing", (_, _) => throw exception)
+            .Build();
+
+        var result = consumer.Accept(Message<Command>.Create(new("sku-1", 3)));
+
+        var failure = ScenarioExpect.Single(result.Failures);
+        ScenarioExpect.False(result.Accepted);
+        ScenarioExpect.Equal(1, result.HandlerCount);
+        ScenarioExpect.Equal("throwing", failure.HandlerName);
+        ScenarioExpect.Equal("handler failed", failure.Reason);
+        ScenarioExpect.Same(exception, failure.Exception);
+    }
+
     [Scenario("Builder RejectsInvalidConfiguration")]
     [Fact]
     public void Builder_RejectsInvalidConfiguration()
@@ -87,7 +129,28 @@ public sealed class EventDrivenConsumerTests
         ScenarioExpect.Throws<ArgumentException>(() => EventDrivenConsumer<Command>.Create(""));
         ScenarioExpect.Throws<ArgumentException>(() => EventDrivenConsumer<Command>.Create().Handle("", (_, _) => EventDrivenConsumerHandlerResult.Success("handler")));
         ScenarioExpect.Throws<ArgumentNullException>(() => EventDrivenConsumer<Command>.Create().Handle("handler", (EventDrivenConsumer<Command>.Handler)null!));
+        ScenarioExpect.Throws<ArgumentNullException>(() => EventDrivenConsumer<Command>.Create().Handle("handler", (Action<Message<Command>, MessageContext>)null!));
         ScenarioExpect.Throws<InvalidOperationException>(() => EventDrivenConsumer<Command>.Create().Build());
+    }
+
+    [Scenario("Accept RejectsNullMessage")]
+    [Fact]
+    public void Accept_RejectsNullMessage()
+    {
+        var consumer = EventDrivenConsumer<Command>.Create()
+            .Handle("handler", (_, _) => EventDrivenConsumerHandlerResult.Success("handler"))
+            .Build();
+
+        ScenarioExpect.Throws<ArgumentNullException>(() => consumer.Accept(null!));
+    }
+
+    [Scenario("HandlerResult RejectsInvalidInputs")]
+    [Fact]
+    public void HandlerResult_RejectsInvalidInputs()
+    {
+        ScenarioExpect.Throws<ArgumentException>(() => EventDrivenConsumerHandlerResult.Success(""));
+        ScenarioExpect.Throws<ArgumentException>(() => EventDrivenConsumerHandlerResult.Failure("", "reason"));
+        ScenarioExpect.Throws<ArgumentException>(() => EventDrivenConsumerHandlerResult.Failure("handler", ""));
     }
 
     public sealed record Command(string Sku, int Quantity);


### PR DESCRIPTION
## Summary
- Add TinyBDD scenarios for EventDrivenConsumer context, exception, null, and handler result validation paths
- Cover Table Data Gateway missing mutations, cancellation, list/comparer behavior, and null mutation inputs
- Cover synchronous BulkheadPolicy queue, rejection, timeout, and metadata/result paths

## Validation
- dotnet test test/PatternKit.Tests/PatternKit.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~TableDataGatewayTests|FullyQualifiedName~EventDrivenConsumerTests"
- dotnet test test/PatternKit.Tests/PatternKit.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~BulkheadPolicyTests"
- dotnet test test/PatternKit.Tests/PatternKit.Tests.csproj --configuration Release --no-build -p:TestTfmsInParallel=false

Refs #414