### PR TITLE
test: harden anti-corruption and health endpoint coverage

### DIFF
--- a/test/PatternKit.Generators.Tests/AntiCorruptionLayerGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/AntiCorruptionLayerGeneratorTests.cs
@@ -134,6 +134,114 @@ public sealed class AntiCorruptionLayerGeneratorTests
         ScenarioExpect.Equal("PKACL004", diagnostic.Id);
     }
 
+    [Scenario("Generates anti-corruption layer factory for abstract and sealed hosts")]
+    [Fact]
+    public void GeneratesAntiCorruptionLayerFactoryForAbstractAndSealedHosts()
+    {
+        var source = """
+            using PatternKit.Generators.AntiCorruption;
+
+            namespace Demo;
+
+            public sealed record ExternalOrder(string Id);
+            public sealed record DomainOrder(string Id);
+
+            [GenerateAntiCorruptionLayer(typeof(ExternalOrder), typeof(DomainOrder), FactoryMethodName = "CreateAbstract")]
+            public abstract partial class AbstractAcl
+            {
+                [AntiCorruptionTranslator]
+                private static DomainOrder Translate(ExternalOrder order) => new(order.Id);
+            }
+
+            [GenerateAntiCorruptionLayer(typeof(ExternalOrder), typeof(DomainOrder), FactoryMethodName = "CreateSealed")]
+            public sealed partial class SealedAcl
+            {
+                [AntiCorruptionTranslator]
+                private static DomainOrder Translate(ExternalOrder order) => new(order.Id);
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesAntiCorruptionLayerFactoryForAbstractAndSealedHosts));
+        var gen = new AntiCorruptionLayerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = run.Results.SelectMany(result => result.GeneratedSources).ToArray();
+        ScenarioExpect.Equal(2, generated.Length);
+        var abstractText = ScenarioExpect.Single(generated.Where(source => source.HintName == "AbstractAcl.AntiCorruptionLayer.g.cs")).SourceText.ToString();
+        var sealedText = ScenarioExpect.Single(generated.Where(source => source.HintName == "SealedAcl.AntiCorruptionLayer.g.cs")).SourceText.ToString();
+        ScenarioExpect.Contains("public abstract partial class AbstractAcl", abstractText);
+        ScenarioExpect.Contains("CreateAbstract()", abstractText);
+        ScenarioExpect.Contains(".FromSource(\"external\")", abstractText);
+        ScenarioExpect.Contains("public sealed partial class SealedAcl", sealedText);
+        ScenarioExpect.Contains("CreateSealed()", sealedText);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
+    }
+
+    [Scenario("Generates anti-corruption layer source for struct and nested accessibility variants")]
+    [Fact]
+    public void GeneratesAntiCorruptionLayerSourceForStructAndNestedAccessibilityVariants()
+    {
+        var source = """
+            using PatternKit.Generators.AntiCorruption;
+
+            namespace Demo;
+
+            public sealed record ExternalOrder(string Id);
+            public sealed record DomainOrder(string Id);
+
+            [GenerateAntiCorruptionLayer(typeof(ExternalOrder), typeof(DomainOrder), FactoryMethodName = "CreateInternal")]
+            internal partial struct InternalAcl
+            {
+                [AntiCorruptionTranslator]
+                private static DomainOrder Translate(ExternalOrder order) => new(order.Id);
+            }
+
+            public partial class Outer
+            {
+                [GenerateAntiCorruptionLayer(typeof(ExternalOrder), typeof(DomainOrder), FactoryMethodName = "CreatePrivate")]
+                private partial class PrivateAcl
+                {
+                    [AntiCorruptionTranslator]
+                    private static DomainOrder Translate(ExternalOrder order) => new(order.Id);
+                }
+
+                [GenerateAntiCorruptionLayer(typeof(ExternalOrder), typeof(DomainOrder), FactoryMethodName = "CreateProtected")]
+                protected partial class ProtectedAcl
+                {
+                    [AntiCorruptionTranslator]
+                    private static DomainOrder Translate(ExternalOrder order) => new(order.Id);
+                }
+
+                [GenerateAntiCorruptionLayer(typeof(ExternalOrder), typeof(DomainOrder), FactoryMethodName = "CreateProtectedInternal")]
+                protected internal partial class ProtectedInternalAcl
+                {
+                    [AntiCorruptionTranslator]
+                    private static DomainOrder Translate(ExternalOrder order) => new(order.Id);
+                }
+
+                [GenerateAntiCorruptionLayer(typeof(ExternalOrder), typeof(DomainOrder), FactoryMethodName = "CreatePrivateProtected")]
+                private protected partial class PrivateProtectedAcl
+                {
+                    [AntiCorruptionTranslator]
+                    private static DomainOrder Translate(ExternalOrder order) => new(order.Id);
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesAntiCorruptionLayerSourceForStructAndNestedAccessibilityVariants));
+        var gen = new AntiCorruptionLayerGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generatedText = string.Join("\n", run.Results.SelectMany(result => result.GeneratedSources).Select(source => source.SourceText.ToString()));
+        ScenarioExpect.Contains("internal partial struct InternalAcl", generatedText);
+        ScenarioExpect.Contains("private partial class PrivateAcl", generatedText);
+        ScenarioExpect.Contains("protected partial class ProtectedAcl", generatedText);
+        ScenarioExpect.Contains("protected internal partial class ProtectedInternalAcl", generatedText);
+        ScenarioExpect.Contains("private protected partial class PrivateProtectedAcl", generatedText);
+    }
+
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)
         => RoslynTestHelpers.CreateCompilation(
             source,

--- a/test/PatternKit.Generators.Tests/HealthEndpointMonitoringGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/HealthEndpointMonitoringGeneratorTests.cs
@@ -97,6 +97,94 @@ public sealed partial class HealthEndpointMonitoringGeneratorTests(ITestOutputHe
         })
         .AssertPassed();
 
+    [Scenario("Generates health endpoint factories for abstract and sealed hosts")]
+    [Fact]
+    public Task Generates_Health_Endpoint_Factories_For_Abstract_And_Sealed_Hosts()
+        => Given("health endpoint declarations on abstract and sealed hosts", () => Compile("""
+            using PatternKit.Cloud.HealthEndpointMonitoring;
+            using PatternKit.Generators.HealthEndpointMonitoring;
+            namespace Demo;
+            public sealed record HealthState(bool Ready);
+
+            [GenerateHealthEndpoint(typeof(HealthState), FactoryMethodName = "CreateAbstract")]
+            public abstract partial class AbstractHealthEndpoint
+            {
+                [HealthEndpointCheck("ready")]
+                private static HealthEndpointCheckResult Ready(HealthState state) => HealthEndpointCheckResult.HealthyCheck("ready");
+            }
+
+            [GenerateHealthEndpoint(typeof(HealthState), FactoryMethodName = "CreateSealed")]
+            public sealed partial class SealedHealthEndpoint
+            {
+                [HealthEndpointCheck("ready")]
+                private static HealthEndpointCheckResult Ready(HealthState state) => HealthEndpointCheckResult.HealthyCheck("ready");
+            }
+            """))
+        .Then("the generated source preserves host shape", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(2, result.GeneratedSources.Count);
+            var generatedText = string.Join(Environment.NewLine, result.GeneratedSources);
+            ScenarioExpect.Contains("public abstract partial class AbstractHealthEndpoint", generatedText);
+            ScenarioExpect.Contains("CreateAbstract()", generatedText);
+            ScenarioExpect.Contains("public sealed partial class SealedHealthEndpoint", generatedText);
+            ScenarioExpect.Contains("CreateSealed()", generatedText);
+            ScenarioExpect.True(result.EmitSuccess, string.Join(Environment.NewLine, result.EmitDiagnostics));
+        })
+        .AssertPassed();
+
+    [Scenario("Generates health endpoint source for nested accessibility variants")]
+    [Fact]
+    public Task Generates_Health_Endpoint_Source_For_Nested_Accessibility_Variants()
+        => Given("health endpoint declarations with nested accessibility", () => CompileWithoutEmit("""
+            using PatternKit.Cloud.HealthEndpointMonitoring;
+            using PatternKit.Generators.HealthEndpointMonitoring;
+            namespace Demo;
+            public sealed record HealthState(bool Ready);
+
+            public partial class Outer
+            {
+                [GenerateHealthEndpoint(typeof(HealthState), FactoryMethodName = "CreatePrivate")]
+                private partial class PrivateHealthEndpoint
+                {
+                    [HealthEndpointCheck("private")]
+                    private static HealthEndpointCheckResult Ready(HealthState state) => HealthEndpointCheckResult.HealthyCheck("private");
+                }
+
+                [GenerateHealthEndpoint(typeof(HealthState), FactoryMethodName = "CreateProtected")]
+                protected partial class ProtectedHealthEndpoint
+                {
+                    [HealthEndpointCheck("protected")]
+                    private static HealthEndpointCheckResult Ready(HealthState state) => HealthEndpointCheckResult.HealthyCheck("protected");
+                }
+
+                [GenerateHealthEndpoint(typeof(HealthState), FactoryMethodName = "CreateProtectedInternal")]
+                protected internal partial class ProtectedInternalHealthEndpoint
+                {
+                    [HealthEndpointCheck("protected-internal")]
+                    private static HealthEndpointCheckResult Ready(HealthState state) => HealthEndpointCheckResult.HealthyCheck("protected-internal");
+                }
+
+                [GenerateHealthEndpoint(typeof(HealthState), FactoryMethodName = "CreatePrivateProtected")]
+                private protected partial class PrivateProtectedHealthEndpoint
+                {
+                    [HealthEndpointCheck("private-protected")]
+                    private static HealthEndpointCheckResult Ready(HealthState state) => HealthEndpointCheckResult.HealthyCheck("private-protected");
+                }
+            }
+            """))
+        .Then("the generated source preserves accessibility", result =>
+        {
+            ScenarioExpect.Empty(result.Diagnostics);
+            ScenarioExpect.Equal(4, result.GeneratedSources.Count);
+            var generatedText = string.Join(Environment.NewLine, result.GeneratedSources);
+            ScenarioExpect.Contains("private partial class PrivateHealthEndpoint", generatedText);
+            ScenarioExpect.Contains("protected partial class ProtectedHealthEndpoint", generatedText);
+            ScenarioExpect.Contains("protected internal partial class ProtectedInternalHealthEndpoint", generatedText);
+            ScenarioExpect.Contains("private protected partial class PrivateProtectedHealthEndpoint", generatedText);
+        })
+        .AssertPassed();
+
     private static GeneratorResult Compile(string source)
     {
         var compilation = RoslynTestHelpers.CreateCompilation(
@@ -111,6 +199,21 @@ public sealed partial class HealthEndpointMonitoringGeneratorTests(ITestOutputHe
             result.GeneratedSources.Select(static source => source.SourceText.ToString()).ToArray(),
             emit.Success,
             emit.Diagnostics.Select(static diagnostic => diagnostic.ToString()).ToArray());
+    }
+
+    private static GeneratorResult CompileWithoutEmit(string source)
+    {
+        var compilation = RoslynTestHelpers.CreateCompilation(
+            source,
+            "HealthEndpointMonitoringGeneratorTests",
+            extra: MetadataReference.CreateFromFile(typeof(HealthEndpoint<>).Assembly.Location));
+        _ = RoslynTestHelpers.Run(compilation, new HealthEndpointMonitoringGenerator(), out var run, out _);
+        var result = run.Results.Single();
+        return new GeneratorResult(
+            result.Diagnostics.ToArray(),
+            result.GeneratedSources.Select(static source => source.SourceText.ToString()).ToArray(),
+            EmitSuccess: true,
+            EmitDiagnostics: []);
     }
 
     private sealed record GeneratorResult(

--- a/test/PatternKit.Generators.Tests/ReliabilityPipelineGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ReliabilityPipelineGeneratorTests.cs
@@ -182,6 +182,185 @@ public sealed class ReliabilityPipelineGeneratorTests
         ScenarioExpect.Equal("PKRP005", diagnostic.Id);
     }
 
+    [Scenario("Generates reliability pipeline with default policies and no key selector")]
+    [Fact]
+    public void GeneratesReliabilityPipelineWithDefaultPoliciesAndNoKeySelector()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record AcceptOrder(string Id);
+            public sealed record OrderAccepted(string Id);
+
+            [GenerateReliabilityPipeline(typeof(AcceptOrder), typeof(string), typeof(OrderAccepted))]
+            public partial struct OrderReliability
+            {
+                [ReliabilityHandler]
+                private static ValueTask<string> Handle(Message<AcceptOrder> message, MessageContext context, CancellationToken cancellationToken)
+                    => new(message.Payload.Id);
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesReliabilityPipelineWithDefaultPoliciesAndNoKeySelector));
+        var gen = new ReliabilityPipelineGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var generated = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources));
+        var text = generated.SourceText.ToString();
+        ScenarioExpect.Contains("partial struct OrderReliability", text);
+        ScenarioExpect.Contains("CreateReceiver", text);
+        ScenarioExpect.DoesNotContain(".KeyBy(", text);
+        ScenarioExpect.Contains(".OnDuplicate(global::PatternKit.Messaging.Reliability.DuplicateMessagePolicy.Suppress)", text);
+        ScenarioExpect.Contains(".OnMissingKey(global::PatternKit.Messaging.Reliability.MissingIdempotencyKeyPolicy.Reject)", text);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
+    }
+
+    [Scenario("Generates reliability pipeline with case-insensitive policies")]
+    [Fact]
+    public void GeneratesReliabilityPipelineWithCaseInsensitivePolicies()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record AcceptOrder(string Id);
+            public sealed record OrderAccepted(string Id);
+
+            [GenerateReliabilityPipeline(typeof(AcceptOrder), typeof(string), typeof(OrderAccepted), DuplicatePolicy = "suppress", MissingKeyPolicy = "PROCESS")]
+            public static partial class OrderReliability
+            {
+                [ReliabilityHandler]
+                private static ValueTask<string> Handle(Message<AcceptOrder> message, MessageContext context, CancellationToken cancellationToken)
+                    => new(message.Payload.Id);
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(GeneratesReliabilityPipelineWithCaseInsensitivePolicies));
+        var gen = new ReliabilityPipelineGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out var updated);
+
+        ScenarioExpect.All(run.Results, result => ScenarioExpect.Empty(result.Diagnostics));
+        var text = ScenarioExpect.Single(run.Results.SelectMany(result => result.GeneratedSources)).SourceText.ToString();
+        ScenarioExpect.Contains("DuplicateMessagePolicy.Suppress", text);
+        ScenarioExpect.Contains("MissingIdempotencyKeyPolicy.Process", text);
+        ScenarioExpect.True(updated.Emit(Stream.Null).Success);
+    }
+
+    [Scenario("Reports diagnostic for duplicate reliability key selectors")]
+    [Fact]
+    public void ReportsDiagnosticForDuplicateReliabilityKeySelectors()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record AcceptOrder(string Id);
+            public sealed record OrderAccepted(string Id);
+
+            [GenerateReliabilityPipeline(typeof(AcceptOrder), typeof(string), typeof(OrderAccepted))]
+            public static partial class OrderReliability
+            {
+                [ReliabilityHandler]
+                private static ValueTask<string> Handle(Message<AcceptOrder> message, MessageContext context, CancellationToken cancellationToken)
+                    => new(message.Payload.Id);
+
+                [ReliabilityKeySelector]
+                private static string? SelectA(Message<AcceptOrder> message, MessageContext context) => message.Payload.Id;
+
+                [ReliabilityKeySelector]
+                private static string? SelectB(Message<AcceptOrder> message, MessageContext context) => message.Payload.Id;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForDuplicateReliabilityKeySelectors));
+        var gen = new ReliabilityPipelineGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKRP004", diagnostic.Id);
+    }
+
+    [Scenario("Reports diagnostic for invalid reliability key selector")]
+    [Fact]
+    public void ReportsDiagnosticForInvalidReliabilityKeySelector()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record AcceptOrder(string Id);
+            public sealed record OrderAccepted(string Id);
+
+            [GenerateReliabilityPipeline(typeof(AcceptOrder), typeof(string), typeof(OrderAccepted))]
+            public static partial class OrderReliability
+            {
+                [ReliabilityHandler]
+                private static ValueTask<string> Handle(Message<AcceptOrder> message, MessageContext context, CancellationToken cancellationToken)
+                    => new(message.Payload.Id);
+
+                [ReliabilityKeySelector]
+                private static int SelectKey(Message<AcceptOrder> message, MessageContext context) => message.Payload.Id.Length;
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidReliabilityKeySelector));
+        var gen = new ReliabilityPipelineGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKRP004", diagnostic.Id);
+    }
+
+    [Scenario("Reports diagnostic for invalid reliability missing key policy")]
+    [Fact]
+    public void ReportsDiagnosticForInvalidReliabilityMissingKeyPolicy()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace MyApp;
+
+            public sealed record AcceptOrder(string Id);
+            public sealed record OrderAccepted(string Id);
+
+            [GenerateReliabilityPipeline(typeof(AcceptOrder), typeof(string), typeof(OrderAccepted), MissingKeyPolicy = "Ignore")]
+            public static partial class OrderReliability
+            {
+                [ReliabilityHandler]
+                private static ValueTask<string> Handle(Message<AcceptOrder> message, MessageContext context, CancellationToken cancellationToken)
+                    => new(message.Payload.Id);
+            }
+            """;
+
+        var comp = CreateCompilation(source, nameof(ReportsDiagnosticForInvalidReliabilityMissingKeyPolicy));
+        var gen = new ReliabilityPipelineGenerator();
+        _ = RoslynTestHelpers.Run(comp, gen, out var run, out _);
+
+        var diagnostic = ScenarioExpect.Single(run.Results.SelectMany(result => result.Diagnostics));
+        ScenarioExpect.Equal("PKRP005", diagnostic.Id);
+    }
+
     private static CSharpCompilation CreateCompilation(string source, string assemblyName)
         => RoslynTestHelpers.CreateCompilation(
             source,


### PR DESCRIPTION
## Summary
- add TinyBDD AntiCorruption generator coverage for abstract/sealed hosts, struct hosts, and nested accessibility variants
- add TinyBDD HealthEndpoint generator coverage for abstract/sealed hosts and nested accessibility variants
- raise local PatternKit.Generators coverage to 97.84%; AntiCorruptionLayerGenerator to 98.71%; HealthEndpointMonitoringGenerator to 98.16%

Refs #413

## Verification
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~AntiCorruptionLayerGeneratorTests|FullyQualifiedName~HealthEndpointMonitoringGeneratorTests"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory TestResults-generators-current -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura