### PR TITLE
fix: forward template cancellation tokens

### DIFF
--- a/src/PatternKit.Generators/TemplateGenerator.cs
+++ b/src/PatternKit.Generators/TemplateGenerator.cs
@@ -566,7 +566,9 @@ public sealed class TemplateGenerator : IIncrementalGenerator
                 }
                 else
                 {
-                    sb.AppendLine($"        {hook.Method.Name}(ctx);");
+                    var hasCt = hook.Method.Parameters.Any(IsCancellationToken);
+                    var args = hasCt ? "ctx, ct" : "ctx";
+                    sb.AppendLine($"        {hook.Method.Name}({args});");
                 }
             }
 
@@ -588,7 +590,9 @@ public sealed class TemplateGenerator : IIncrementalGenerator
                     }
                     else
                     {
-                        sb.AppendLine($"            {step.Method.Name}(ctx);");
+                        var hasCt = step.Method.Parameters.Any(IsCancellationToken);
+                        var args = hasCt ? "ctx, ct" : "ctx";
+                        sb.AppendLine($"            {step.Method.Name}({args});");
                     }
                 }
 
@@ -604,7 +608,9 @@ public sealed class TemplateGenerator : IIncrementalGenerator
                     }
                     else
                     {
-                        sb.AppendLine($"            {hook.Method.Name}(ctx);");
+                        var hasCt = hook.Method.Parameters.Any(IsCancellationToken);
+                        var args = hasCt ? "ctx, ct" : "ctx";
+                        sb.AppendLine($"            {hook.Method.Name}({args});");
                     }
                 }
 
@@ -624,7 +630,9 @@ public sealed class TemplateGenerator : IIncrementalGenerator
                     }
                     else
                     {
-                        sb.AppendLine($"            {hook.Method.Name}(ctx, ex);");
+                        var hasCt = hook.Method.Parameters.Any(IsCancellationToken);
+                        var args = hasCt ? "ctx, ex, ct" : "ctx, ex";
+                        sb.AppendLine($"            {hook.Method.Name}({args});");
                     }
                 }
 
@@ -649,7 +657,9 @@ public sealed class TemplateGenerator : IIncrementalGenerator
                     }
                     else
                     {
-                        sb.AppendLine($"        {step.Method.Name}(ctx);");
+                        var hasCt = step.Method.Parameters.Any(IsCancellationToken);
+                        var args = hasCt ? "ctx, ct" : "ctx";
+                        sb.AppendLine($"        {step.Method.Name}({args});");
                     }
                 }
 
@@ -665,7 +675,9 @@ public sealed class TemplateGenerator : IIncrementalGenerator
                     }
                     else
                     {
-                        sb.AppendLine($"        {hook.Method.Name}(ctx);");
+                        var hasCt = hook.Method.Parameters.Any(IsCancellationToken);
+                        var args = hasCt ? "ctx, ct" : "ctx";
+                        sb.AppendLine($"        {hook.Method.Name}({args});");
                     }
                 }
             }

--- a/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/TemplateGeneratorTests.cs
@@ -1068,5 +1068,145 @@ public class TemplateGeneratorTests
         ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
 
