### PR TITLE
test: harden content enricher policy generation

### DIFF
--- a/src/PatternKit.Generators/Messaging/ContentEnricherGenerator.cs
+++ b/src/PatternKit.Generators/Messaging/ContentEnricherGenerator.cs
@@ -85,6 +85,12 @@ public sealed class ContentEnricherGenerator : IIncrementalGenerator
             return;
         }
 
+        if (!IsKnownPolicy(defaultPolicy))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(InvalidConfiguration, node.Identifier.GetLocation(), type.Name, $"default policy '{defaultPolicy}' is not supported"));
+            return;
+        }
+
         var steps = type.GetMembers().OfType<IMethodSymbol>()
             .Select(method => (Method: method, Attribute: method.GetAttributes().FirstOrDefault(static attr => attr.AttributeClass?.ToDisplayString() == StepAttributeName)))
             .Where(static item => item.Attribute is not null)
@@ -104,6 +110,12 @@ public sealed class ContentEnricherGenerator : IIncrementalGenerator
             if (!IsStep(step.Method, payloadType))
             {
                 context.ReportDiagnostic(Diagnostic.Create(InvalidStep, step.Method.Locations.FirstOrDefault(), step.Method.Name));
+                return;
+            }
+
+            if (!IsKnownPolicy(step.Policy))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(InvalidConfiguration, step.Method.Locations.FirstOrDefault(), type.Name, $"step '{step.Name}' policy '{step.Policy}' is not supported"));
                 return;
             }
 
@@ -224,6 +236,9 @@ public sealed class ContentEnricherGenerator : IIncrementalGenerator
 
     private static int? GetNamedInt(AttributeData attribute, string name)
         => attribute.NamedArguments.FirstOrDefault(kv => kv.Key == name).Value.Value as int?;
+
+    private static bool IsKnownPolicy(string policy)
+        => policy is "Throw" or "Skip" or "UseDefault";
 
     private static string Escape(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
 

--- a/test/PatternKit.Generators.Tests/ContentEnricherGeneratorTests.cs
+++ b/test/PatternKit.Generators.Tests/ContentEnricherGeneratorTests.cs
@@ -259,6 +259,52 @@ public sealed class ContentEnricherGeneratorTests
         ScenarioExpect.Equal("PKMCE004", diagnostic.Id);
     }
 
+    [Scenario("Reports diagnostic for invalid default content enricher policy")]
+    [Fact]
+    public void ReportsDiagnosticForInvalidDefaultContentEnricherPolicy()
+    {
+        var source = """
+            using PatternKit.Generators.Messaging;
+
+            namespace Demo;
+
+            [GenerateContentEnricher(typeof(string), DefaultPolicy = (ContentEnrichmentErrorPolicy)99)]
+            public static partial class Host;
+            """;
+
+        var diagnostic = RunAndGetSingleDiagnostic(source, nameof(ReportsDiagnosticForInvalidDefaultContentEnricherPolicy));
+
+        ScenarioExpect.Equal("PKMCE004", diagnostic.Id);
+        ScenarioExpect.Contains("default policy '99' is not supported", diagnostic.GetMessage());
+    }
+
+    [Scenario("Reports diagnostic for invalid content enricher step policy")]
+    [Fact]
+    public void ReportsDiagnosticForInvalidContentEnricherStepPolicy()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using PatternKit.Generators.Messaging;
+            using PatternKit.Messaging;
+
+            namespace Demo;
+
+            [GenerateContentEnricher(typeof(string))]
+            public static partial class Host
+            {
+                [ContentEnrichmentStep("invalid", Policy = (ContentEnrichmentErrorPolicy)99)]
+                private static ValueTask<string> Add(string payload, MessageContext context, CancellationToken cancellationToken)
+                    => ValueTask.FromResult(payload);
+            }
+            """;
+
+        var diagnostic = RunAndGetSingleDiagnostic(source, nameof(ReportsDiagnosticForInvalidContentEnricherStepPolicy));
+
+        ScenarioExpect.Equal("PKMCE004", diagnostic.Id);
+        ScenarioExpect.Contains("step 'invalid' policy '99' is not supported", diagnostic.GetMessage());
+    }
+
     [Scenario("Reports diagnostic for invalid default content enricher factory")]
     [Fact]
     public void ReportsDiagnosticForInvalidDefaultContentEnricherFactory()


### PR DESCRIPTION
## Summary
- reject unsupported ContentEnricher default policies before generating invalid source
- reject unsupported ContentEnricher step policies with PKMCE004 diagnostics
- add TinyBDD generator scenarios for both invalid policy paths

Refs #413

## Verification
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --filter "FullyQualifiedName~ContentEnricherGeneratorTests"
- dotnet test test\PatternKit.Generators.Tests\PatternKit.Generators.Tests.csproj --configuration Release -p:TestTfmsInParallel=false --collect:"XPlat Code Coverage" --results-directory TestResults-generators-current -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
- PatternKit.Generators coverage: 97.88%