### PR TITLE
test: harden retry and circuit-breaker generator coverage

### DIFF
--- a/test/PatternKit.Generators.Tests/CircuitBreakerPolicyGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/CircuitBreakerPolicyGeneratorTests.cs
@@ -204,6 +204,75 @@ public sealed class CircuitBreakerPolicyGeneratorTests
         ScenarioExpect.Equal("PKCB004", diagnostic.Id);
     }
 
+    [Scenario("Generates circuit breaker policy factory for abstract and sealed hosts")]
+    [Fact]
+    public void GeneratesCircuitBreakerPolicyFactoryForAbstractAndSealedHosts()
+    {
+        var source = """
+            using PatternKit.Generators.CircuitBreaker;
+
+            namespace Demo;
+
+            [GenerateCircuitBreakerPolicy(typeof(string), FactoryMethodName = "CreateAbstract")]
+            public abstract partial class AbstractCircuitBreakerHost;
+
+            [GenerateCircuitBreakerPolicy(typeof(string), FactoryMethodName = "CreateSealed")]
+            public sealed partial class SealedCircuitBreakerHost;
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesCircuitBreakerPolicyFactoryForAbstractAndSealedHosts));
+        var gen = new CircuitBreakerPolicyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = run.Results.SelectMany(result => result.GeneratedSources).ToArray();
+        ScenarioExpect.Equal(2, generated.Length);
+        var abstractText = ScenarioExpect.Single(generated.Where(source => source.HintName == "AbstractCircuitBreakerHost.CircuitBreakerPolicy.g.cs")).SourceText.ToString();
+        var sealedText = ScenarioExpect.Single(generated.Where(source => source.HintName == "SealedCircuitBreakerHost.CircuitBreakerPolicy.g.cs")).SourceText.ToString();
+        ScenarioExpect.Contains("public abstract partial class AbstractCircuitBreakerHost", abstractText);
+        ScenarioExpect.Contains("CreateAbstract()", abstractText);
+        ScenarioExpect.Contains("public sealed partial class SealedCircuitBreakerHost", sealedText);
+        ScenarioExpect.Contains("CreateSealed()", sealedText);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
+    }
+
+    [Scenario("Generates circuit breaker policy source for nested accessibility variants")]
+    [Fact]
+    public void GeneratesCircuitBreakerPolicySourceForNestedAccessibilityVariants()
+    {
+        var source = """
+            using PatternKit.Generators.CircuitBreaker;
+
+            namespace Demo;
+
+            public partial class Outer
+            {
+                [GenerateCircuitBreakerPolicy(typeof(string), FactoryMethodName = "CreatePrivate")]
+                private partial class PrivateCircuitBreakerHost;
+
+                [GenerateCircuitBreakerPolicy(typeof(string), FactoryMethodName = "CreateProtected")]
+                protected partial class ProtectedCircuitBreakerHost;
+
+                [GenerateCircuitBreakerPolicy(typeof(string), FactoryMethodName = "CreateProtectedInternal")]
+                protected internal partial class ProtectedInternalCircuitBreakerHost;
+
+                [GenerateCircuitBreakerPolicy(typeof(string), FactoryMethodName = "CreatePrivateProtected")]
+                private protected partial class PrivateProtectedCircuitBreakerHost;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesCircuitBreakerPolicySourceForNestedAccessibilityVariants));
+        var gen = new CircuitBreakerPolicyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generatedText = string.Join("\n", run.Results.SelectMany(result => result.GeneratedSources).Select(source => source.SourceText.ToString()));
+        ScenarioExpect.Contains("private partial class PrivateCircuitBreakerHost", generatedText);
+        ScenarioExpect.Contains("protected partial class ProtectedCircuitBreakerHost", generatedText);
+        ScenarioExpect.Contains("protected internal partial class ProtectedInternalCircuitBreakerHost", generatedText);
+        ScenarioExpect.Contains("private protected partial class PrivateProtectedCircuitBreakerHost", generatedText);
+    }
+
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)
         => RoslynTestHelpers.CreateCompilation(
             source,

--- a/test/PatternKit.Generators.Tests/RetryPolicyGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/RetryPolicyGeneratorTests.cs
@@ -205,6 +205,75 @@ public sealed class RetryPolicyGeneratorTests
         ScenarioExpect.Equal("PKRET004", diagnostic.Id);
     }
 
+    [Scenario("Generates retry policy factory for abstract and sealed hosts")]
+    [Fact]
+    public void GeneratesRetryPolicyFactoryForAbstractAndSealedHosts()
+    {
+        var source = """
+            using PatternKit.Generators.Retry;
+
+            namespace Demo;
+
+            [GenerateRetryPolicy(typeof(string), FactoryMethodName = "CreateAbstract")]
+            public abstract partial class AbstractRetryHost;
+
+            [GenerateRetryPolicy(typeof(string), FactoryMethodName = "CreateSealed")]
+            public sealed partial class SealedRetryHost;
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesRetryPolicyFactoryForAbstractAndSealedHosts));
+        var gen = new RetryPolicyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = run.Results.SelectMany(result => result.GeneratedSources).ToArray();
+        ScenarioExpect.Equal(2, generated.Length);
+        var abstractText = ScenarioExpect.Single(generated.Where(source => source.HintName == "AbstractRetryHost.RetryPolicy.g.cs")).SourceText.ToString();
+        var sealedText = ScenarioExpect.Single(generated.Where(source => source.HintName == "SealedRetryHost.RetryPolicy.g.cs")).SourceText.ToString();
+        ScenarioExpect.Contains("public abstract partial class AbstractRetryHost", abstractText);
+        ScenarioExpect.Contains("CreateAbstract()", abstractText);
+        ScenarioExpect.Contains("public sealed partial class SealedRetryHost", sealedText);
+        ScenarioExpect.Contains("CreateSealed()", sealedText);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
+    }
+
+    [Scenario("Generates retry policy source for nested accessibility variants")]
+    [Fact]
+    public void GeneratesRetryPolicySourceForNestedAccessibilityVariants()
+    {
+        var source = """
+            using PatternKit.Generators.Retry;
+
+            namespace Demo;
+
+            public partial class Outer
+            {
+                [GenerateRetryPolicy(typeof(string), FactoryMethodName = "CreatePrivate")]
+                private partial class PrivateRetryHost;
+
+                [GenerateRetryPolicy(typeof(string), FactoryMethodName = "CreateProtected")]
+                protected partial class ProtectedRetryHost;
+
+                [GenerateRetryPolicy(typeof(string), FactoryMethodName = "CreateProtectedInternal")]
+                protected internal partial class ProtectedInternalRetryHost;
+
+                [GenerateRetryPolicy(typeof(string), FactoryMethodName = "CreatePrivateProtected")]
+                private protected partial class PrivateProtectedRetryHost;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesRetryPolicySourceForNestedAccessibilityVariants));
+        var gen = new RetryPolicyGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generatedText = string.Join("\n", run.Results.SelectMany(result => result.GeneratedSources).Select(source => source.SourceText.ToString()));
+        ScenarioExpect.Contains("private partial class PrivateRetryHost", generatedText);
+        ScenarioExpect.Contains("protected partial class ProtectedRetryHost", generatedText);
+        ScenarioExpect.Contains("protected internal partial class ProtectedInternalRetryHost", generatedText);
+        ScenarioExpect.Contains("private protected partial class PrivateProtectedRetryHost", generatedText);
+    }
+
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)
         => RoslynTestHelpers.CreateCompilation(
             source,


### PR DESCRIPTION
## Summary
- add TinyBDD Retry generator coverage for abstract/sealed hosts and nested accessibility variants
- add TinyBDD CircuitBreaker generator coverage for abstract/sealed hosts and nested accessibility variants
- raise local PatternKit.Generators coverage to 97.69%; RetryPolicyGenerator to 98.62%; CircuitBreakerPolicyGenerator to 98.58%

Refs #413

## Verification
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~RetryPolicyGeneratorTests|FullyQualifiedName~CircuitBreakerPolicyGeneratorTests"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory TestResults-generators-current -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura