### PR TITLE
test: cover prototype and template generator branches

### DIFF
--- a/test/PatternKit.Generators.Tests/PrototypeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/PrototypeGeneratorTests.cs
@@ -1035,4 +1035,43 @@ public class PrototypeGeneratorTests
         ScenarioExpect.Contains("Cloneable.Clone()", generatedSource);
         ScenarioExpect.Contains("this.NonCloneable", generatedSource);
     }
+
+    [Scenario("ShallowPrototype CopiesArraysAndCollections")]
+    [Fact]
+    public void ShallowPrototype_CopiesArraysAndCollections()
+    {
+        const string source = """
+            using PatternKit.Generators.Prototype;
+            using System.Collections.Generic;
+
+            namespace TestNamespace;
+
+            [Prototype(Mode = PrototypeMode.Shallow)]
+            public partial class Snapshot
+            {
+                [PrototypeStrategy(PrototypeCloneStrategy.ShallowCopy)]
+                public int[] Scores { get; set; } = [];
+
+                [PrototypeStrategy(PrototypeCloneStrategy.ShallowCopy)]
+                public List<string> Tags { get; set; } = [];
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ShallowPrototype_CopiesArraysAndCollections));
+        var gen = new PrototypeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.DoesNotContain(r.Diagnostics, d => d.Severity == DiagnosticSeverity.Error));
+
+        var generatedSource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "Snapshot.Prototype.g.cs")
+            .SourceText.ToString();
+
+        ScenarioExpect.Contains("((int[])this.Scores.Clone())", generatedSource);
+        ScenarioExpect.Contains("new global::System.Collections.Generic.List<string>(this.Tags)", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
 }

--- a/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
@@ -1012,5 +1012,61 @@ public class TemplateGeneratorTests
         ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("ForceAsync Template GeneratesAsyncPathForSynchronousSteps")]
+    [Fact]
+    public void ForceAsync_Template_GeneratesAsyncPathForSynchronousSteps()
+    {
+        var source = """
+            using PatternKit.Generators.Template;
+            using System.Collections.Generic;
+
+            namespace PatternKit.Examples;
+
+            public sealed class ImportContext
+            {
+                public List<string> Log { get; } = new();
+            }
+
+            [Template(GenerateAsync = true, ForceAsync = true, ErrorPolicy = TemplateErrorPolicy.HandleAndContinue)]
+            public partial class ImportWorkflow
+            {
+                [TemplateHook(HookPoint.BeforeAll)]
+                private void Open(ImportContext ctx) => ctx.Log.Add("open");
+
+                [TemplateStep(0, Optional = true)]
+                private void Validate(ImportContext ctx) => ctx.Log.Add("validate");
+
+                [TemplateHook(HookPoint.AfterAll)]
+                private void Close(ImportContext ctx) => ctx.Log.Add("close");
+
+                [TemplateHook(HookPoint.OnError)]
+                private void CaptureError(ImportContext ctx, System.Exception ex) => ctx.Log.Add(ex.Message);
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(ForceAsync_Template_GeneratesAsyncPathForSynchronousSteps));
+
+        var gen = new TemplateGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+
+        var generated = run.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Single(gs => gs.HintName == "ImportWorkflow.Template.g.cs")
+            .SourceText.ToString();
+
+        ScenarioExpect.Contains("public async System.Threading.Tasks.ValueTask ExecuteAsync", generated);
+        ScenarioExpect.Contains("Open(ctx);", generated);
+        ScenarioExpect.Contains("Validate(ctx);", generated);
+        ScenarioExpect.Contains("Close(ctx);", generated);
+        ScenarioExpect.Contains("catch (System.Exception ex)", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
     #endregion
 }


### PR DESCRIPTION
Refs #413.

## Summary
- adds TinyBDD coverage for prototype shallow-copy generation over arrays and collection copy constructors
- adds TinyBDD coverage for template force-async generation with synchronous steps and error hooks

## Validation
- `dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~ShallowPrototype_CopiesArraysAndCollections|FullyQualifiedName~ForceAsync_Template_GeneratesAsyncPathForSynchronousSteps"`
- `dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory TestResults-generators-current -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura`
- PatternKit.Generators coverage: 97.29%