### PR TITLE
test: harden prototype generator coverage

### DIFF
--- a/src/PatternKit.Generators/PrototypeGenerator.cs
+++ b/src/PatternKit.Generators/PrototypeGenerator.cs
@@ -532,8 +532,8 @@ public sealed class PrototypeGenerator : IIncrementalGenerator
             return true;
 
         // Check for known immutable collections (basic check)
-        var typeName = type.ToDisplayString();
-        if (typeName.StartsWith("System.Collections.Immutable.", StringComparison.Ordinal))
+        var typeName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        if (typeName.Contains("System.Collections.Immutable.", StringComparison.Ordinal))
             return true;
 
         // Conservative: assume mutable

--- a/test/PatternKit.Generators.Tests/PrototypeGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/PrototypeGeneratorTests.cs
@@ -1074,4 +1074,152 @@ public class PrototypeGeneratorTests
         var emit = updated.Emit(Stream.Null);
         ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
     }
+
+    [Scenario("MutableRecordPrototype UsesCopyConstructor")]
+    [Fact]
+    public void MutableRecordPrototype_UsesCopyConstructor()
+    {
+        const string source = """
+            using PatternKit.Generators.Prototype;
+
+            namespace TestNamespace;
+
+            [Prototype]
+            public partial record class MutableSnapshot
+            {
+                public string Name { get; set; } = "";
+                public int Version { get; set; }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(MutableRecordPrototype_UsesCopyConstructor));
+        var gen = new PrototypeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.DoesNotContain(r.Diagnostics, d => d.Severity == DiagnosticSeverity.Error));
+
+        var generatedSource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "MutableSnapshot.Prototype.g.cs")
+            .SourceText.ToString();
+
+        ScenarioExpect.Contains("new global::TestNamespace.MutableSnapshot(this)", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Scenario("MutableRecordStructPrototype UsesParameterlessConstruction")]
+    [Fact]
+    public void MutableRecordStructPrototype_UsesParameterlessConstruction()
+    {
+        const string source = """
+            using PatternKit.Generators.Prototype;
+
+            namespace TestNamespace;
+
+            [Prototype]
+            public partial record struct MutablePoint
+            {
+                public int X { get; set; }
+                public int Y { get; set; }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(MutableRecordStructPrototype_UsesParameterlessConstruction));
+        var gen = new PrototypeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.DoesNotContain(r.Diagnostics, d => d.Severity == DiagnosticSeverity.Error));
+
+        var generatedSource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "MutablePoint.Prototype.g.cs")
+            .SourceText.ToString();
+
+        ScenarioExpect.Contains("return new global::TestNamespace.MutablePoint", generatedSource);
+        ScenarioExpect.Contains("X = this.X", generatedSource);
+        ScenarioExpect.Contains("Y = this.Y", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Scenario("ImmutableCollectionDoesNotWarnInShallowWithWarningsMode")]
+    [Fact]
+    public void ImmutableCollectionDoesNotWarnInShallowWithWarningsMode()
+    {
+        const string source = """
+            using PatternKit.Generators.Prototype;
+
+            namespace TestNamespace
+            {
+                [Prototype]
+                public partial class ImmutableSnapshot
+                {
+                    public System.Collections.Immutable.ImmutableTags Tags { get; set; } = new();
+                }
+            }
+
+            namespace System.Collections.Immutable
+            {
+                public sealed class ImmutableTags
+                {
+                }
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(ImmutableCollectionDoesNotWarnInShallowWithWarningsMode));
+        var gen = new PrototypeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        var diagnostics = result.Results.SelectMany(r => r.Diagnostics).ToArray();
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Id == "PKPRO003");
+        ScenarioExpect.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
+
+    [Scenario("PrototypeIncludesFieldsAndShallowCopyReferenceFallback")]
+    [Fact]
+    public void PrototypeIncludesFieldsAndShallowCopyReferenceFallback()
+    {
+        const string source = """
+            using PatternKit.Generators.Prototype;
+
+            namespace TestNamespace;
+
+            public sealed class Payload
+            {
+                public string Value { get; set; } = "";
+            }
+
+            [Prototype(Mode = PrototypeMode.Shallow)]
+            public partial class Snapshot
+            {
+                public int Version;
+
+                [PrototypeStrategy(PrototypeCloneStrategy.ShallowCopy)]
+                public Payload Data { get; set; } = new();
+            }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(source, nameof(PrototypeIncludesFieldsAndShallowCopyReferenceFallback));
+        var gen = new PrototypeGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var result, out var updated);
+
+        ScenarioExpect.All(result.Results, r => ScenarioExpect.DoesNotContain(r.Diagnostics, d => d.Severity == DiagnosticSeverity.Error));
+
+        var generatedSource = result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(gs => gs.HintName == "Snapshot.Prototype.g.cs")
+            .SourceText.ToString();
+
+        ScenarioExpect.Contains("Version = this.Version", generatedSource);
+        ScenarioExpect.Contains("Data = this.Data", generatedSource);
+
+        var emit = updated.Emit(Stream.Null);
+        ScenarioExpect.True(emit.Success, string.Join("\n", emit.Diagnostics));
+    }
 }


### PR DESCRIPTION
Refs #413.

## Summary
- add TinyBDD coverage for mutable record/record struct prototype construction branches
- add Prototype scenarios for immutable collection warning suppression, public fields, and shallow-copy reference fallback
- harden immutable namespace detection so generator behavior is not dependent on shorthand type display strings

## Validation
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~PrototypeGeneratorTests"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory TestResults-generators-current -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura

Local generator coverage: 97.46%; PrototypeGenerator coverage: 97.10%.