### PR TITLE
ci: widen coverage test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   pr-checks:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     permissions:
       contents: read
       pull-requests: write
@@ -53,7 +53,7 @@ jobs:
           docfx build docs/docfx.json
 
       - name: Test with coverage
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: |
           dotnet test PatternKit.slnx \
             --configuration Release \
@@ -110,7 +110,7 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     permissions:
       contents: write
       packages: write
@@ -169,7 +169,7 @@ jobs:
           /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 
       - name: Test with coverage (Release)
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           dotnet test PatternKit.slnx \
             --configuration Release \


### PR DESCRIPTION
## Summary
- widens the coverage-test timeout budget for PR and main release workflows
- keeps the full solution coverage command unchanged; the prior main run failed because the release test step hit the 30-minute timeout, not because tests failed

## Validation
- `git diff --check`
- observed main CI failure on 36aeb3e timed out during `Test with coverage (Release)` after passing active test assemblies