+    [Scenario("CancellationToken Sync Template Members AreForwardedInAsyncWrapper")]
+    [Fact]
+    public void CancellationToken_Sync_Template_Members_AreForwardedInAsyncWrapper()
+    {
+        var source = """
+            using PatternKit.Generators.Template;
+            using System;
+            using System.Threading;
+
+            namespace PatternKit.Examples;
+
+            public sealed class ImportContext
+            {
+                public int Count { get; set; }
+            }
+
+            [Template(ErrorPolicy = TemplateErrorPolicy.Rethrow)]
+            public partial class ImportWorkflow
+            {
+                [TemplateHook(HookPoint.BeforeAll)]
+                private void Open(ImportContext ctx, CancellationToken ct) => ctx.Count++;
+
+                [TemplateStep(0)]
+                private void Validate(ImportContext ctx, CancellationToken ct) => ctx.Count++;
+
+                [TemplateHook(HookPoint.AfterAll)]
+                private void Close(ImportContext ctx, CancellationToken ct) => ctx.Count++;
+
+                [TemplateHook(HookPoint.OnError)]
+                private void CaptureError(ImportContext ctx, Exception ex, CancellationToken ct) => ctx.Count--;
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(CancellationToken_Sync_Template_Members_AreForwardedInAsyncWrapper));
+
+        var gen = new TemplateGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+
+        var generated = run.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Single(gs => gs.HintName == "ImportWorkflow.Template.g.cs")
+            .SourceText.ToString();
+
+        ScenarioExpect.Contains("public async System.Threading.Tasks.ValueTask ExecuteAsync", generated);
+        ScenarioExpect.Contains("Open(ctx, ct);", generated);
+        ScenarioExpect.Contains("Validate(ctx, ct);", generated);
+        ScenarioExpect.Contains("Close(ctx, ct);", generated);
+        ScenarioExpect.Contains("CaptureError(ctx, ex, ct);", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Scenario("CancellationToken Async Template WithoutErrorHooks ForwardsAfterAllTokens")]
+    [Fact]
+    public void CancellationToken_Async_Template_WithoutErrorHooks_ForwardsAfterAllTokens()
+    {
+        var source = """
+            using PatternKit.Generators.Template;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace PatternKit.Examples;
+
+            public sealed class ImportContext
+            {
+                public int Count { get; set; }
+            }
+
+            [Template]
+            public partial class ImportWorkflow
+            {
+                [TemplateStep(0)]
+                private void Validate(ImportContext ctx, CancellationToken ct) => ctx.Count++;
+
+                [TemplateHook(HookPoint.AfterAll)]
+                private ValueTask FlushAsync(ImportContext ctx, CancellationToken ct) => ValueTask.CompletedTask;
+
+                [TemplateHook(HookPoint.AfterAll)]
+                private void Close(ImportContext ctx, CancellationToken ct) => ctx.Count++;
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(CancellationToken_Async_Template_WithoutErrorHooks_ForwardsAfterAllTokens));
+
+        var gen = new TemplateGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+
+        var generated = run.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Single(gs => gs.HintName == "ImportWorkflow.Template.g.cs")
+            .SourceText.ToString();
+
+        ScenarioExpect.Contains("Validate(ctx, ct);", generated);
+        ScenarioExpect.Contains("await FlushAsync(ctx, ct).ConfigureAwait(false);", generated);
+        ScenarioExpect.Contains("Close(ctx, ct);", generated);
+        ScenarioExpect.DoesNotContain("catch (System.Exception ex)", generated);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Scenario("Reports Error When Template Step HasNoContextParameter")]
+    [Fact]
+    public void Reports_Error_When_Template_Step_HasNoContextParameter()
+    {
+        var source = """
+            using PatternKit.Generators.Template;
+
+            namespace PatternKit.Examples;
+
+            [Template]
+            public partial class ImportWorkflow
+            {
+                [TemplateStep(0)]
+                private void Validate()
+                {
+                }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(Reports_Error_When_Template_Step_HasNoContextParameter));
+
+        var gen = new TemplateGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostics = run.Results.SelectMany(r => r.Diagnostics).ToArray();
+        ScenarioExpect.Contains(diagnostics, d => d.Id == "PKTMP004" && d.GetMessage().Contains("Validate"));
+    }
+
     #endregion
 }


### PR DESCRIPTION
Refs #413.

## Summary
- forward CancellationToken parameters for synchronous Template steps and hooks when async wrapper generation is inferred
- add TinyBDD coverage for sync Template members that accept CancellationToken across before/step/after/error paths
- add TinyBDD coverage for Template steps missing a context parameter

## Validation
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~TemplateGeneratorTests"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory TestResults-generators-current -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura