### PR TITLE
test: harden strategy and cache-aside generator coverage

### DIFF
--- a/test/PatternKit.Generators.Tests/CacheAsidePolicyGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/CacheAsidePolicyGeneratorTests.cs
@@ -149,6 +149,75 @@ public sealed class CacheAsidePolicyGeneratorTests
         ScenarioExpect.True(updated.Emit(Stream.Null).Success);
     }
 
+    [Scenario("Generates cache-aside policy factory for abstract and sealed hosts")]
+    [Fact]
+    public void GeneratesCacheAsidePolicyFactoryForAbstractAndSealedHosts()
+    {
+        var source = """
+            using PatternKit.Generators.CacheAside;
+
+            namespace Demo;
+
+            [GenerateCacheAsidePolicy(typeof(string), FactoryMethodName = "CreateAbstract")]
+            public abstract partial class AbstractCacheAsideHost;
+
+            [GenerateCacheAsidePolicy(typeof(string), FactoryMethodName = "CreateSealed")]
+            public sealed partial class SealedCacheAsideHost;
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesCacheAsidePolicyFactoryForAbstractAndSealedHosts));
+        var gen = new CacheAsidePolicyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = run.Results.SelectMany(result => result.GeneratedSources).ToArray();
+        ScenarioExpect.Equal(2, generated.Length);
+        var abstractText = ScenarioExpect.Single(generated.Where(source => source.HintName == "AbstractCacheAsideHost.CacheAsidePolicy.g.cs")).SourceText.ToString();
+        var sealedText = ScenarioExpect.Single(generated.Where(source => source.HintName == "SealedCacheAsideHost.CacheAsidePolicy.g.cs")).SourceText.ToString();
+        ScenarioExpect.Contains("public abstract partial class AbstractCacheAsideHost", abstractText);
+        ScenarioExpect.Contains("CreateAbstract()", abstractText);
+        ScenarioExpect.Contains("public sealed partial class SealedCacheAsideHost", sealedText);
+        ScenarioExpect.Contains("CreateSealed()", sealedText);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
+    }
+
+    [Scenario("Generates cache-aside policy source for nested accessibility variants")]
+    [Fact]
+    public void GeneratesCacheAsidePolicySourceForNestedAccessibilityVariants()
+    {
+        var source = """
+            using PatternKit.Generators.CacheAside;
+
+            namespace Demo;
+
+            public partial class Outer
+            {
+                [GenerateCacheAsidePolicy(typeof(string), FactoryMethodName = "CreatePrivate")]
+                private partial class PrivateCacheAsideHost;
+
+                [GenerateCacheAsidePolicy(typeof(string), FactoryMethodName = "CreateProtected")]
+                protected partial class ProtectedCacheAsideHost;
+
+                [GenerateCacheAsidePolicy(typeof(string), FactoryMethodName = "CreateProtectedInternal")]
+                protected internal partial class ProtectedInternalCacheAsideHost;
+
+                [GenerateCacheAsidePolicy(typeof(string), FactoryMethodName = "CreatePrivateProtected")]
+                private protected partial class PrivateProtectedCacheAsideHost;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesCacheAsidePolicySourceForNestedAccessibilityVariants));
+        var gen = new CacheAsidePolicyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generatedText = string.Join("\n", run.Results.SelectMany(result => result.GeneratedSources).Select(source => source.SourceText.ToString()));
+        ScenarioExpect.Contains("private partial class PrivateCacheAsideHost", generatedText);
+        ScenarioExpect.Contains("protected partial class ProtectedCacheAsideHost", generatedText);
+        ScenarioExpect.Contains("protected internal partial class ProtectedInternalCacheAsideHost", generatedText);
+        ScenarioExpect.Contains("private protected partial class PrivateProtectedCacheAsideHost", generatedText);
+    }
+
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)
         => RoslynTestHelpers.CreateCompilation(
             source,

--- a/test/PatternKit.Generators.Tests/StrategyGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/StrategyGeneratorTests.cs
@@ -425,4 +425,29 @@ public class StrategyGeneratorTests
 
         ScenarioExpect.Equal("int:42|str:hello", result);
     }
+
+    [Scenario("Unsupported strategy kind does not emit source")]
+    [Fact]
+    public void UnsupportedStrategyKindDoesNotEmitSource()
+    {
+        const string source = """
+            using PatternKit.Generators;
+
+            namespace PatternKit.Examples.Generators;
+
+            [GenerateStrategy(nameof(UnsupportedRouter), typeof(int), (StrategyKind)99)]
+            public partial class UnsupportedRouter { }
+            """;
+
+        var comp = RoslynTestHelpers.CreateCompilation(
+            source,
+            assemblyName: nameof(UnsupportedStrategyKindDoesNotEmitSource),
+            extra: [MetadataReference.CreateFromFile(typeof(BranchBuilder<,>).Assembly.Location)]);
+        var gen = new StrategyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        ScenarioExpect.All(run.Results, r => ScenarioExpect.Empty(r.Diagnostics));
+        ScenarioExpect.Empty(run.Results.SelectMany(r => r.GeneratedSources));
+    }
+
 }


### PR DESCRIPTION
## Summary
- add TinyBDD Strategy generator coverage for unsupported strategy enum values
- add TinyBDD CacheAside generator coverage for abstract/sealed hosts and nested accessibility variants
- raise local PatternKit.Generators coverage to 97.63%; CacheAsidePolicyGenerator to 98.34%

Refs #413

## Verification
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~StrategyGeneratorTests|FullyQualifiedName~CacheAsidePolicyGeneratorTests"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory TestResults-generators-current -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura